### PR TITLE
web: fix EPS card width in 8-column fundamentals panel

### DIFF
--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -63,7 +63,7 @@ function EpsMetricCard({ actualEps, forecastEps, changeRate }: EpsMetricCardProp
   };
 
   return (
-    <div className="col-span-2 flex min-h-16 flex-col justify-center rounded-md bg-background/50 px-2 py-1.5">
+    <div className="flex min-h-16 flex-col justify-center rounded-md bg-background/50 px-2 py-1.5">
       <span className="mb-0.5 text-center text-[10px] uppercase tracking-wide text-muted-foreground leading-tight">
         EPS
       </span>


### PR DESCRIPTION
### Motivation
- The fundamentals summary grid is 8 columns but the EPS card was occupying two columns (`col-span-2`), which made the layout inconsistent with other metrics; the intent is to make EPS occupy a single column like the rest.

### Description
- Changed the EPS metric container in `apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx` by removing the `col-span-2` class so the `EpsMetricCard` renders as a single grid cell and preserved its internal display logic for forecast and change rate.

### Testing
- Ran the focused unit test `bun run --filter @trading25/web test src/components/Chart/FundamentalsSummaryCard.test.tsx`, which passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c19b801648331879022411f769249)