### PR TITLE
feat: add new fundamentals ratios and chart summary rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ bun run --filter @trading25/shared bt:sync   # bt の OpenAPI → TS型生成
 `contracts/` に bt/ts 間の安定インターフェースを定義。詳細は [`contracts/README.md`](contracts/README.md) 参照。
 - **バージョニング**: additive (minor) / breaking (major) → 新版ファイル作成
 - **命名規則**: `{domain}-{purpose}-v{N}.schema.json`
+- **現行追加契約**: `fundamentals-metrics-v1.schema.json`（fundamentals API 指標拡張）
 - **アーカイブ**: `hono-openapi-baseline.json`（Phase 3 移行 baseline、参照用に保持）
 
 ## エラーレスポンス

--- a/apps/bt/src/server/routes/analytics_jquants.py
+++ b/apps/bt/src/server/routes/analytics_jquants.py
@@ -132,6 +132,12 @@ async def get_fundamentals(
     to_date: str | None = Query(None, alias="to"),
     periodType: Literal["all", "FY", "1Q", "2Q", "3Q"] = Query("all"),
     preferConsolidated: bool = Query(True),
+    tradingValuePeriod: int = Query(
+        15,
+        ge=1,
+        le=250,
+        description="Rolling average period in days for trading value to market cap ratio",
+    ),
 ) -> FundamentalsComputeResponse:
     """ファンダメンタルズ分析指標を取得"""
     req = FundamentalsComputeRequest(
@@ -140,6 +146,7 @@ async def get_fundamentals(
         to_date=to_date,
         period_type=periodType,
         prefer_consolidated=preferConsolidated,
+        trading_value_period=tradingValuePeriod,
     )
     loop = asyncio.get_event_loop()
     result = await loop.run_in_executor(

--- a/apps/bt/src/server/schemas/fundamentals.py
+++ b/apps/bt/src/server/schemas/fundamentals.py
@@ -27,6 +27,12 @@ class FundamentalsComputeRequest(BaseModel):
     prefer_consolidated: bool = Field(
         default=True, description="Prefer consolidated statements"
     )
+    trading_value_period: int = Field(
+        default=15,
+        ge=1,
+        le=250,
+        description="Rolling period (days) for trading value to market cap ratio",
+    )
 
 
 class FundamentalDataPoint(BaseModel):
@@ -91,6 +97,12 @@ class FundamentalDataPoint(BaseModel):
     fcf: float | None = Field(None, description="Free cash flow (millions JPY)")
     fcfYield: float | None = Field(None, description="FCF yield (%)")
     fcfMargin: float | None = Field(None, description="FCF margin (%)")
+    cfoToNetProfitRatio: float | None = Field(
+        None, description="Operating cash flow / net profit ratio (x)"
+    )
+    tradingValueToMarketCapRatio: float | None = Field(
+        None, description="N-day average trading value / market cap ratio (x)"
+    )
 
     # Forecast EPS
     forecastEps: float | None = Field(None, description="Forecast EPS (JPY)")
@@ -144,5 +156,8 @@ class FundamentalsComputeResponse(BaseModel):
     )
     dailyValuation: list[DailyValuationDataPoint] | None = Field(
         None, description="Daily PER/PBR time-series"
+    )
+    tradingValuePeriod: int = Field(
+        ..., description="Rolling period used for trading value to market cap ratio"
     )
     lastUpdated: str = Field(..., description="Last updated timestamp (ISO 8601)")

--- a/apps/bt/tests/server/routes/test_fundamentals.py
+++ b/apps/bt/tests/server/routes/test_fundamentals.py
@@ -71,6 +71,7 @@ class TestFundamentalsComputeEndpoint:
             ],
             latestMetrics=None,
             dailyValuation=None,
+            tradingValuePeriod=15,
             lastUpdated="2024-05-15T10:00:00",
         )
 
@@ -98,6 +99,7 @@ class TestFundamentalsComputeEndpoint:
             data=[],
             latestMetrics=None,
             dailyValuation=None,
+            tradingValuePeriod=15,
             lastUpdated="2024-05-15T10:00:00",
         )
 
@@ -126,6 +128,7 @@ class TestFundamentalsComputeEndpoint:
             data=[],
             latestMetrics=None,
             dailyValuation=None,
+            tradingValuePeriod=15,
             lastUpdated="2024-05-15T10:00:00",
         )
 
@@ -223,6 +226,7 @@ class TestFundamentalsSchemaValidation:
                 data=[],
                 latestMetrics=None,
                 dailyValuation=None,
+                tradingValuePeriod=15,
                 lastUpdated="2024-05-15T10:00:00",
             )
 

--- a/apps/bt/tests/unit/server/test_routes_analytics_fundamentals.py
+++ b/apps/bt/tests/unit/server/test_routes_analytics_fundamentals.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
+from src.server.schemas.analytics_margin import (
+    MarginFlowPressureData,
+    MarginLongPressureData,
+    MarginPressureIndicatorsResponse,
+    MarginTurnoverDaysData,
+    MarginVolumeRatioData,
+    MarginVolumeRatioResponse,
+)
+from src.server.schemas.analytics_roe import ROEMetadata, ROEResponse, ROEResultItem, ROESummary
 from src.server.schemas.fundamentals import (
     FundamentalDataPoint,
     FundamentalsComputeResponse,
 )
+from src.server.routes import analytics_jquants
 
 
 @pytest.fixture()
@@ -39,6 +52,7 @@ def _make_response(symbol: str = "7203", data_count: int = 1) -> FundamentalsCom
         data=data,
         latestMetrics=data[0] if data else None,
         dailyValuation=None,
+        tradingValuePeriod=15,
         lastUpdated="2024-06-01T00:00:00Z",
     )
 
@@ -63,6 +77,7 @@ class TestGetFundamentals:
             data=[],
             latestMetrics=None,
             dailyValuation=None,
+            tradingValuePeriod=15,
             lastUpdated="2024-06-01T00:00:00Z",
         )
         resp = client.get("/api/analytics/fundamentals/9999")
@@ -74,13 +89,19 @@ class TestGetFundamentals:
         mock_service.compute_fundamentals.return_value = _make_response()
         resp = client.get(
             "/api/analytics/fundamentals/7203",
-            params={"from": "2020-01-01", "to": "2024-12-31", "periodType": "FY"},
+            params={
+                "from": "2020-01-01",
+                "to": "2024-12-31",
+                "periodType": "FY",
+                "tradingValuePeriod": 20,
+            },
         )
         assert resp.status_code == 200
         call_args = mock_service.compute_fundamentals.call_args[0][0]
         assert call_args.from_date == "2020-01-01"
         assert call_args.to_date == "2024-12-31"
         assert call_args.period_type == "FY"
+        assert call_args.trading_value_period == 20
 
     @patch("src.server.routes.analytics_jquants.fundamentals_service")
     def test_default_params(self, mock_service: MagicMock, client: TestClient) -> None:
@@ -92,6 +113,7 @@ class TestGetFundamentals:
         assert call_args.to_date is None
         assert call_args.period_type == "all"
         assert call_args.prefer_consolidated is True
+        assert call_args.trading_value_period == 15
 
     @patch("src.server.routes.analytics_jquants.fundamentals_service")
     def test_prefer_consolidated_false(self, mock_service: MagicMock, client: TestClient) -> None:
@@ -103,3 +125,172 @@ class TestGetFundamentals:
         assert resp.status_code == 200
         call_args = mock_service.compute_fundamentals.call_args[0][0]
         assert call_args.prefer_consolidated is False
+
+
+def _make_roe_response() -> ROEResponse:
+    return ROEResponse(
+        results=[
+            ROEResultItem(
+                roe=12.5,
+                netProfit=4000000.0,
+                equity=30000000.0,
+                metadata=ROEMetadata(
+                    code="7203",
+                    periodType="FY",
+                    periodEnd="2024-03-31",
+                    isConsolidated=True,
+                    accountingStandard="JGAAP",
+                    isAnnualized=False,
+                ),
+            )
+        ],
+        summary=ROESummary(averageROE=12.5, maxROE=12.5, minROE=12.5, totalCompanies=1),
+        lastUpdated="2024-06-01T00:00:00Z",
+    )
+
+
+def _make_margin_pressure_response(empty: bool = False) -> MarginPressureIndicatorsResponse:
+    return MarginPressureIndicatorsResponse(
+        symbol="7203",
+        averagePeriod=15,
+        longPressure=[]
+        if empty
+        else [MarginLongPressureData(date="2024-06-01", pressure=1.2, longVol=1000, shortVol=500, avgVolume=2000)],
+        flowPressure=[]
+        if empty
+        else [
+            MarginFlowPressureData(
+                date="2024-06-01",
+                flowPressure=0.3,
+                currentNetMargin=500,
+                previousNetMargin=400,
+                avgVolume=2000,
+            )
+        ],
+        turnoverDays=[]
+        if empty
+        else [MarginTurnoverDaysData(date="2024-06-01", turnoverDays=2.1, longVol=1000, avgVolume=2000)],
+        lastUpdated="2024-06-01T00:00:00Z",
+    )
+
+
+def _make_margin_ratio_response(empty: bool = False) -> MarginVolumeRatioResponse:
+    return MarginVolumeRatioResponse(
+        symbol="7203",
+        longRatio=[]
+        if empty
+        else [MarginVolumeRatioData(date="2024-06-01", ratio=0.8, weeklyAvgVolume=1000, marginVolume=800)],
+        shortRatio=[]
+        if empty
+        else [MarginVolumeRatioData(date="2024-06-01", ratio=0.3, weeklyAvgVolume=1000, marginVolume=300)],
+        lastUpdated="2024-06-01T00:00:00Z",
+    )
+
+
+class TestAnalyticsRouteHelpers:
+    def test_get_executor_recreates_when_shutdown(self) -> None:
+        with patch.object(analytics_jquants, "_executor", SimpleNamespace(_shutdown=True)):
+            executor = analytics_jquants._get_executor()
+            assert isinstance(executor, ThreadPoolExecutor)
+            executor.shutdown(wait=True)
+
+    def test_get_roe_service_not_initialized(self) -> None:
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+        with pytest.raises(HTTPException) as exc:
+            analytics_jquants._get_roe_service(request)  # type: ignore[arg-type]
+        assert exc.value.status_code == 422
+
+    def test_get_margin_service_not_initialized(self) -> None:
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+        with pytest.raises(HTTPException) as exc:
+            analytics_jquants._get_margin_service(request)  # type: ignore[arg-type]
+        assert exc.value.status_code == 422
+
+
+class TestGetRoe:
+    @patch("src.server.routes.analytics_jquants._get_roe_service")
+    def test_requires_code_or_date(
+        self, _mock_get_service: MagicMock, client: TestClient
+    ) -> None:
+        resp = client.get("/api/analytics/roe")
+        assert resp.status_code == 400
+
+    @patch("src.server.routes.analytics_jquants._get_roe_service")
+    def test_get_roe_success(
+        self, mock_get_service: MagicMock, client: TestClient
+    ) -> None:
+        service = AsyncMock()
+        service.calculate_roe.return_value = _make_roe_response()
+        mock_get_service.return_value = service
+
+        resp = client.get(
+            "/api/analytics/roe",
+            params={
+                "code": "7203",
+                "annualize": "false",
+                "preferConsolidated": "false",
+                "minEquity": "2000",
+                "sortBy": "date",
+                "limit": "10",
+            },
+        )
+        assert resp.status_code == 200
+        service.calculate_roe.assert_awaited_once_with(
+            code="7203",
+            date=None,
+            annualize=False,
+            prefer_consolidated=False,
+            min_equity=2000.0,
+            sort_by="date",
+            limit=10,
+        )
+
+
+class TestMarginRoutes:
+    @patch("src.server.routes.analytics_jquants._get_margin_service")
+    def test_get_margin_pressure_success(
+        self, mock_get_service: MagicMock, client: TestClient
+    ) -> None:
+        service = AsyncMock()
+        service.get_margin_pressure.return_value = _make_margin_pressure_response()
+        mock_get_service.return_value = service
+
+        resp = client.get(
+            "/api/analytics/stocks/7203/margin-pressure", params={"period": 20}
+        )
+        assert resp.status_code == 200
+        service.get_margin_pressure.assert_awaited_once_with("7203", 20)
+
+    @patch("src.server.routes.analytics_jquants._get_margin_service")
+    def test_get_margin_pressure_not_found(
+        self, mock_get_service: MagicMock, client: TestClient
+    ) -> None:
+        service = AsyncMock()
+        service.get_margin_pressure.return_value = _make_margin_pressure_response(empty=True)
+        mock_get_service.return_value = service
+
+        resp = client.get("/api/analytics/stocks/7203/margin-pressure")
+        assert resp.status_code == 404
+
+    @patch("src.server.routes.analytics_jquants._get_margin_service")
+    def test_get_margin_ratio_success(
+        self, mock_get_service: MagicMock, client: TestClient
+    ) -> None:
+        service = AsyncMock()
+        service.get_margin_ratio.return_value = _make_margin_ratio_response()
+        mock_get_service.return_value = service
+
+        resp = client.get("/api/analytics/stocks/7203/margin-ratio")
+        assert resp.status_code == 200
+        service.get_margin_ratio.assert_awaited_once_with("7203")
+
+    @patch("src.server.routes.analytics_jquants._get_margin_service")
+    def test_get_margin_ratio_not_found(
+        self, mock_get_service: MagicMock, client: TestClient
+    ) -> None:
+        service = AsyncMock()
+        service.get_margin_ratio.return_value = _make_margin_ratio_response(empty=True)
+        mock_get_service.return_value = service
+
+        resp = client.get("/api/analytics/stocks/7203/margin-ratio")
+        assert resp.status_code == 404

--- a/apps/ts/packages/shared/src/types/api-types.ts
+++ b/apps/ts/packages/shared/src/types/api-types.ts
@@ -218,6 +218,10 @@ export interface ApiFundamentalDataPoint {
   fcfYield: number | null;
   /** FCF Margin = FCF / Net Sales × 100 (%) */
   fcfMargin: number | null;
+  /** Operating Cash Flow / Net Profit (x) */
+  cfoToNetProfitRatio: number | null;
+  /** N-day average trading value / market cap (x) */
+  tradingValueToMarketCapRatio: number | null;
   // Forecast EPS
   /** Forecast EPS for current/next fiscal year (円) */
   forecastEps?: number | null;
@@ -252,6 +256,8 @@ export interface ApiFundamentalsResponse {
   latestMetrics?: ApiFundamentalDataPoint;
   /** Daily PER/PBR time series (calculated with daily close prices and FY EPS/BPS) */
   dailyValuation?: ApiDailyValuationDataPoint[];
+  /** Rolling average period used for trading value to market cap ratio (days) */
+  tradingValuePeriod: number;
   /** Last updated timestamp */
   lastUpdated: string;
 }

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
@@ -46,7 +46,40 @@ describe('FundamentalsPanel', () => {
 
     render(<FundamentalsPanel symbol="7203" enabled={false} />);
 
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false, tradingValuePeriod: 15 });
+  });
+
+  it('forwards custom tradingValuePeriod to useFundamentals and summary card', () => {
+    mockUseFundamentals.mockReturnValue({
+      data: {
+        data: [
+          {
+            date: '2024-03-31',
+            periodType: 'FY',
+            adjustedEps: 100,
+            eps: 95,
+            adjustedForecastEps: 120,
+            forecastEps: 110,
+            cashFlowOperating: 100,
+            cashFlowInvesting: -50,
+            cashFlowFinancing: -20,
+            cashAndEquivalents: 500,
+            netProfit: 200,
+            equity: 1000,
+          },
+        ],
+        latestMetrics: {},
+        dailyValuation: [],
+        tradingValuePeriod: 30,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<FundamentalsPanel symbol="7203" tradingValuePeriod={30} />);
+
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: true, tradingValuePeriod: 30 });
+    expect(mockSummaryCard.mock.calls.at(-1)?.[0]).toMatchObject({ tradingValuePeriod: 30 });
   });
 
   it('renders loading and normalized error states', () => {
@@ -110,8 +143,11 @@ describe('FundamentalsPanel', () => {
           prevCashFlowInvesting: -40,
           prevCashFlowFinancing: -10,
           prevCashAndEquivalents: 450,
+          cfoToNetProfitRatio: 0.45,
+          tradingValueToMarketCapRatio: 0.03,
         },
         dailyValuation: [{ per: 18, pbr: 1.4, close: 2500, marketCap: 1000000000 }],
+        tradingValuePeriod: 20,
       },
       isLoading: false,
       error: null,
@@ -131,6 +167,9 @@ describe('FundamentalsPanel', () => {
     expect(metrics?.per).toBe(18);
     expect(metrics?.pbr).toBe(1.4);
     expect(metrics?.stockPrice).toBe(2500);
+    expect(metrics?.cfoToNetProfitRatio).toBe(0.45);
+    expect(metrics?.tradingValueToMarketCapRatio).toBe(0.03);
+    expect(mockSummaryCard.mock.calls.at(-1)?.[0]).toMatchObject({ tradingValuePeriod: 20 });
   });
 
   it('falls back when latestMetrics is missing and adjusted EPS cannot compute change rate', () => {

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
@@ -8,10 +8,15 @@ import { FundamentalsTimeSeriesChart } from './FundamentalsTimeSeriesChart';
 interface FundamentalsPanelProps {
   symbol: string | null;
   enabled?: boolean;
+  tradingValuePeriod?: number;
 }
 
-export function FundamentalsPanel({ symbol, enabled = true }: FundamentalsPanelProps) {
-  const { data, isLoading, error } = useFundamentals(symbol, { enabled });
+export function FundamentalsPanel({
+  symbol,
+  enabled = true,
+  tradingValuePeriod = 15,
+}: FundamentalsPanelProps) {
+  const { data, isLoading, error } = useFundamentals(symbol, { enabled, tradingValuePeriod });
 
   // Get the latest FY (full year) data with actual financial data for summary card
   // Then update PER/PBR/stockPrice with latest daily valuation for current prices
@@ -44,6 +49,9 @@ export function FundamentalsPanel({ symbol, enabled = true }: FundamentalsPanelP
       prevCashFlowInvesting: data.latestMetrics?.prevCashFlowInvesting ?? null,
       prevCashFlowFinancing: data.latestMetrics?.prevCashFlowFinancing ?? null,
       prevCashAndEquivalents: data.latestMetrics?.prevCashAndEquivalents ?? null,
+      cfoToNetProfitRatio: data.latestMetrics?.cfoToNetProfitRatio ?? fyData.cfoToNetProfitRatio ?? null,
+      tradingValueToMarketCapRatio:
+        data.latestMetrics?.tradingValueToMarketCapRatio ?? fyData.tradingValueToMarketCapRatio ?? null,
     };
 
     const displayActualEps = result.adjustedEps ?? result.eps ?? null;
@@ -95,7 +103,10 @@ export function FundamentalsPanel({ symbol, enabled = true }: FundamentalsPanelP
       {data && (
         <div className="h-full grid grid-cols-2 gap-4">
           <div className="h-full overflow-hidden rounded-lg bg-background/30">
-            <FundamentalsSummaryCard metrics={latestFyMetrics} />
+            <FundamentalsSummaryCard
+              metrics={latestFyMetrics}
+              tradingValuePeriod={data.tradingValuePeriod ?? tradingValuePeriod}
+            />
           </div>
           <div className="h-full overflow-hidden rounded-lg bg-background/30">
             <FundamentalsTimeSeriesChart data={data.data} dailyValuation={data.dailyValuation} />

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -1,0 +1,102 @@
+/* @vitest-environment jsdom */
+
+import type { ApiFundamentalDataPoint } from '@trading25/shared/types/api-types';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FundamentalsSummaryCard } from './FundamentalsSummaryCard';
+
+const baseMetrics: ApiFundamentalDataPoint = {
+  date: '2024-03-31',
+  disclosedDate: '2024-05-15',
+  periodType: 'FY',
+  isConsolidated: true,
+  accountingStandard: 'JGAAP',
+  roe: 13.3,
+  eps: 300,
+  dilutedEps: 290,
+  bps: 2250,
+  per: 20,
+  pbr: 2.7,
+  roa: 4.4,
+  operatingMargin: 11.1,
+  netMargin: 8.9,
+  stockPrice: 6100,
+  netProfit: 4_000_000,
+  equity: 30_000_000,
+  totalAssets: 90_000_000,
+  netSales: 45_000_000,
+  operatingProfit: 5_000_000,
+  cashFlowOperating: 6_000_000,
+  cashFlowInvesting: -2_000_000,
+  cashFlowFinancing: -1_000_000,
+  cashAndEquivalents: 8_000_000,
+  fcf: 4_000_000,
+  fcfYield: 0.5,
+  fcfMargin: 8.9,
+  cfoToNetProfitRatio: 1.5,
+  tradingValueToMarketCapRatio: 0.12,
+  forecastEps: 350,
+  forecastEpsChangeRate: 16.7,
+  revisedForecastEps: null,
+  revisedForecastSource: null,
+  prevCashFlowOperating: null,
+  prevCashFlowInvesting: null,
+  prevCashFlowFinancing: null,
+  prevCashAndEquivalents: null,
+};
+
+describe('FundamentalsSummaryCard', () => {
+  it('renders empty state when metrics are missing', () => {
+    render(<FundamentalsSummaryCard metrics={undefined} />);
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('renders new ratio row with custom trading value period', () => {
+    render(<FundamentalsSummaryCard metrics={baseMetrics} tradingValuePeriod={20} />);
+
+    expect(screen.getByText('営業CF/純利益')).toBeInTheDocument();
+    expect(screen.getByText('20日売買代金/時価総額')).toBeInTheDocument();
+    expect(screen.getByText('1.50x')).toBeInTheDocument();
+    expect(screen.getByText('0.12x')).toBeInTheDocument();
+  });
+
+  it('uses 15-day label by default', () => {
+    render(<FundamentalsSummaryCard metrics={baseMetrics} />);
+    expect(screen.getByText('15日売買代金/時価総額')).toBeInTheDocument();
+  });
+
+  it('renders adjusted EPS context and previous cash flow value', () => {
+    const metrics: ApiFundamentalDataPoint = {
+      ...baseMetrics,
+      isConsolidated: false,
+      accountingStandard: null,
+      stockPrice: null,
+      adjustedEps: 320,
+      adjustedForecastEps: 280,
+      adjustedBps: 2300,
+      forecastEpsChangeRate: -12.5,
+      prevCashFlowOperating: 200,
+    };
+
+    render(<FundamentalsSummaryCard metrics={metrics} />);
+
+    expect(screen.getByText('320')).toBeInTheDocument();
+    expect(screen.getByText('予: 280')).toBeInTheDocument();
+    expect(screen.getByText('(-12.5%)')).toBeInTheDocument();
+    expect(screen.getByText('(2億)')).toBeInTheDocument();
+    expect(screen.getByText(/単体 \/ JGAAP/)).toBeInTheDocument();
+    expect(screen.queryByText(/株価 @ 開示日/)).not.toBeInTheDocument();
+  });
+
+  it('does not render EPS forecast block when forecast values are missing', () => {
+    const metrics: ApiFundamentalDataPoint = {
+      ...baseMetrics,
+      forecastEps: null,
+      adjustedForecastEps: null,
+      forecastEpsChangeRate: 0,
+    };
+
+    render(<FundamentalsSummaryCard metrics={metrics} />);
+    expect(screen.queryByText(/予:/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -66,9 +66,10 @@ function EpsMetricCard({ actualEps, forecastEps, changeRate }: EpsMetricCardProp
 
 interface FundamentalsSummaryCardProps {
   metrics: ApiFundamentalDataPoint | undefined;
+  tradingValuePeriod?: number;
 }
 
-export function FundamentalsSummaryCard({ metrics }: FundamentalsSummaryCardProps) {
+export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: FundamentalsSummaryCardProps) {
   if (!metrics) {
     return (
       <div className="h-full flex items-center justify-center">
@@ -131,6 +132,16 @@ export function FundamentalsSummaryCard({ metrics }: FundamentalsSummaryCardProp
         <MetricCard label="FCF" value={metrics.fcf} format="millions" colorScheme="cashFlow" />
         <MetricCard label="FCF利回り" value={metrics.fcfYield} format="percent" colorScheme="fcfYield" />
         <MetricCard label="FCFマージン" value={metrics.fcfMargin} format="percent" colorScheme="fcfMargin" />
+        <MetricCard label="" value={null} format="yen" />
+
+        {/* Row 5: Additional Fundamental Analysis */}
+        <MetricCard label="営業CF/純利益" value={metrics.cfoToNetProfitRatio ?? null} format="times" />
+        <MetricCard
+          label={`${tradingValuePeriod}日売買代金/時価総額`}
+          value={metrics.tradingValueToMarketCapRatio ?? null}
+          format="times"
+        />
+        <MetricCard label="" value={null} format="yen" />
         <MetricCard label="" value={null} format="yen" />
       </div>
 

--- a/apps/ts/packages/web/src/hooks/useFundamentals.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useFundamentals.test.tsx
@@ -25,7 +25,39 @@ describe('useFundamentals', () => {
     const { wrapper } = createTestWrapper();
     const { result } = renderHook(() => useFundamentals('7203'), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203');
+    expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
+      tradingValuePeriod: 15,
+    });
+  });
+
+  it('uses custom trading value period', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ roe: 10, per: 15 });
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useFundamentals('7203', { tradingValuePeriod: 30 }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
+      tradingValuePeriod: 30,
+    });
+  });
+
+  it('normalizes invalid trading value period to default', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ roe: 10, per: 15 });
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useFundamentals('7203', { tradingValuePeriod: Number.NaN }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
+      tradingValuePeriod: 15,
+    });
+  });
+
+  it('normalizes fractional trading value period to a minimum integer', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ roe: 10, per: 15 });
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useFundamentals('7203', { tradingValuePeriod: 0.6 }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
+      tradingValuePeriod: 1,
+    });
   });
 
   it('is disabled when symbol is null', () => {

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -171,6 +171,12 @@ describe('ChartsPage', () => {
     mockFundamentalsPanelProps.mockReset();
     mockFactorRegressionPanelProps.mockReset();
 
+    mockSettings.showPPOChart = true;
+    mockSettings.showVolumeComparison = true;
+    mockSettings.showTradingValueMA = true;
+    mockSettings.tradingValueMA.period = 15;
+    mockSettings.relativeMode = true;
+
     mockUseFundamentals.mockReturnValue({ data: null });
   });
 

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -120,14 +120,19 @@ export function ChartsPage() {
   const factorSection = useLazySectionVisibility();
 
   const { chartData, signalMarkers, isLoading, error, selectedSymbol } = useMultiTimeframeChart();
+  const { settings } = useChartStore();
   const {
     data: marginPressureData,
     isLoading: marginPressureLoading,
     error: marginPressureError,
   } = useBtMarginIndicators(selectedSymbol, { enabled: marginSection.isVisible });
   const { data: stockData } = useStockData(selectedSymbol, 'daily'); // Get stock data for company name
-  const { data: fundamentalsData } = useFundamentals(selectedSymbol, { enabled: fundamentalsSection.isVisible });
   const { settings } = useChartStore();
+  const tradingValuePeriod = Math.max(1, Math.trunc(settings.tradingValueMA.period ?? 15));
+  const { data: fundamentalsData } = useFundamentals(selectedSymbol, {
+    enabled: fundamentalsSection.isVisible,
+    tradingValuePeriod,
+  });
 
   logger.debug('ChartsPage render', {
     selectedSymbol,
@@ -469,7 +474,11 @@ export function ChartsPage() {
                   </div>
                   <div className="h-[calc(100%-4rem)] p-4">
                     <ErrorBoundary>
-                      <FundamentalsPanel symbol={selectedSymbol} enabled={fundamentalsSection.isVisible} />
+                      <FundamentalsPanel
+                        symbol={selectedSymbol}
+                        enabled={fundamentalsSection.isVisible}
+                        tradingValuePeriod={tradingValuePeriod}
+                      />
                     </ErrorBoundary>
                   </div>
                 </div>

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -52,13 +52,13 @@ bun run --filter @trading25/shared bt:sync
 
 | File | Status | Description |
 |---|---|---|
-| `dataset-schema.json` | Deprecated | 旧 dataset schema（参照用） |
-| `dataset-db-schema-v2.json` | Active | dataset.db 契約 |
-| `market-db-schema-v1.json` | Active | market.db 契約 |
-| `portfolio-db-schema-v1.json` | Active | portfolio.db 契約 |
-| `strategy-config-v1.schema.json` | Active | strategy YAML 契約 |
-| `backtest-run-manifest-v1.schema.json` | Active | backtest manifest 契約 |
-| `hono-openapi-baseline.json` | Archived | Hono -> FastAPI 移行ベースライン |
+| `dataset-schema.json` | **Deprecated** | Minimal dataset snapshot schema (legacy v1). Do not use for new work. |
+| `dataset-db-schema-v2.json` | **Active** | Dataset DB schema contract aligned with `apps/ts` Drizzle tables (395 lines). Use this for all new development. |
+| `backtest-run-manifest-v1.schema.json` | **Active** | Backtest run manifest emitted by `apps/bt`. |
+| `strategy-config-v1.schema.json` | **Active** | Strategy YAML schema validated by `apps/bt`. |
+| `fundamentals-metrics-v1.schema.json` | **Active** | Fundamentals API response contract (`/api/analytics/fundamentals/{symbol}`), including `cfoToNetProfitRatio`, `tradingValueToMarketCapRatio`, and `tradingValuePeriod`. |
+| `portfolio-db-schema-v1.json` | **Active** | Portfolio DB schema contract (portfolios, portfolio_items, watchlists, watchlist_items, portfolio_metadata). |
+| `hono-openapi-baseline.json` | **Archived** | Hono OpenAPI snapshot used as Phase 3 migration baseline. Phase 3F (2026-02-07) で全 90 EP 移行完了・Hono 廃止済み。参照用に保持。 |
 
 ## OpenAPI Snapshot
 

--- a/contracts/fundamentals-metrics-v1.schema.json
+++ b/contracts/fundamentals-metrics-v1.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Trading25 Fundamentals Metrics Contract v1",
+  "description": "FastAPI fundamentals response contract used by apps/ts frontend and shared types.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["symbol", "data", "tradingValuePeriod", "lastUpdated"],
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "minLength": 1
+    },
+    "companyName": {
+      "type": ["string", "null"]
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/data_point"
+      }
+    },
+    "latestMetrics": {
+      "anyOf": [
+        { "$ref": "#/$defs/data_point" },
+        { "type": "null" }
+      ]
+    },
+    "dailyValuation": {
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/$defs/daily_valuation_point"
+      }
+    },
+    "tradingValuePeriod": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 250
+    },
+    "lastUpdated": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "data_point": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "date",
+        "disclosedDate",
+        "periodType",
+        "isConsolidated",
+        "cfoToNetProfitRatio",
+        "tradingValueToMarketCapRatio"
+      ],
+      "properties": {
+        "date": { "type": "string" },
+        "disclosedDate": { "type": "string" },
+        "periodType": { "type": "string" },
+        "isConsolidated": { "type": "boolean" },
+        "cfoToNetProfitRatio": { "type": ["number", "null"] },
+        "tradingValueToMarketCapRatio": { "type": ["number", "null"] }
+      }
+    },
+    "daily_valuation_point": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["date", "close", "per", "pbr", "marketCap"],
+      "properties": {
+        "date": { "type": "string" },
+        "close": { "type": "number" },
+        "per": { "type": ["number", "null"] },
+        "pbr": { "type": ["number", "null"] },
+        "marketCap": { "type": ["number", "null"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary: add CFO-to-net-profit and N-day trading-value-to-market-cap ratios to fundamentals API and wire them to Fundamental Analysis summary rows in ChartsPage. Includes API/schema updates, shared type updates, contract schema addition, and backend/frontend test coverage improvements.