### PR TITLE
feat(bt): add ROA as a backtest fundamental signal

### DIFF
--- a/apps/bt/src/models/signals/fundamental.py
+++ b/apps/bt/src/models/signals/fundamental.py
@@ -152,6 +152,21 @@ class FundamentalSignalParams(BaseSignalParams):
             description="条件（above=閾値以上、below=閾値以下）",
         )
 
+    class ROAParams(BaseModel):
+        """ROA（総資産利益率）シグナルパラメータ"""
+
+        enabled: bool = Field(default=False, description="ROAシグナル有効")
+        threshold: float = Field(
+            default=5.0,
+            gt=0,
+            le=100.0,
+            description="ROA閾値（この値を上回る高ROA判定、%単位）",
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値以下）",
+        )
+
     class OperatingMarginParams(BaseModel):
         """営業利益率シグナルパラメータ"""
 
@@ -320,6 +335,7 @@ class FundamentalSignalParams(BaseSignalParams):
 
     # 収益性・キャッシュフロー系
     roe: ROEParams = Field(default_factory=ROEParams, description="ROEシグナル")
+    roa: ROAParams = Field(default_factory=ROAParams, description="ROAシグナル")
     operating_margin: OperatingMarginParams = Field(
         default_factory=OperatingMarginParams, description="営業利益率シグナル"
     )

--- a/apps/bt/src/strategies/signals/fundamental.py
+++ b/apps/bt/src/strategies/signals/fundamental.py
@@ -46,6 +46,7 @@ from .fundamental_growth import (
 from .fundamental_quality import (
     is_high_dividend_yield,
     is_high_operating_margin,
+    is_high_roa,
     is_high_roe,
 )
 
@@ -75,6 +76,7 @@ __all__ = [
     "is_growing_sales",
     # 収益性・品質系
     "is_high_roe",
+    "is_high_roa",
     "is_high_operating_margin",
     "is_high_dividend_yield",
     # キャッシュフロー系・時価総額系

--- a/apps/bt/src/strategies/signals/fundamental_quality.py
+++ b/apps/bt/src/strategies/signals/fundamental_quality.py
@@ -1,7 +1,7 @@
 """
 財務指標シグナル — 収益性・品質系
 
-ROE・営業利益率・配当利回りに基づく品質判定シグナルを提供
+ROE・ROA・営業利益率・配当利回りに基づく品質判定シグナルを提供
 """
 
 from __future__ import annotations
@@ -39,6 +39,33 @@ def is_high_roe(
         - 推奨period_type: "FY"（通期利益ベース）
     """
     return _calc_threshold_signal(roe, threshold, condition)
+
+
+def is_high_roa(
+    roa: pd.Series[float],
+    threshold: float = 5.0,
+    condition: Literal["above", "below"] = "above",
+) -> pd.Series[bool]:
+    """
+    ROA（Return on Assets）シグナル
+
+    既に計算済みのROAデータを使用して、
+    指定した条件で閾値と比較してTrueを返すシグナル
+
+    Args:
+        roa: ROAデータ（%単位、ローダーで日次補完済み）
+        threshold: ROA閾値（デフォルト5.0 = 5%）
+        condition: 条件（above=閾値以上、below=閾値以下）
+
+    Returns:
+        pd.Series[bool]: 条件を満たす場合にTrue
+
+    Note:
+        - ROAがNaNの場合はFalseを返す
+        - ROAが負の値の場合はFalseを返す（損失企業除外）
+        - 推奨period_type: "FY"（通期利益ベース）
+    """
+    return _calc_threshold_signal(roa, threshold, condition)
 
 
 def is_high_operating_margin(

--- a/apps/bt/src/strategies/signals/registry.py
+++ b/apps/bt/src/strategies/signals/registry.py
@@ -28,6 +28,7 @@ from .fundamental import (
     is_growing_sales,
     is_high_dividend_yield,
     is_high_operating_margin,
+    is_high_roa,
     is_high_roe,
     market_cap_threshold,
     operating_cash_flow_threshold,
@@ -288,6 +289,24 @@ SIGNAL_REGISTRY: list[SignalDefinition] = [
         param_key="fundamental.roe",
         data_checker=lambda d: _has_statements_column(d, "ROE"),
         data_requirements=["statements:ROE"],
+    ),
+    # 5.5. ROAシグナル
+    SignalDefinition(
+        name="ROA",
+        signal_func=is_high_roa,
+        enabled_checker=lambda p: p.fundamental.enabled and p.fundamental.roa.enabled,
+        param_builder=lambda p, d: {
+            "roa": d["statements_data"]["ROA"],
+            "threshold": p.fundamental.roa.threshold,
+            "condition": p.fundamental.roa.condition,
+        },
+        entry_purpose="ROA（総資産利益率）が閾値以上の高効率企業を選定",
+        exit_purpose="ROAが閾値を下回った資産効率低下企業を除外",
+        category="fundamental",
+        description="ROA（総資産利益率）の閾値判定",
+        param_key="fundamental.roa",
+        data_checker=lambda d: _has_statements_column(d, "ROA"),
+        data_requirements=["statements:ROA"],
     ),
     # 6. β値シグナル
     SignalDefinition(

--- a/apps/bt/tests/unit/strategies/signals/test_fundamental.py
+++ b/apps/bt/tests/unit/strategies/signals/test_fundamental.py
@@ -15,6 +15,7 @@ from src.strategies.signals.fundamental import (
     is_growing_profit,
     is_growing_sales,
     is_high_roe,
+    is_high_roa,
     is_high_dividend_yield,
     is_high_operating_margin,
     operating_cash_flow_threshold,
@@ -210,6 +211,48 @@ class TestIsHighRoe:
         # 負のROEはFalse
         assert signal.sum() == 0
 
+
+
+
+class TestIsHighRoa:
+    """is_high_roa()のテスト"""
+
+    def setup_method(self):
+        """テストデータ作成"""
+        self.dates = pd.date_range("2023-01-01", periods=100)
+        # ROA=8%
+        self.roa = pd.Series(np.ones(100) * 8, index=self.dates)
+
+    def test_roa_basic(self):
+        """ROAシグナル基本テスト"""
+        signal = is_high_roa(self.roa, threshold=5.0)
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
+        assert len(signal) == len(self.roa)
+        # ROA=8% > 5%なので全てTrue
+        assert signal.sum() == len(self.roa)
+
+    def test_roa_threshold_effect(self):
+        """ROA閾値の効果テスト"""
+        signal_low = is_high_roa(self.roa, threshold=3.0)
+        signal_high = is_high_roa(self.roa, threshold=10.0)
+
+        assert isinstance(signal_low, pd.Series)
+        assert isinstance(signal_high, pd.Series)
+        # 低い閾値の方がTrue数が多い
+        assert signal_low.sum() >= signal_high.sum()
+
+    def test_roa_negative(self):
+        """負のROAの場合"""
+        roa_negative = pd.Series(np.ones(100) * -1, index=self.dates)
+
+        signal = is_high_roa(roa_negative, threshold=5.0)
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
+        # 負のROAはFalse
+        assert signal.sum() == 0
 
 class TestIsUndervaluedGrowthByPeg:
     """is_undervalued_growth_by_peg()のテスト"""

--- a/apps/bt/tests/unit/strategies/signals/test_registry.py
+++ b/apps/bt/tests/unit/strategies/signals/test_registry.py
@@ -183,6 +183,15 @@ class TestSignalRegistry:
         assert "statements:EPS" in sig.data_requirements
         assert "statements:NextYearForecastEPS" not in sig.data_requirements
 
+    def test_roa_registered(self) -> None:
+        """roa（総資産利益率）がレジストリに登録されていること"""
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.roa"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "ROA"
+        assert sig.category == "fundamental"
+        assert "statements:ROA" in sig.data_requirements
+
     def test_market_cap_registered(self) -> None:
         """market_cap（時価総額）がレジストリに登録されていること"""
         matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.market_cap"]


### PR DESCRIPTION
### Motivation
- The frontend already exposes ROA alongside ROE but ROA was not available as a backtest signal, preventing strategies from using asset-efficiency filtering.
- Add ROA to the unified signal system so strategies can enable/configure ROA-based entry/exit filters like ROE.

### Description
- Added `ROAParams` and `roa` field to `FundamentalSignalParams` (`apps/bt/src/models/signals/fundamental.py`).
- Implemented `is_high_roa()` in `fundamental_quality` and re-exported it from the aggregate `fundamental` module (`apps/bt/src/strategies/signals/fundamental_quality.py`, `apps/bt/src/strategies/signals/fundamental.py`).
- Registered a new `fundamental.roa` `SignalDefinition` in `SIGNAL_REGISTRY` with appropriate `param_builder`, data check (`statements:ROA`) and entry/exit purposes (`apps/bt/src/strategies/signals/registry.py`).
- Added unit tests for the ROA signal behavior and registry registration (`apps/bt/tests/unit/strategies/signals/test_fundamental.py`, `apps/bt/tests/unit/strategies/signals/test_registry.py`).

### Testing
- Ran the focused unit tests: `uv run pytest tests/unit/strategies/signals/test_fundamental.py tests/unit/strategies/signals/test_registry.py` in `apps/bt`, and all tests passed: `171 passed in 2.06s`.
- The new tests exercise `is_high_roa()` behavior (threshold/negative/edge cases) and confirm `fundamental.roa` is present in `SIGNAL_REGISTRY` with `statements:ROA` data requirement.
- Commit created: `feat(bt): add ROA fundamental signal to signal registry` and PR metadata prepared.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698af78c77688331baf1cfe7f798dca8)