### PR TITLE
fix(shared): use clients-ts imports in dataset after facade removal

### DIFF
--- a/apps/ts/packages/shared/src/dataset/api-client.ts
+++ b/apps/ts/packages/shared/src/dataset/api-client.ts
@@ -3,7 +3,7 @@
  * Simplified wrapper around JQuantsClient with integrated rate limiting
  */
 
-import type { JQuantsClient } from '../clients/JQuantsClient';
+import type { JQuantsClient } from '@trading25/clients-ts/JQuantsClient';
 import type {
   JQuantsDailyQuote,
   JQuantsDailyQuotesResponse,

--- a/apps/ts/packages/shared/src/dataset/builder.ts
+++ b/apps/ts/packages/shared/src/dataset/builder.ts
@@ -4,7 +4,7 @@
  */
 
 import * as fs from 'node:fs';
-import type { JQuantsClient } from '../clients/JQuantsClient';
+import type { JQuantsClient } from '@trading25/clients-ts/JQuantsClient';
 import { DATASET_METADATA_KEYS, DrizzleDatasetDatabase } from '../db';
 import { ApiClient } from './api-client';
 import { getDateRange, validateConfig } from './config';

--- a/apps/ts/packages/shared/src/dataset/fetchers.ts
+++ b/apps/ts/packages/shared/src/dataset/fetchers.ts
@@ -3,8 +3,8 @@
  * Single class replacing 12 specialized fetchers
  */
 
-import { calculatePlanConcurrency, validateJQuantsPlan } from '../clients/base/BaseJQuantsClient';
-import { type BatchExecutor, categorizeErrorType, createBatchExecutor } from '../clients/base/BatchExecutor';
+import { calculatePlanConcurrency, validateJQuantsPlan } from '@trading25/clients-ts/base/BaseJQuantsClient';
+import { type BatchExecutor, categorizeErrorType, createBatchExecutor } from '@trading25/clients-ts/base/BatchExecutor';
 import { getAllIndexCodesExcludingTOPIX } from '../db/constants/index-master-data';
 import type { ApiClient } from './api-client';
 import { type StreamConfig, StreamingFetchers, StreamingUtils } from './streaming/memory-efficient-fetchers';

--- a/apps/ts/packages/shared/src/dataset/index.ts
+++ b/apps/ts/packages/shared/src/dataset/index.ts
@@ -36,13 +36,13 @@ export {
   JQUANTS_PLAN_LIMITS,
   type JQuantsPlan,
   validateJQuantsPlan,
-} from '../clients/base/BaseJQuantsClient';
+} from '@trading25/clients-ts/base/BaseJQuantsClient';
 // Batch execution (rate limiting is in BaseJQuantsClient)
 export {
   BatchExecutor,
   categorizeErrorType,
   createBatchExecutor,
-} from '../clients/base/BatchExecutor';
+} from '@trading25/clients-ts/base/BatchExecutor';
 // Database operations (for advanced users)
 export { DrizzleDatasetDatabase as Database } from '../db';
 export { ApiClient } from './api-client';

--- a/apps/ts/packages/shared/src/dataset/streaming/memory-efficient-fetchers.ts
+++ b/apps/ts/packages/shared/src/dataset/streaming/memory-efficient-fetchers.ts
@@ -3,8 +3,8 @@
  * Generator-based streaming to optimize memory usage for large datasets
  */
 
-import { calculatePlanConcurrency, validateJQuantsPlan } from '../../clients/base/BaseJQuantsClient';
-import { type BatchExecutor, createBatchExecutor } from '../../clients/base/BatchExecutor';
+import { calculatePlanConcurrency, validateJQuantsPlan } from '@trading25/clients-ts/base/BaseJQuantsClient';
+import { type BatchExecutor, createBatchExecutor } from '@trading25/clients-ts/base/BatchExecutor';
 import type { ApiClient } from '../api-client';
 import type { DateRange, MarginData, ProgressCallback, StockData } from '../types';
 


### PR DESCRIPTION
## Summary\n- fix broken dataset imports in @trading25/shared after removing shared/src/clients facades\n- switch dataset modules from relative ../clients/* paths to @trading25/clients-ts/*\n\n## Why\nThe post-merge CI on main failed in typecheck because shared dataset files still referenced deleted client facade files.\n\n## Validation\n- CI will verify via typecheck/test workflow