### PR TITLE
Fix pyright failure in market data volume coercion

### DIFF
--- a/apps/bt/src/server/services/market_data_service.py
+++ b/apps/bt/src/server/services/market_data_service.py
@@ -34,13 +34,23 @@ class MarketDataService:
         """Convert DB volume value to int with safe fallback for null/invalid values."""
         if value is None:
             return 0
-        try:
+
+        if isinstance(value, int):
+            return value
+
+        if isinstance(value, float):
             return int(value)
-        except (TypeError, ValueError):
+
+        if isinstance(value, str):
             try:
-                return int(float(str(value)))
-            except (TypeError, ValueError):
-                return 0
+                return int(value)
+            except ValueError:
+                try:
+                    return int(float(value))
+                except ValueError:
+                    return 0
+
+        return 0
 
     def get_stock_info(self, code: str) -> StockInfo | None:
         """単一銘柄の情報を取得"""


### PR DESCRIPTION
### Motivation
- Pyright reported a `reportArgumentType` error because `_coerce_volume` accepted `object` and called `int()` on it, causing CI typecheck to fail.
- The function needs to keep the original fallback behavior (invalid/null -> `0`) while satisfying strict type checking.

### Description
- Replace the previous generic `int()`/`float()` attempts with explicit type-narrowing branches for `int`, `float`, and `str` in `MarketDataService._coerce_volume`.
- Preserve the existing fallback semantics by returning `0` for `None` or any unconvertible/invalid values.
- Change is limited to `apps/bt/src/server/services/market_data_service.py` and only affects volume coercion logic.

### Testing
- Ran `CI=1 ./scripts/typecheck.sh` (pyright) and it completed with 0 errors and 1 warning.
- Ran `CI=1 ./scripts/lint.sh` (ruff/biome) and linting passed with no issues.
- Ran the service unit tests with `CI=1 ./scripts/bt-run.sh pytest tests/unit/server/services/test_market_data_service.py tests/unit/server/services/test_market_data_service_alias.py` and all 24 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c11d0aa188331b7274a101eb7ff38)