### PR TITLE
fix(bt-server): remove market self-calls and harden sqlite concurrency

### DIFF
--- a/apps/bt/src/server/services/market_ohlcv_loader.py
+++ b/apps/bt/src/server/services/market_ohlcv_loader.py
@@ -1,0 +1,95 @@
+"""Market OHLCV Loader
+
+market.db から OHLCV/TOPIX を DataFrame として読み込む共通ローダ。
+Indicator/Signal で source=market を扱う際の重複実装を避ける。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from src.lib.market_db.market_reader import MarketDbReader
+from src.lib.market_db.query_helpers import stock_code_candidates
+
+
+def _rows_to_dataframe(rows: list[Any]) -> pd.DataFrame:
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame([dict(row) for row in rows])
+
+
+def load_stock_ohlcv_df(
+    reader: MarketDbReader,
+    stock_code: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> pd.DataFrame:
+    """market.db から銘柄 OHLCV を DataFrame で取得する。"""
+    candidates = stock_code_candidates(stock_code)
+    placeholders = ",".join("?" for _ in candidates)
+
+    row = reader.query_one(
+        f"SELECT code FROM stocks WHERE code IN ({placeholders}) "
+        "ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END LIMIT 1",
+        tuple(candidates),
+    )
+    if row is None:
+        return pd.DataFrame()
+
+    db_code = row["code"]
+    sql = "SELECT date, open, high, low, close, volume FROM stock_data WHERE code = ?"
+    params: list[str] = [db_code]
+
+    if start_date:
+        sql += " AND date >= ?"
+        params.append(start_date)
+    if end_date:
+        sql += " AND date <= ?"
+        params.append(end_date)
+
+    sql += " ORDER BY date"
+    rows = reader.query(sql, tuple(params))
+    if not rows:
+        return pd.DataFrame()
+
+    df = _rows_to_dataframe(rows)
+    df["date"] = pd.to_datetime(df["date"])
+    df.set_index("date", inplace=True)
+    df = df[["open", "high", "low", "close", "volume"]]
+    df.columns = pd.Index(["Open", "High", "Low", "Close", "Volume"])
+    return df
+
+
+def load_topix_df(
+    reader: MarketDbReader,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> pd.DataFrame:
+    """market.db から TOPIX OHLC を DataFrame で取得する。"""
+    sql = "SELECT date, open, high, low, close FROM topix_data"
+    params: list[str] = []
+    conditions: list[str] = []
+
+    if start_date:
+        conditions.append("date >= ?")
+        params.append(start_date)
+    if end_date:
+        conditions.append("date <= ?")
+        params.append(end_date)
+
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    sql += " ORDER BY date"
+
+    rows = reader.query(sql, tuple(params))
+    if not rows:
+        return pd.DataFrame()
+
+    df = _rows_to_dataframe(rows)
+    df["date"] = pd.to_datetime(df["date"])
+    df.set_index("date", inplace=True)
+    df = df[["open", "high", "low", "close"]]
+    df.columns = pd.Index(["Open", "High", "Low", "Close"])
+    return df

--- a/apps/bt/tests/unit/server/db/test_market_reader.py
+++ b/apps/bt/tests/unit/server/db/test_market_reader.py
@@ -55,3 +55,66 @@ class TestMarketDbReader:
         """read-only 接続で書き込み不可"""
         with pytest.raises(sqlite3.OperationalError):
             reader.query("INSERT INTO stocks (code, company_name, market_code, market_name, sector_17_code, sector_17_name, sector_33_code, sector_33_name, listed_date) VALUES ('99990', 'test', 'prime', 'p', 's17', 's17n', 's33', 's33n', '2024-01-01')")
+
+    def test_get_latest_price(self, reader):
+        """最新終値を取得できること（4桁/5桁候補解決を含む）"""
+        assert reader.get_latest_price("7203") == 2525.0
+        assert reader.get_latest_price("72030") == 2525.0
+
+    def test_get_latest_price_not_found(self, reader):
+        """該当銘柄がない場合はNone"""
+        assert reader.get_latest_price("0000") is None
+
+    def test_get_stock_prices_by_date(self, reader):
+        """日次終値を日付昇順で取得"""
+        rows = reader.get_stock_prices_by_date("72030")
+        assert rows == [
+            ("2024-01-15", 2505.0),
+            ("2024-01-16", 2515.0),
+            ("2024-01-17", 2525.0),
+        ]
+
+    def test_get_stock_prices_by_date_prefers_4digit(self, market_db_path):
+        """4桁/5桁が同居する場合は4桁を優先マージ"""
+        conn = sqlite3.connect(market_db_path)
+        conn.execute(
+            "INSERT INTO stocks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "7203",
+                "トヨタ自動車(4桁)",
+                "TOYOTA MOTOR 4D",
+                "prime",
+                "プライム",
+                "S17_1",
+                "輸送用機器",
+                "S33_1",
+                "輸送用機器",
+                "TOPIX Large70",
+                "1949-05-16",
+                None,
+                None,
+            ),
+        )
+        for i, d in enumerate(("2024-01-15", "2024-01-16", "2024-01-17")):
+            base = 2600.0 + i * 10
+            conn.execute(
+                "INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("7203", d, base, base + 20, base - 10, base + 5, 999999 + i, 1.0, None),
+            )
+        conn.commit()
+        conn.close()
+
+        reader = MarketDbReader(market_db_path)
+        try:
+            rows = reader.get_stock_prices_by_date("7203")
+            assert rows == [
+                ("2024-01-15", 2605.0),
+                ("2024-01-16", 2615.0),
+                ("2024-01-17", 2625.0),
+            ]
+        finally:
+            reader.close()
+
+    def test_get_stock_prices_by_date_not_found(self, reader):
+        """該当銘柄がない場合は空配列"""
+        assert reader.get_stock_prices_by_date("0000") == []

--- a/apps/bt/tests/unit/server/db/test_market_reader_concurrency.py
+++ b/apps/bt/tests/unit/server/db/test_market_reader_concurrency.py
@@ -1,0 +1,52 @@
+"""MarketDbReader concurrency tests."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from src.lib.market_db.market_reader import MarketDbReader
+
+
+def test_query_one_is_thread_safe(market_db_path: str) -> None:
+    """複数スレッドの同時 query_one で例外が発生しないことを確認。"""
+    reader = MarketDbReader(market_db_path)
+    try:
+        stock_codes = ["72030", "67580"] * 100
+
+        def fetch_company_name(code: str) -> str:
+            row = reader.query_one(
+                "SELECT company_name FROM stocks WHERE code = ?",
+                (code,),
+            )
+            assert row is not None
+            return str(row["company_name"])
+
+        with ThreadPoolExecutor(max_workers=16) as executor:
+            names = list(executor.map(fetch_company_name, stock_codes))
+
+        assert len(names) == len(stock_codes)
+        assert set(names) == {"トヨタ自動車", "ソニーグループ"}
+    finally:
+        reader.close()
+
+
+def test_query_and_query_one_mixed_concurrency(market_db_path: str) -> None:
+    """query/query_one の混在実行でも結果整合が崩れないことを確認。"""
+    reader = MarketDbReader(market_db_path)
+    try:
+        def worker(i: int) -> tuple[str, int]:
+            code = "72030" if i % 2 == 0 else "67580"
+            row = reader.query_one("SELECT code FROM stocks WHERE code = ?", (code,))
+            assert row is not None
+            rows = reader.query(
+                "SELECT date FROM stock_data WHERE code = ? ORDER BY date",
+                (code,),
+            )
+            return str(row["code"]), len(rows)
+
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            results = list(executor.map(worker, range(200)))
+
+        assert len(results) == 200
+        assert all(code in {"72030", "67580"} for code, _ in results)
+        assert all(count == 3 for _, count in results)
+    finally:
+        reader.close()

--- a/apps/bt/tests/unit/server/routes/test_indicators.py
+++ b/apps/bt/tests/unit/server/routes/test_indicators.py
@@ -15,7 +15,7 @@ client = TestClient(app)
 class TestComputeEndpoint:
     """POST /api/indicators/compute テスト"""
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_success(self, mock_compute: MagicMock):
         mock_compute.return_value = {
             "stock_code": "7203",
@@ -40,7 +40,7 @@ class TestComputeEndpoint:
         assert "sma_20" in data["indicators"]
         mock_compute.assert_called_once()
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_not_found(self, mock_compute: MagicMock):
         mock_compute.side_effect = ValueError("銘柄 9999 のOHLCVデータが取得できません")
 
@@ -88,7 +88,7 @@ class TestComputeEndpoint:
         assert response.status_code == 422
 
     @patch("src.server.routes.indicators.TIMEOUT_SECONDS", 0.001)
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_timeout(self, mock_compute: MagicMock):
         """タイムアウト時に504を返す"""
         import time
@@ -110,7 +110,7 @@ class TestComputeEndpoint:
         assert response.status_code == 504
         assert "タイムアウト" in response.json()["message"]
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_unexpected_error(self, mock_compute: MagicMock):
         """予期しないエラー時に500を返す"""
         mock_compute.side_effect = RuntimeError("unexpected error")
@@ -126,7 +126,7 @@ class TestComputeEndpoint:
         assert response.status_code == 500
         assert "計算エラー" in response.json()["message"]
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_value_error_422(self, mock_compute: MagicMock):
         """ValueError（取得できません以外）で422を返す"""
         mock_compute.side_effect = ValueError("パラメータが不正です")
@@ -141,7 +141,7 @@ class TestComputeEndpoint:
 
         assert response.status_code == 422
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_multiple_indicators(self, mock_compute: MagicMock):
         mock_compute.return_value = {
             "stock_code": "7203",
@@ -170,7 +170,7 @@ class TestComputeEndpoint:
         data = response.json()
         assert len(data["indicators"]) == 3
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_api_not_found_returns_404(self, mock_compute: MagicMock):
         """APINotFoundError が 404 で返ること"""
         mock_compute.side_effect = APINotFoundError("Resource not found: Stock not found")
@@ -185,7 +185,7 @@ class TestComputeEndpoint:
 
         assert response.status_code == 404
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_api_error_returns_status_code(self, mock_compute: MagicMock):
         """APIError が適切なステータスコードで返ること"""
         mock_compute.side_effect = APIError("Bad request", status_code=400)
@@ -200,7 +200,7 @@ class TestComputeEndpoint:
 
         assert response.status_code == 400
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_api_error_no_status_returns_500(self, mock_compute: MagicMock):
         """status_code=None の APIError が 500 で返ること"""
         mock_compute.side_effect = APIError("Connection failed")
@@ -219,7 +219,7 @@ class TestComputeEndpoint:
 class TestMarginEndpoint:
     """POST /api/indicators/margin テスト"""
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_margin_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_margin_indicators")
     def test_margin_success(self, mock_compute: MagicMock):
         mock_compute.return_value = {
             "stock_code": "7203",
@@ -243,7 +243,7 @@ class TestMarginEndpoint:
         assert data["stock_code"] == "7203"
         assert "margin_long_pressure" in data["indicators"]
 
-    @patch("src.server.services.indicator_service.indicator_service.compute_margin_indicators")
+    @patch("src.server.routes.indicators.IndicatorService.compute_margin_indicators")
     def test_margin_not_found(self, mock_compute: MagicMock):
         mock_compute.side_effect = ValueError("銘柄 9999 の信用データが取得できません")
 

--- a/apps/bt/tests/unit/server/services/test_market_ohlcv_loader.py
+++ b/apps/bt/tests/unit/server/services/test_market_ohlcv_loader.py
@@ -1,0 +1,106 @@
+"""market_ohlcv_loader tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.lib.market_db.market_reader import MarketDbReader
+from src.server.services.market_ohlcv_loader import (
+    _rows_to_dataframe,
+    load_stock_ohlcv_df,
+    load_topix_df,
+)
+
+
+def test_rows_to_dataframe_empty() -> None:
+    """空配列は空DataFrameになる。"""
+    df = _rows_to_dataframe([])
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_load_stock_ohlcv_df_success(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_stock_ohlcv_df(reader, "7203")
+        assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert len(df) == 3
+    finally:
+        reader.close()
+
+
+def test_load_stock_ohlcv_df_with_date_filters(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_stock_ohlcv_df(
+            reader,
+            "72030",
+            start_date="2024-01-16",
+            end_date="2024-01-16",
+        )
+        assert len(df) == 1
+        assert float(df.iloc[0]["Close"]) == 2515.0
+    finally:
+        reader.close()
+
+
+def test_load_stock_ohlcv_df_not_found(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_stock_ohlcv_df(reader, "0000")
+        assert df.empty
+    finally:
+        reader.close()
+
+
+def test_load_stock_ohlcv_df_out_of_range_returns_empty(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_stock_ohlcv_df(
+            reader,
+            "7203",
+            start_date="2030-01-01",
+            end_date="2030-12-31",
+        )
+        assert df.empty
+    finally:
+        reader.close()
+
+
+def test_load_topix_df_success(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_topix_df(reader)
+        assert list(df.columns) == ["Open", "High", "Low", "Close"]
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert len(df) == 3
+    finally:
+        reader.close()
+
+
+def test_load_topix_df_with_date_filters(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_topix_df(
+            reader,
+            start_date="2024-01-16",
+            end_date="2024-01-16",
+        )
+        assert len(df) == 1
+        assert float(df.iloc[0]["Close"]) == 2510.0
+    finally:
+        reader.close()
+
+
+def test_load_topix_df_out_of_range_returns_empty(market_db_path: str) -> None:
+    reader = MarketDbReader(market_db_path)
+    try:
+        df = load_topix_df(
+            reader,
+            start_date="2030-01-01",
+            end_date="2030-12-31",
+        )
+        assert df.empty
+    finally:
+        reader.close()


### PR DESCRIPTION
## Summary
- Fix chart initialization 500s caused by SQLite connection misuse under concurrent market OHLCV access
- Remove internal HTTP self-calls on source=market paths and read market.db directly
- Inject app.state.market_reader into indicator/signal/ohlcv services at route scope
- Add shared market OHLCV loader and extend regression tests (concurrency + loader + route/service paths)

## Implementation
- MarketDbReader: switched from single shared sqlite connection to per-thread connection management
- Added market_ohlcv_loader.py for stock/TOPIX DataFrame loading from market.db
- Updated IndicatorService and SignalService to prefer injected market_reader, fallback to API clients only when absent
- Updated routes for /api/ohlcv/resample, /api/indicators/*, /api/signals/compute to construct request-scoped services with injected reader

## Validation
- Ran targeted pytest suite for db/service/route changes (177 passed)
- Ran ruff check on changed source/test files
- Ran pyright on changed source files
- Verified line+branch coverage for changed target modules is >= 80% (aggregate 95%)