### PR TITLE
fix(web): handle nullable strategy constraints and fundamental nesting

### DIFF
--- a/apps/ts/packages/web/src/components/Backtest/SignalReferencePanel.test.ts
+++ b/apps/ts/packages/web/src/components/Backtest/SignalReferencePanel.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatConstraints } from './signalConstraints';
+
+describe('formatConstraints', () => {
+  it('formats only numeric constraints', () => {
+    const result = formatConstraints({
+      gt: 0,
+      ge: 1,
+      lt: null as unknown as number,
+      le: undefined,
+    });
+
+    expect(result).toEqual(['>0', '>=1']);
+  });
+
+  it('returns empty array when constraints are absent', () => {
+    expect(formatConstraints(undefined)).toEqual([]);
+  });
+
+  it('formats upper-bound numeric constraints', () => {
+    const result = formatConstraints({
+      gt: null as unknown as number,
+      ge: undefined,
+      lt: 9,
+      le: 10,
+    });
+
+    expect(result).toEqual(['<9', '<=10']);
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/SignalReferencePanel.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/SignalReferencePanel.tsx
@@ -12,16 +12,7 @@ import { Input } from '@/components/ui/input';
 import { useSignalReference } from '@/hooks/useBacktest';
 import type { SignalCategory, SignalDefinition } from '@/types/backtest';
 import { logger } from '@/utils/logger';
-
-function formatConstraints(constraints: SignalDefinition['fields'][number]['constraints']): string[] {
-  if (!constraints) return [];
-  const parts: string[] = [];
-  if (constraints.gt !== undefined) parts.push(`>${constraints.gt}`);
-  if (constraints.ge !== undefined) parts.push(`>=${constraints.ge}`);
-  if (constraints.lt !== undefined) parts.push(`<${constraints.lt}`);
-  if (constraints.le !== undefined) parts.push(`<=${constraints.le}`);
-  return parts;
-}
+import { formatConstraints } from './signalConstraints';
 
 interface SignalItemProps {
   signal: SignalDefinition;

--- a/apps/ts/packages/web/src/components/Backtest/signalConstraints.ts
+++ b/apps/ts/packages/web/src/components/Backtest/signalConstraints.ts
@@ -1,0 +1,12 @@
+import type { SignalDefinition } from '@/types/backtest';
+
+export function formatConstraints(constraints: SignalDefinition['fields'][number]['constraints']): string[] {
+  if (!constraints) return [];
+
+  const parts: string[] = [];
+  if (typeof constraints.gt === 'number') parts.push(`>${constraints.gt}`);
+  if (typeof constraints.ge === 'number') parts.push(`>=${constraints.ge}`);
+  if (typeof constraints.lt === 'number') parts.push(`<${constraints.lt}`);
+  if (typeof constraints.le === 'number') parts.push(`<=${constraints.le}`);
+  return parts;
+}

--- a/apps/ts/packages/web/src/components/Backtest/strategyValidation.test.ts
+++ b/apps/ts/packages/web/src/components/Backtest/strategyValidation.test.ts
@@ -63,6 +63,221 @@ describe('validateStrategyConfigLocally', () => {
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
   });
+
+  it('ignores null numeric constraints from signal reference payload', () => {
+    const withNullConstraint: SignalDefinition[] = [
+      {
+        key: 'risk_adjusted_return',
+        name: 'Risk Adjusted Return',
+        category: 'fundamental',
+        description: '',
+        usage_hint: '',
+        yaml_snippet: '',
+        exit_disabled: false,
+        data_requirements: [],
+        fields: [
+          { name: 'enabled', type: 'boolean', description: '' },
+          {
+            name: 'threshold',
+            type: 'number',
+            description: '',
+            constraints: { ge: -5, le: 10, lt: null as unknown as number },
+          },
+        ],
+      },
+    ];
+
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          risk_adjusted_return: {
+            enabled: true,
+            threshold: 1.0,
+          },
+        },
+      },
+      withNullConstraint
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('does not reject nested fundamental group key', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          fundamental: {
+            per: { enabled: true, threshold: 15 },
+          },
+        },
+      },
+      signalDefs
+    );
+
+    expect(result.errors).not.toContain('entry_filter_params.fundamental is not a valid signal name');
+  });
+
+  it('skips signal-name validation when signal reference is unavailable', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          period_breakout: { enabled: true, period: 20 },
+        },
+      },
+      []
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toContain('Signal reference is unavailable, so parameter-name validation may be incomplete');
+  });
+
+  it('returns error when both entry and exit sections are missing', () => {
+    const result = validateStrategyConfigLocally({}, signalDefs);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params or exit_trigger_params is required');
+  });
+
+  it('returns error when signal section is not an object', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: 'invalid',
+      },
+      signalDefs
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params must be an object');
+  });
+
+  it('returns error for unknown signal name', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          unknown_signal: { enabled: true },
+        },
+      },
+      signalDefs
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params.unknown_signal is not a valid signal name');
+  });
+
+  it('returns error when signal config is not an object', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          volume: true,
+        },
+      },
+      signalDefs
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params.volume must be an object');
+  });
+
+  it('returns error when nested fundamental value is not an object', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          fundamental: true,
+        },
+      },
+      signalDefs
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params.fundamental must be an object');
+  });
+
+  it('validates primitive types and select option values', () => {
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          volume: {
+            enabled: 'true',
+            direction: 'invalid',
+            threshold: '1.0',
+          },
+        },
+      },
+      signalDefs
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params.volume.enabled must be a boolean');
+    expect(result.errors).toContain('entry_filter_params.volume.direction must be one of: surge, drop');
+    expect(result.errors).toContain('entry_filter_params.volume.threshold must be a number');
+  });
+
+  it('validates numeric constraints for gt/ge/lt/le', () => {
+    const constrainedDefs: SignalDefinition[] = [
+      {
+        key: 'constraint_signal',
+        name: 'Constraint Signal',
+        category: 'breakout',
+        description: '',
+        usage_hint: '',
+        yaml_snippet: '',
+        exit_disabled: false,
+        data_requirements: [],
+        fields: [
+          { name: 'enabled', type: 'boolean', description: '' },
+          { name: 'gt_only', type: 'number', description: '', constraints: { gt: 1 } },
+          { name: 'ge_only', type: 'number', description: '', constraints: { ge: 1 } },
+          { name: 'lt_only', type: 'number', description: '', constraints: { lt: 10 } },
+          { name: 'le_only', type: 'number', description: '', constraints: { le: 10 } },
+        ],
+      },
+    ];
+
+    const result = validateStrategyConfigLocally(
+      {
+        entry_filter_params: {
+          constraint_signal: {
+            enabled: true,
+            gt_only: 1,
+            ge_only: 0.5,
+            lt_only: 10,
+            le_only: 11,
+          },
+        },
+      },
+      constrainedDefs
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('entry_filter_params.constraint_signal.gt_only must be > 1');
+    expect(result.errors).toContain('entry_filter_params.constraint_signal.ge_only must be >= 1');
+    expect(result.errors).toContain('entry_filter_params.constraint_signal.lt_only must be < 10');
+    expect(result.errors).toContain('entry_filter_params.constraint_signal.le_only must be <= 10');
+  });
+
+  it('validates shared_config object shape and kelly type', () => {
+    const nonObject = validateStrategyConfigLocally(
+      {
+        entry_filter_params: { volume: { enabled: true, direction: 'drop', threshold: 1.1 } },
+        shared_config: 'invalid',
+      },
+      signalDefs
+    );
+    expect(nonObject.valid).toBe(false);
+    expect(nonObject.errors).toContain('shared_config must be an object');
+
+    const invalidFieldAndType = validateStrategyConfigLocally(
+      {
+        entry_filter_params: { volume: { enabled: true, direction: 'drop', threshold: 1.1 } },
+        shared_config: { unknown_key: true, kelly_fraction: 'x' },
+      },
+      signalDefs
+    );
+    expect(invalidFieldAndType.valid).toBe(false);
+    expect(invalidFieldAndType.errors).toContain('shared_config.unknown_key is not a valid parameter name');
+    expect(invalidFieldAndType.errors).toContain('shared_config.kelly_fraction must be a number');
+  });
 });
 
 describe('mergeValidationResults', () => {

--- a/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
+++ b/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
@@ -38,6 +38,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isNumericConstraint(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Validation logic needs explicit branch handling
 function validateFieldValue(
   sectionName: string,
@@ -59,17 +63,23 @@ function validateFieldValue(
       return;
     }
 
-    if (field.constraints?.gt !== undefined && value <= field.constraints.gt) {
-      errors.push(`${fieldPath} must be > ${field.constraints.gt}`);
+    const constraints = field.constraints;
+    const gt = constraints?.gt;
+    const ge = constraints?.ge;
+    const lt = constraints?.lt;
+    const le = constraints?.le;
+
+    if (isNumericConstraint(gt) && value <= gt) {
+      errors.push(`${fieldPath} must be > ${gt}`);
     }
-    if (field.constraints?.ge !== undefined && value < field.constraints.ge) {
-      errors.push(`${fieldPath} must be >= ${field.constraints.ge}`);
+    if (isNumericConstraint(ge) && value < ge) {
+      errors.push(`${fieldPath} must be >= ${ge}`);
     }
-    if (field.constraints?.lt !== undefined && value >= field.constraints.lt) {
-      errors.push(`${fieldPath} must be < ${field.constraints.lt}`);
+    if (isNumericConstraint(lt) && value >= lt) {
+      errors.push(`${fieldPath} must be < ${lt}`);
     }
-    if (field.constraints?.le !== undefined && value > field.constraints.le) {
-      errors.push(`${fieldPath} must be <= ${field.constraints.le}`);
+    if (isNumericConstraint(le) && value > le) {
+      errors.push(`${fieldPath} must be <= ${le}`);
     }
     return;
   }
@@ -95,9 +105,22 @@ function validateSignalSection(
     return;
   }
 
+  // Signal reference未取得時はunknown signal誤検知を避ける
+  if (signalDefinitions.length === 0) {
+    return;
+  }
+
   const signalMap = new Map(signalDefinitions.map((signal) => [signal.key, signal]));
 
   for (const [signalKey, signalConfig] of Object.entries(sectionValue)) {
+    // fundamentalは子シグナル構造（per/roe/...)を持つため、トップレベル名の検証は除外
+    if (signalKey === 'fundamental') {
+      if (!isPlainObject(signalConfig)) {
+        errors.push(`${sectionName}.${signalKey} must be an object`);
+      }
+      continue;
+    }
+
     const signalDef = signalMap.get(signalKey);
     if (!signalDef) {
       errors.push(`${sectionName}.${signalKey} is not a valid signal name`);
@@ -108,12 +131,6 @@ function validateSignalSection(
       errors.push(`${sectionName}.${signalKey} must be an object`);
       continue;
     }
-
-    // fundamentalのようなネスト構造は誤検知を避けるため、シグナル名の存在確認のみに留める
-    if (signalKey === 'fundamental') {
-      continue;
-    }
-
     const allowedFields = new Map(signalDef.fields.map((field) => [field.name, field]));
 
     for (const [paramName, paramValue] of Object.entries(signalConfig)) {

--- a/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
+++ b/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
@@ -94,6 +94,7 @@ function validateFieldValue(
   }
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Validation logic needs explicit branch handling
 function validateSignalSection(
   sectionName: 'entry_filter_params' | 'exit_trigger_params',
   sectionValue: unknown,


### PR DESCRIPTION
## Summary
- fix strategy local validation to ignore non-numeric/null constraint values
- allow nested fundamental block without invalid signal-name false positives
- extract signal constraint formatter into signalConstraints.ts and add focused tests
- extend backtest strategy validation tests for type, boundary, and shape error branches

## Verification
- bun test packages/web/src/components/Backtest/strategyValidation.test.ts packages/web/src/components/Backtest/SignalReferencePanel.test.ts
- bun run --filter @trading25/web typecheck
- bun run test:coverage -- src/components/Backtest/strategyValidation.test.ts src/components/Backtest/SignalReferencePanel.test.ts --coverage.include=src/components/Backtest/strategyValidation.ts --coverage.include=src/components/Backtest/signalConstraints.ts