### PR TITLE
fix: normalize market_code alias filtering in FastAPI analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **market.db**: 読み書き（SQLAlchemy Core）
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
+- 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う
 - **ts/web** は `/api` パスを FastAPI (:3002) にプロキシ
 - **Hono サーバー** (:3001) は廃止済み（`apps/ts/packages/api` は archived・read-only）
 

--- a/apps/bt/src/server/services/market_code_alias.py
+++ b/apps/bt/src/server/services/market_code_alias.py
@@ -1,0 +1,56 @@
+"""
+Market Code Alias Utilities
+
+市場コードの表現ゆれ（legacy: prime/standard/growth, current: 0111/0112/0113）を吸収する。
+"""
+
+from __future__ import annotations
+
+MARKET_CODE_ALIASES: dict[str, tuple[str, ...]] = {
+    "prime": ("prime", "0111"),
+    "standard": ("standard", "0112"),
+    "growth": ("growth", "0113"),
+    "0111": ("prime", "0111"),
+    "0112": ("standard", "0112"),
+    "0113": ("growth", "0113"),
+}
+
+
+def parse_requested_market_codes(
+    markets: str,
+    fallback: list[str] | None = None,
+) -> list[str]:
+    """クエリ文字列を市場コード配列に変換。空なら fallback を返す。"""
+    market_codes = [m.strip() for m in markets.split(",") if m.strip()]
+    if market_codes:
+        return market_codes
+    if fallback is not None:
+        return fallback[:]
+    return ["prime"]
+
+
+def expand_market_codes(market_codes: list[str]) -> list[str]:
+    """市場コードを alias 展開し、重複を除去して返す。"""
+    expanded: list[str] = []
+    seen: set[str] = set()
+
+    for market_code in market_codes:
+        alias_key = market_code.lower()
+        candidates = MARKET_CODE_ALIASES.get(alias_key, (market_code,))
+        for candidate in candidates:
+            if candidate in seen:
+                continue
+            expanded.append(candidate)
+            seen.add(candidate)
+
+    return expanded
+
+
+def resolve_market_codes(
+    markets: str,
+    fallback: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """入力市場コードとクエリ用市場コードをまとめて解決する。"""
+    requested_market_codes = parse_requested_market_codes(markets, fallback=fallback)
+    query_market_codes = expand_market_codes(requested_market_codes)
+    return requested_market_codes, query_market_codes

--- a/apps/bt/tests/unit/server/services/test_chart_service.py
+++ b/apps/bt/tests/unit/server/services/test_chart_service.py
@@ -1,0 +1,112 @@
+"""
+Chart Service Unit Tests
+"""
+
+import sqlite3
+
+import pytest
+
+from src.lib.market_db.market_reader import MarketDbReader
+from src.server.services.chart_service import ChartService
+
+
+@pytest.fixture
+def chart_db(tmp_path):
+    db_path = str(tmp_path / "chart.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    conn.execute("""
+        CREATE TABLE stocks (
+            code TEXT PRIMARY KEY,
+            company_name TEXT NOT NULL,
+            company_name_english TEXT,
+            market_code TEXT NOT NULL,
+            market_name TEXT NOT NULL,
+            sector_17_code TEXT NOT NULL,
+            sector_17_name TEXT NOT NULL,
+            sector_33_code TEXT NOT NULL,
+            sector_33_name TEXT NOT NULL,
+            scale_category TEXT,
+            listed_date TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE stock_data (
+            code TEXT NOT NULL,
+            date TEXT NOT NULL,
+            open REAL NOT NULL,
+            high REAL NOT NULL,
+            low REAL NOT NULL,
+            close REAL NOT NULL,
+            volume INTEGER NOT NULL,
+            adjustment_factor REAL,
+            created_at TEXT,
+            PRIMARY KEY (code, date)
+        )
+    """)
+
+    stocks = [
+        ("10010", "Legacy Prime", "LPRIME", "prime"),
+        ("10020", "Numeric Prime", "NPRIME", "0111"),
+        ("10030", "Legacy Standard", "LSTD", "standard"),
+        ("10040", "Numeric Standard", "NSTD", "0112"),
+    ]
+    for i, (code, company_name, company_name_english, market_code) in enumerate(stocks):
+        conn.execute(
+            "INSERT INTO stocks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                code,
+                company_name,
+                company_name_english,
+                market_code,
+                "Market",
+                "S17",
+                "セクター17",
+                "S33",
+                "セクター33",
+                "TOPIX Small 1",
+                "2020-01-01",
+                None,
+                None,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (code, "2026-02-06", 100 + i, 110 + i, 95 + i, 105 + i, 100_000 + i * 1000, 1.0, None),
+        )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def service(chart_db):
+    reader = MarketDbReader(chart_db)
+    yield ChartService(reader, None)
+    reader.close()
+
+
+class TestSectorStocksMarketCodeCompatibility:
+    def test_prime_query_matches_legacy_and_numeric_prime(self, service):
+        result = service.get_sector_stocks(markets="prime")
+        assert result is not None
+        assert result.markets == ["prime"]
+        assert len(result.stocks) == 2
+        assert {item.marketCode for item in result.stocks} == {"prime", "0111"}
+
+    def test_numeric_prime_query_matches_legacy_and_numeric_prime(self, service):
+        result = service.get_sector_stocks(markets="0111")
+        assert result is not None
+        assert result.markets == ["0111"]
+        assert len(result.stocks) == 2
+        assert {item.marketCode for item in result.stocks} == {"prime", "0111"}
+
+    def test_comma_separated_market_query_expands_all_aliases(self, service):
+        result = service.get_sector_stocks(markets="prime,standard")
+        assert result is not None
+        assert result.markets == ["prime", "standard"]
+        assert len(result.stocks) == 4

--- a/apps/bt/tests/unit/server/services/test_chart_service_branches.py
+++ b/apps/bt/tests/unit/server/services/test_chart_service_branches.py
@@ -1,0 +1,170 @@
+"""
+ChartService branch coverage tests for fallback/error paths.
+"""
+
+import pytest
+
+from src.server.services.chart_service import ChartService
+
+
+class FakeReader:
+    def __init__(self, query_one_results=None, query_results=None):
+        self.query_one_results = list(query_one_results or [])
+        self.query_results = list(query_results or [])
+
+    def query_one(self, sql, params=()):  # noqa: ANN001, ANN201
+        if self.query_one_results:
+            return self.query_one_results.pop(0)
+        return None
+
+    def query(self, sql, params=()):  # noqa: ANN001, ANN201
+        if self.query_results:
+            return self.query_results.pop(0)
+        return []
+
+
+class FakeJQuants:
+    def __init__(self, responses=None, raise_paths=None):
+        self.responses = responses or {}
+        self.raise_paths = set(raise_paths or [])
+        self.calls = []
+
+    async def get(self, path, params=None):  # noqa: ANN001, ANN201
+        self.calls.append((path, params))
+        if path in self.raise_paths:
+            raise RuntimeError("jquants error")
+        return self.responses.get(path, {})
+
+
+class TestReaderNonePaths:
+    def test_indices_return_none_when_reader_is_none(self):
+        service = ChartService(None, FakeJQuants())
+        assert service.get_indices_list() is None
+        assert service.get_index_data("0000") is None
+
+    def test_stock_from_db_returns_none_when_reader_is_none(self):
+        service = ChartService(None, FakeJQuants())
+        assert service._get_stock_from_db("7203", "daily") is None  # noqa: SLF001
+
+    def test_sector_stocks_return_none_when_reader_is_none(self):
+        service = ChartService(None, FakeJQuants())
+        assert service.get_sector_stocks() is None
+
+
+class TestTopixFallbackPaths:
+    @pytest.mark.asyncio
+    async def test_topix_falls_back_to_jquants_when_db_unavailable(self):
+        jq = FakeJQuants(
+            responses={
+                "/indices/bars/daily/topix": {
+                    "data": [{"Date": "2026-02-06", "O": 100, "H": 110, "L": 95, "C": 105}]
+                }
+            }
+        )
+        service = ChartService(None, jq)
+        result = await service.get_topix_data("2026-01-01", "2026-02-06")
+        assert result is not None
+        assert len(result.topix) == 1
+        assert jq.calls[0][0] == "/indices/bars/daily/topix"
+        assert jq.calls[0][1] == {"from": "20260101", "to": "20260206"}
+
+    @pytest.mark.asyncio
+    async def test_topix_jquants_error_and_empty_return_none(self):
+        service_err = ChartService(None, FakeJQuants(raise_paths={"/indices/bars/daily/topix"}))
+        assert await service_err._get_topix_from_jquants(None, None) is None  # noqa: SLF001
+
+        service_empty = ChartService(None, FakeJQuants(responses={"/indices/bars/daily/topix": {"data": []}}))
+        assert await service_empty._get_topix_from_jquants(None, None) is None  # noqa: SLF001
+
+    def test_topix_from_db_returns_none_on_empty(self):
+        service = ChartService(FakeReader(query_results=[[]]), FakeJQuants())
+        assert service._get_topix_from_db(None, None) is None  # noqa: SLF001
+
+
+class TestStockFallbackPaths:
+    @pytest.mark.asyncio
+    async def test_get_stock_data_falls_back_to_jquants(self):
+        reader = FakeReader(query_one_results=[None])
+        jq = FakeJQuants(
+            responses={
+                "/equities/bars/daily": {"data": [{"Date": "2026-02-06", "AdjO": 10, "AdjH": 11, "AdjL": 9, "AdjC": 10.5, "AdjVo": 1000}]},
+                "/equities/master": {"data": [{"CoName": "Test Corp"}]},
+            }
+        )
+        service = ChartService(reader, jq)
+        result = await service.get_stock_data("7203", "daily", adjusted=True)
+        assert result is not None
+        assert result.companyName == "Test Corp"
+
+    @pytest.mark.asyncio
+    async def test_stock_from_jquants_handles_error_empty_and_unadjusted(self):
+        service_err = ChartService(None, FakeJQuants(raise_paths={"/equities/bars/daily"}))
+        assert await service_err._get_stock_from_jquants("7203", "daily", adjusted=True) is None  # noqa: SLF001
+
+        service_empty = ChartService(None, FakeJQuants(responses={"/equities/bars/daily": {"data": []}}))
+        assert await service_empty._get_stock_from_jquants("7203", "daily", adjusted=True) is None  # noqa: SLF001
+
+        service_unadj = ChartService(
+            None,
+            FakeJQuants(
+                responses={
+                    "/equities/bars/daily": {
+                        "data": [
+                            {"Date": "2026-02-05", "O": 10, "H": 11, "L": 9, "C": 0, "Vo": 1000},
+                            {"Date": "2026-02-06", "O": 10, "H": 11, "L": 9, "C": 10.5, "Vo": 2000},
+                        ]
+                    },
+                    "/equities/master": {"data": []},
+                }
+            ),
+        )
+        result = await service_unadj._get_stock_from_jquants("7203", "daily", adjusted=False)  # noqa: SLF001
+        assert result is not None
+        assert len(result.data) == 1
+
+    def test_stock_from_db_returns_none_when_rows_empty(self):
+        reader = FakeReader(query_one_results=[{"code": "72030", "company_name": "Toyota"}], query_results=[[]])
+        service = ChartService(reader, FakeJQuants())
+        assert service._get_stock_from_db("7203", "daily") is None  # noqa: SLF001
+
+
+class TestMiscBranches:
+    def test_search_stocks_returns_empty_for_blank_query(self):
+        service = ChartService(FakeReader(), FakeJQuants())
+        result = service.search_stocks("   ")
+        assert result.count == 0
+
+    def test_sector_stocks_returns_none_when_no_latest_date(self):
+        reader = FakeReader(query_one_results=[{"max_date": None}])
+        service = ChartService(reader, FakeJQuants())
+        assert service.get_sector_stocks() is None
+
+    def test_sector_stocks_with_base_date_and_sector17_filter(self):
+        reader = FakeReader(
+            query_one_results=[
+                {"max_date": "2026-02-06"},
+                {"date": "2026-02-05"},
+                {"date": "2026-01-16"},
+            ],
+            query_results=[
+                [
+                    {
+                        "code": "72030",
+                        "company_name": "トヨタ自動車",
+                        "market_code": "prime",
+                        "sector_33_name": "輸送用機器",
+                        "current_price": 2500.0,
+                        "volume": 1000000,
+                        "trading_value": 2.5e9,
+                        "base_price": 2480.0,
+                        "change_amount": 20.0,
+                        "change_percentage": 0.81,
+                    }
+                ]
+            ],
+        )
+        service = ChartService(reader, FakeJQuants())
+        result = service.get_sector_stocks(sector17_name="輸送･機器", markets="prime", lookback_days=1)
+        assert result is not None
+        assert len(result.stocks) == 1
+        assert result.stocks[0].basePrice == 2480.0

--- a/apps/bt/tests/unit/server/services/test_market_code_alias.py
+++ b/apps/bt/tests/unit/server/services/test_market_code_alias.py
@@ -1,0 +1,49 @@
+"""
+Market code alias utility tests.
+"""
+
+from src.server.services.market_code_alias import (
+    expand_market_codes,
+    parse_requested_market_codes,
+    resolve_market_codes,
+)
+
+
+class TestParseRequestedMarketCodes:
+    def test_returns_split_codes(self):
+        result = parse_requested_market_codes("prime,standard")
+        assert result == ["prime", "standard"]
+
+    def test_returns_fallback_on_empty(self):
+        result = parse_requested_market_codes("", fallback=["prime", "standard"])
+        assert result == ["prime", "standard"]
+
+    def test_returns_default_prime_when_empty_without_fallback(self):
+        result = parse_requested_market_codes("")
+        assert result == ["prime"]
+
+
+class TestExpandMarketCodes:
+    def test_expands_legacy_codes(self):
+        result = expand_market_codes(["prime", "standard"])
+        assert result == ["prime", "0111", "standard", "0112"]
+
+    def test_expands_numeric_codes(self):
+        result = expand_market_codes(["0111", "0112"])
+        assert result == ["prime", "0111", "standard", "0112"]
+
+    def test_deduplicates_and_keeps_unknown(self):
+        result = expand_market_codes(["prime", "0111", "custom"])
+        assert result == ["prime", "0111", "custom"]
+
+
+class TestResolveMarketCodes:
+    def test_resolves_requested_and_query_codes(self):
+        requested, query_codes = resolve_market_codes("prime,custom")
+        assert requested == ["prime", "custom"]
+        assert query_codes == ["prime", "0111", "custom"]
+
+    def test_resolves_with_fallback(self):
+        requested, query_codes = resolve_market_codes("", fallback=["standard"])
+        assert requested == ["standard"]
+        assert query_codes == ["standard", "0112"]

--- a/apps/bt/tests/unit/server/services/test_market_data_service_alias.py
+++ b/apps/bt/tests/unit/server/services/test_market_data_service_alias.py
@@ -1,0 +1,84 @@
+"""
+MarketDataService market-code alias tests.
+"""
+
+import sqlite3
+
+import pytest
+
+from src.lib.market_db.market_reader import MarketDbReader
+from src.server.services.market_data_service import MarketDataService
+
+
+@pytest.fixture
+def market_alias_db(tmp_path):
+    db_path = str(tmp_path / "market-alias.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    conn.execute("""
+        CREATE TABLE stocks (
+            code TEXT PRIMARY KEY,
+            company_name TEXT NOT NULL,
+            market_code TEXT NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE stock_data (
+            code TEXT NOT NULL,
+            date TEXT NOT NULL,
+            open REAL NOT NULL,
+            high REAL NOT NULL,
+            low REAL NOT NULL,
+            close REAL NOT NULL,
+            volume INTEGER NOT NULL,
+            PRIMARY KEY (code, date)
+        )
+    """)
+
+    stocks = [
+        ("10010", "Legacy Prime", "prime"),
+        ("10020", "Numeric Prime", "0111"),
+        ("10030", "Legacy Standard", "standard"),
+        ("10040", "Numeric Standard", "0112"),
+    ]
+    for i, (code, company_name, market_code) in enumerate(stocks):
+        conn.execute(
+            "INSERT INTO stocks (code, company_name, market_code) VALUES (?, ?, ?)",
+            (code, company_name, market_code),
+        )
+        conn.execute(
+            "INSERT INTO stock_data (code, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (code, "2026-02-06", 100 + i, 101 + i, 99 + i, 100 + i, 1000 + i),
+        )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def service(market_alias_db):
+    reader = MarketDbReader(market_alias_db)
+    yield MarketDataService(reader)
+    reader.close()
+
+
+class TestGetAllStocksMarketCodeCompatibility:
+    def test_prime_query_matches_legacy_and_numeric_prime(self, service):
+        result = service.get_all_stocks(market="prime", history_days=30)
+        assert result is not None
+        assert len(result) == 2
+        assert {item.code for item in result} == {"10010", "10020"}
+
+    def test_standard_query_matches_legacy_and_numeric_standard(self, service):
+        result = service.get_all_stocks(market="standard", history_days=30)
+        assert result is not None
+        assert len(result) == 2
+        assert {item.code for item in result} == {"10030", "10040"}
+
+    def test_numeric_prime_query_also_matches_legacy_prime(self, service):
+        result = service.get_all_stocks(market="0111", history_days=30)
+        assert result is not None
+        assert len(result) == 2
+        assert {item.code for item in result} == {"10010", "10020"}

--- a/apps/bt/tests/unit/server/services/test_ranking_service.py
+++ b/apps/bt/tests/unit/server/services/test_ranking_service.py
@@ -41,11 +41,13 @@ def ranking_db(tmp_path):
     conn.execute("INSERT INTO stocks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                  ("67580", "ソニー", "SONY", "prime", "P", "S17", "電気", "S33", "電気機器", None, "2000-01-01", None, None))
     conn.execute("INSERT INTO stocks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                 ("83060", "Numeric Prime", "NPRIME", "0111", "P", "S17", "銀行", "S33", "銀行業", None, "2000-01-01", None, None))
+    conn.execute("INSERT INTO stocks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                  ("99840", "テスト", "TEST", "standard", "S", "S17", "情報", "S33", "情報通信", None, "2000-01-01", None, None))
 
     # 5日分のOHLCVデータ
     dates = ["2024-01-15", "2024-01-16", "2024-01-17", "2024-01-18", "2024-01-19"]
-    for code, base_v in [("72030", 2000000), ("67580", 1500000), ("99840", 100000)]:
+    for code, base_v in [("72030", 2000000), ("67580", 1500000), ("83060", 1100000), ("99840", 100000)]:
         for i, d in enumerate(dates):
             price = 2500.0 + i * 10 if code == "72030" else (13000.0 + i * 50 if code == "67580" else 500.0 + i * 5)
             vol = base_v + i * 10000
@@ -99,6 +101,18 @@ class TestGetRankings:
         items = result.rankings.tradingValue
         for item in items:
             assert item.marketCode == "standard"
+
+    def test_market_filter_alias_prime_includes_numeric_codes(self, service):
+        result = service.get_rankings(markets="prime", limit=20)
+        market_codes = {item.marketCode for item in result.rankings.tradingValue}
+        assert "prime" in market_codes
+        assert "0111" in market_codes
+
+    def test_market_filter_alias_0111_includes_legacy_codes(self, service):
+        result = service.get_rankings(markets="0111", limit=20)
+        market_codes = {item.marketCode for item in result.rankings.tradingValue}
+        assert "prime" in market_codes
+        assert "0111" in market_codes
 
     def test_lookback_days(self, service):
         result = service.get_rankings(lookback_days=3)

--- a/apps/bt/tests/unit/server/services/test_screening_service.py
+++ b/apps/bt/tests/unit/server/services/test_screening_service.py
@@ -1,0 +1,86 @@
+"""
+Screening Service Unit Tests
+"""
+
+import sqlite3
+
+import pytest
+
+from src.lib.market_db.market_reader import MarketDbReader
+from src.server.services.screening_service import ScreeningService
+
+
+@pytest.fixture
+def screening_db(tmp_path):
+    db_path = str(tmp_path / "screening.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    conn.execute("""
+        CREATE TABLE stocks (
+            code TEXT PRIMARY KEY,
+            company_name TEXT NOT NULL,
+            market_code TEXT NOT NULL,
+            scale_category TEXT,
+            sector_33_name TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE stock_data (
+            code TEXT NOT NULL,
+            date TEXT NOT NULL,
+            open REAL NOT NULL,
+            high REAL NOT NULL,
+            low REAL NOT NULL,
+            close REAL NOT NULL,
+            volume INTEGER NOT NULL,
+            PRIMARY KEY (code, date)
+        )
+    """)
+
+    stocks = [
+        ("10010", "Numeric Prime", "0111"),
+        ("10020", "Legacy Prime", "prime"),
+        ("10030", "Numeric Standard", "0112"),
+        ("10040", "Legacy Standard", "standard"),
+    ]
+    for code, company_name, market_code in stocks:
+        conn.execute(
+            "INSERT INTO stocks (code, company_name, market_code, scale_category, sector_33_name) VALUES (?, ?, ?, ?, ?)",
+            (code, company_name, market_code, "TOPIX Small 1", "情報・通信業"),
+        )
+        conn.execute(
+            "INSERT INTO stock_data (code, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (code, "2026-01-06", 100.0, 101.0, 99.0, 100.0, 1000),
+        )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def service(screening_db):
+    reader = MarketDbReader(screening_db)
+    yield ScreeningService(reader)
+    reader.close()
+
+
+class TestMarketCodeCompatibility:
+    def test_prime_query_matches_legacy_and_numeric_prime(self, service):
+        result = service.run_screening(markets="prime")
+        assert result.markets == ["prime"]
+        assert result.summary.totalStocksScreened == 2
+        assert result.summary.skippedCount == 2
+
+    def test_numeric_prime_query_matches_legacy_and_numeric_prime(self, service):
+        result = service.run_screening(markets="0111")
+        assert result.markets == ["0111"]
+        assert result.summary.totalStocksScreened == 2
+        assert result.summary.skippedCount == 2
+
+    def test_comma_separated_market_query_expands_all_aliases(self, service):
+        result = service.run_screening(markets="prime,standard")
+        assert result.markets == ["prime", "standard"]
+        assert result.summary.totalStocksScreened == 4
+        assert result.summary.skippedCount == 4

--- a/apps/bt/tests/unit/server/services/test_screening_service_helpers.py
+++ b/apps/bt/tests/unit/server/services/test_screening_service_helpers.py
@@ -1,0 +1,169 @@
+"""
+Screening helper function tests.
+"""
+
+from src.server.schemas.screening import RangeBreakDetails, ScreeningDetails, ScreeningResultItem
+from src.server.services.screening_service import (
+    RangeBreakParams,
+    ScreeningService,
+    StockDataPoint,
+    _check_volume_condition,
+    _detect_range_break,
+    _ema,
+    _find_max_high,
+    _get_volume_avg,
+    _sma,
+)
+
+
+class DummyReader:
+    def query(self, sql, params=()):  # noqa: ANN001, ANN201
+        return []
+
+
+def make_point(day: int, high: float, volume: float) -> StockDataPoint:
+    return StockDataPoint(
+        date=f"2026-01-{day:02d}",
+        open=high - 1.0,
+        high=high,
+        low=high - 2.0,
+        close=high - 0.5,
+        volume=volume,
+    )
+
+
+class TestVolumeHelpers:
+    def test_sma_and_ema_return_empty_for_invalid_period(self):
+        assert _sma([1, 2, 3], 0) == []
+        assert _ema([1, 2, 3], 5) == []
+
+    def test_get_volume_avg_returns_none_for_out_of_range(self):
+        data = [make_point(1, 10, 100), make_point(2, 11, 120)]
+        assert _get_volume_avg(data, period=3, end_index=1, vol_type="sma") is None
+
+    def test_check_volume_condition_handles_zero_long_average(self):
+        params = RangeBreakParams(volume_short_period=1, volume_long_period=1, volume_ratio_threshold=1.1)
+        data = [make_point(1, 10, 0), make_point(2, 11, 0)]
+        matched, ratio, short_avg, long_avg = _check_volume_condition(data, params, 1)
+        assert (matched, ratio, short_avg, long_avg) == (False, 0.0, 0.0, 0.0)
+
+
+class TestRangeBreakHelpers:
+    def test_find_max_high_invalid_range_returns_zero(self):
+        data = [make_point(1, 10, 100), make_point(2, 11, 100)]
+        assert _find_max_high(data, start=-1, end=1) == 0.0
+        assert _find_max_high(data, start=1, end=0) == 0.0
+
+    def test_detect_range_break_returns_none_when_insufficient_data(self):
+        params = RangeBreakParams(period=5, lookback_days=2)
+        data = [make_point(1, 10, 100), make_point(2, 11, 100), make_point(3, 12, 100)]
+        assert _detect_range_break(data, params=params, recent_days=2) is None
+
+    def test_detect_range_break_returns_details_when_conditions_match(self):
+        params = RangeBreakParams(
+            period=3,
+            lookback_days=1,
+            volume_ratio_threshold=1.0,
+            volume_short_period=1,
+            volume_long_period=2,
+            volume_type="sma",
+        )
+        data = [
+            make_point(1, 10, 100),
+            make_point(2, 10, 100),
+            make_point(3, 10, 100),
+            make_point(4, 11, 300),
+            make_point(5, 12, 400),
+        ]
+        details = _detect_range_break(data, params=params, recent_days=2)
+        assert details is not None
+        assert details.breakDate == "2026-01-05"
+        assert details.breakPercentage > 0
+
+
+class TestServiceHelpers:
+    def test_maybe_add_result_respects_filters(self):
+        service = ScreeningService(DummyReader())
+        results: list[ScreeningResultItem] = []
+        details = RangeBreakDetails(
+            breakDate="2026-01-05",
+            currentHigh=12.0,
+            maxHighInLookback=11.0,
+            breakPercentage=1.0,
+            volumeRatio=1.2,
+            avgVolume20Days=300.0,
+            avgVolume100Days=200.0,
+        )
+
+        service._maybe_add_result(  # noqa: SLF001
+            results,
+            {"code": "10010", "company_name": "A"},
+            "rangeBreakFast",
+            details,
+            min_break_pct=2.0,
+            min_vol_ratio=None,
+        )
+        assert results == []
+
+        service._maybe_add_result(  # noqa: SLF001
+            results,
+            {"code": "10010", "company_name": "A"},
+            "rangeBreakFast",
+            details,
+            min_break_pct=None,
+            min_vol_ratio=1.5,
+        )
+        assert results == []
+
+        service._maybe_add_result(  # noqa: SLF001
+            results,
+            {"code": "10010", "company_name": "A"},
+            "rangeBreakFast",
+            details,
+            min_break_pct=0.5,
+            min_vol_ratio=1.1,
+        )
+        assert len(results) == 1
+
+    def test_sort_results_handles_all_sort_types(self):
+        service = ScreeningService(DummyReader())
+        item_a = ScreeningResultItem(
+            stockCode="1001",
+            companyName="A",
+            screeningType="rangeBreakFast",
+            matchedDate="2026-01-04",
+            details=ScreeningDetails(
+                rangeBreak=RangeBreakDetails(
+                    breakDate="2026-01-04",
+                    currentHigh=11.0,
+                    maxHighInLookback=10.0,
+                    breakPercentage=10.0,
+                    volumeRatio=1.5,
+                    avgVolume20Days=200.0,
+                    avgVolume100Days=130.0,
+                )
+            ),
+        )
+        item_b = ScreeningResultItem(
+            stockCode="1002",
+            companyName="B",
+            screeningType="rangeBreakSlow",
+            matchedDate="2026-01-05",
+            details=ScreeningDetails(
+                rangeBreak=RangeBreakDetails(
+                    breakDate="2026-01-05",
+                    currentHigh=12.0,
+                    maxHighInLookback=10.0,
+                    breakPercentage=20.0,
+                    volumeRatio=2.0,
+                    avgVolume20Days=300.0,
+                    avgVolume100Days=150.0,
+                )
+            ),
+        )
+        base = [item_a, item_b]
+
+        assert service._sort_results(base.copy(), "date", "desc")[0].stockCode == "1002"  # noqa: SLF001
+        assert service._sort_results(base.copy(), "stockCode", "asc")[0].stockCode == "1001"  # noqa: SLF001
+        assert service._sort_results(base.copy(), "volumeRatio", "desc")[0].stockCode == "1002"  # noqa: SLF001
+        assert service._sort_results(base.copy(), "breakPercentage", "desc")[0].stockCode == "1002"  # noqa: SLF001


### PR DESCRIPTION
Summary
- add market code alias resolver for legacy and numeric market codes
- apply alias-aware filtering to Screening, Ranking, Chart sector stocks, and MarketData all-stocks services
- keep API response markets as requested values while querying DB with expanded aliases
- update AGENTS rule to document market code alias compatibility

Testing
- uv run pytest tests/unit/server/services/test_market_code_alias.py tests/unit/server/services/test_screening_service.py tests/unit/server/services/test_screening_service_helpers.py tests/unit/server/services/test_ranking_service.py tests/unit/server/services/test_chart_service.py tests/unit/server/services/test_chart_service_branches.py tests/unit/server/services/test_market_data_service_alias.py
- uv run coverage run --branch -m pytest tests/unit/server/services/test_market_code_alias.py tests/unit/server/services/test_screening_service.py tests/unit/server/services/test_screening_service_helpers.py tests/unit/server/services/test_ranking_service.py tests/unit/server/services/test_chart_service.py tests/unit/server/services/test_chart_service_branches.py tests/unit/server/services/test_market_data_service_alias.py tests/unit/server/routes/test_analytics_complex.py tests/unit/server/routes/test_chart.py tests/unit/server/routes/test_market_data.py
- uv run coverage report -m src/server/services/market_code_alias.py src/server/services/screening_service.py src/server/services/ranking_service.py src/server/services/chart_service.py src/server/services/market_data_service.py