### PR TITLE
Add split‑adjusted dividend-per-share to fundamentals and FY history

### DIFF
--- a/apps/bt/src/api/jquants_client.py
+++ b/apps/bt/src/api/jquants_client.py
@@ -64,6 +64,8 @@ class JQuantsStatement(BaseModel):
     # Forecast EPS
     FEPS: NullableFloat
     NxFEPS: NullableFloat
+    # Dividend
+    DivAnn: NullableFloat = None
     # Non-Consolidated Financial Performance
     NCSales: NullableFloat
     NCOP: NullableFloat

--- a/apps/bt/src/server/schemas/fundamentals.py
+++ b/apps/bt/src/server/schemas/fundamentals.py
@@ -61,6 +61,10 @@ class FundamentalDataPoint(BaseModel):
     adjustedBps: float | None = Field(
         None, description="Adjusted BPS using share count (JPY)"
     )
+    dividendFy: float | None = Field(None, description="Dividend per share for FY (JPY)")
+    adjustedDividendFy: float | None = Field(
+        None, description="Adjusted FY dividend per share using share count (JPY)"
+    )
     per: float | None = Field(None, description="Price to earnings ratio")
     pbr: float | None = Field(None, description="Price to book ratio")
 

--- a/apps/bt/src/server/schemas/jquants.py
+++ b/apps/bt/src/server/schemas/jquants.py
@@ -199,6 +199,8 @@ class RawStatementItem(BaseModel):
     # Forecast EPS
     FEPS: NullableFloat = None
     NxFEPS: NullableFloat = None
+    # Dividend
+    DivAnn: NullableFloat = None
     # Non-Consolidated Financial Performance
     NCSales: NullableFloat = None
     NCOP: NullableFloat = None

--- a/apps/bt/src/server/services/jquants_proxy_service.py
+++ b/apps/bt/src/server/services/jquants_proxy_service.py
@@ -295,6 +295,7 @@ class JQuantsProxyService:
                     AvgSh=stmt.get("AvgSh"),
                     FEPS=stmt.get("FEPS"),
                     NxFEPS=stmt.get("NxFEPS"),
+                    DivAnn=stmt.get("DivAnn"),
                     NCSales=stmt.get("NCSales"),
                     NCOP=stmt.get("NCOP"),
                     NCOdP=stmt.get("NCOdP"),

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -6646,7 +6646,7 @@
                   "additionalProperties": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/OHLCVRecord"
+                      "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                     }
                   },
                   "title": "Response Get Dataset Ohlcv Batch Api Dataset  Name  Stocks Ohlcv Batch Get"
@@ -6766,7 +6766,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/OHLCVRecord"
+                    "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                   },
                   "title": "Response Get Dataset Stock Ohlcv Api Dataset  Name  Stocks  Code  Ohlcv Get"
                 }
@@ -10275,6 +10275,28 @@
             ],
             "title": "Marketcodename"
           },
+          "sector17Code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sector17Code"
+          },
+          "sector17CodeName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sector17Codename"
+          },
           "sector33Code": {
             "anyOf": [
               {
@@ -10307,6 +10329,17 @@
               }
             ],
             "title": "Scalecategory"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
           }
         },
         "type": "object",
@@ -11455,19 +11488,19 @@
       },
       "DateRange": {
         "properties": {
-          "from": {
+          "min": {
             "type": "string",
-            "title": "From"
+            "title": "Min"
           },
-          "to": {
+          "max": {
             "type": "string",
-            "title": "To"
+            "title": "Max"
           }
         },
         "type": "object",
         "required": [
-          "from",
-          "to"
+          "min",
+          "max"
         ],
         "title": "DateRange"
       },
@@ -11832,6 +11865,30 @@
             ],
             "title": "Adjustedbps",
             "description": "Adjusted BPS using share count (JPY)"
+          },
+          "dividendFy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dividendfy",
+            "description": "Dividend per share for FY (JPY)"
+          },
+          "adjustedDividendFy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adjusteddividendfy",
+            "description": "Adjusted FY dividend per share using share count (JPY)"
           },
           "per": {
             "anyOf": [
@@ -13331,7 +13388,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -14780,27 +14837,33 @@
         "properties": {
           "date": {
             "type": "string",
-            "title": "Date"
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
           },
           "open": {
             "type": "number",
-            "title": "Open"
+            "title": "Open",
+            "description": "始値"
           },
           "high": {
             "type": "number",
-            "title": "High"
+            "title": "High",
+            "description": "高値"
           },
           "low": {
             "type": "number",
-            "title": "Low"
+            "title": "Low",
+            "description": "安値"
           },
           "close": {
             "type": "number",
-            "title": "Close"
+            "title": "Close",
+            "description": "終値"
           },
           "volume": {
-            "type": "integer",
-            "title": "Volume"
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
           }
         },
         "type": "object",
@@ -14812,7 +14875,8 @@
           "close",
           "volume"
         ],
-        "title": "OHLCVRecord"
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
       },
       "OHLCVResampleRequest": {
         "properties": {
@@ -14933,7 +14997,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__indicators__OHLCVRecord"
+              "$ref": "#/components/schemas/OHLCVRecord"
             },
             "type": "array",
             "title": "Data",
@@ -15524,7 +15588,7 @@
             "title": "Datapoints"
           },
           "dateRange": {
-            "$ref": "#/components/schemas/DateRange"
+            "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__DateRange"
           },
           "excludedStocks": {
             "items": {
@@ -16604,6 +16668,17 @@
               }
             ],
             "title": "Nxfeps"
+          },
+          "DivAnn": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Divann"
           },
           "NCSales": {
             "anyOf": [
@@ -18028,7 +18103,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -18056,7 +18131,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -19117,7 +19192,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -19511,23 +19586,43 @@
         ],
         "title": "DateRange"
       },
-      "src__server__schemas__db__DateRange": {
+      "src__server__schemas__dataset_data__OHLCVRecord": {
         "properties": {
-          "min": {
+          "date": {
             "type": "string",
-            "title": "Min"
+            "title": "Date"
           },
-          "max": {
-            "type": "string",
-            "title": "Max"
+          "open": {
+            "type": "number",
+            "title": "Open"
+          },
+          "high": {
+            "type": "number",
+            "title": "High"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close"
+          },
+          "volume": {
+            "type": "integer",
+            "title": "Volume"
           }
         },
         "type": "object",
         "required": [
-          "min",
-          "max"
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
         ],
-        "title": "DateRange"
+        "title": "OHLCVRecord"
       },
       "src__server__schemas__factor_regression__DateRange": {
         "properties": {
@@ -19582,50 +19677,23 @@
         "title": "IndexMatch",
         "description": "指数マッチ結果"
       },
-      "src__server__schemas__indicators__OHLCVRecord": {
+      "src__server__schemas__portfolio_factor_regression__DateRange": {
         "properties": {
-          "date": {
+          "from": {
             "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
+            "title": "From"
           },
-          "open": {
-            "type": "number",
-            "title": "Open",
-            "description": "始値"
-          },
-          "high": {
-            "type": "number",
-            "title": "High",
-            "description": "高値"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low",
-            "description": "安値"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close",
-            "description": "終値"
-          },
-          "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
+          "to": {
+            "type": "string",
+            "title": "To"
           }
         },
         "type": "object",
         "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
+          "from",
+          "to"
         ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
+        "title": "DateRange"
       },
       "src__server__schemas__portfolio_performance__DateRange": {
         "properties": {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -2217,12 +2217,18 @@ export interface components {
             marketCode?: string | null;
             /** Marketcodename */
             marketCodeName?: string | null;
+            /** Sector17Code */
+            sector17Code?: string | null;
+            /** Sector17Codename */
+            sector17CodeName?: string | null;
             /** Sector33Code */
             sector33Code?: string | null;
             /** Sector33Codename */
             sector33CodeName?: string | null;
             /** Scalecategory */
             scaleCategory?: string | null;
+            /** Date */
+            date?: string | null;
         };
         /**
          * ApiListedInfoResponse
@@ -2732,10 +2738,10 @@ export interface components {
         };
         /** DateRange */
         DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
         };
         /**
          * DefaultConfigResponse
@@ -2922,6 +2928,16 @@ export interface components {
              * @description Adjusted BPS using share count (JPY)
              */
             adjustedBps?: number | null;
+            /**
+             * Dividendfy
+             * @description Dividend per share for FY (JPY)
+             */
+            dividendFy?: number | null;
+            /**
+             * Adjusteddividendfy
+             * @description Adjusted FY dividend per share using share count (JPY)
+             */
+            adjustedDividendFy?: number | null;
             /**
              * Per
              * @description Price to earnings ratio
@@ -3712,7 +3728,7 @@ export interface components {
              * @default 0
              */
             dateCount: number;
-            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             /** Bycategory */
             byCategory?: {
                 [key: string]: number;
@@ -4433,19 +4449,40 @@ export interface components {
             /** Close */
             close: number;
         };
-        /** OHLCVRecord */
+        /**
+         * OHLCVRecord
+         * @description OHLCVレコード
+         */
         OHLCVRecord: {
-            /** Date */
+            /**
+             * Date
+             * @description 日付 (YYYY-MM-DD)
+             */
             date: string;
-            /** Open */
+            /**
+             * Open
+             * @description 始値
+             */
             open: number;
-            /** High */
+            /**
+             * High
+             * @description 高値
+             */
             high: number;
-            /** Low */
+            /**
+             * Low
+             * @description 安値
+             */
             low: number;
-            /** Close */
+            /**
+             * Close
+             * @description 終値
+             */
             close: number;
-            /** Volume */
+            /**
+             * Volume
+             * @description 出来高
+             */
             volume: number;
         };
         /**
@@ -4524,7 +4561,7 @@ export interface components {
              * Data
              * @description OHLCVデータ
              */
-            data: components["schemas"]["src__server__schemas__indicators__OHLCVRecord"][];
+            data: components["schemas"]["OHLCVRecord"][];
         };
         /**
          * OptimizationGridConfig
@@ -4856,7 +4893,7 @@ export interface components {
             analysisDate: string;
             /** Datapoints */
             dataPoints: number;
-            dateRange: components["schemas"]["DateRange"];
+            dateRange: components["schemas"]["src__server__schemas__portfolio_factor_regression__DateRange"];
             /** Excludedstocks */
             excludedStocks: components["schemas"]["ExcludedStock"][];
         };
@@ -5186,6 +5223,8 @@ export interface components {
             FEPS?: number | null;
             /** Nxfeps */
             NxFEPS?: number | null;
+            /** Divann */
+            DivAnn?: number | null;
             /** Ncsales */
             NCSales?: number | null;
             /** Ncop */
@@ -5719,7 +5758,7 @@ export interface components {
              * @default 0
              */
             dateCount: number;
-            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             /**
              * Averagestocksperday
              * @default 0
@@ -5730,7 +5769,7 @@ export interface components {
         StockDataValidation: {
             /** Count */
             count: number;
-            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             /** Missingdates */
             missingDates?: string[];
             /**
@@ -6293,7 +6332,7 @@ export interface components {
         TopixStats: {
             /** Count */
             count: number;
-            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
         };
         /** ValidationError */
         ValidationError: {
@@ -6424,12 +6463,20 @@ export interface components {
             /** Max */
             max: string;
         };
-        /** DateRange */
-        src__server__schemas__db__DateRange: {
-            /** Min */
-            min: string;
-            /** Max */
-            max: string;
+        /** OHLCVRecord */
+        src__server__schemas__dataset_data__OHLCVRecord: {
+            /** Date */
+            date: string;
+            /** Open */
+            open: number;
+            /** High */
+            high: number;
+            /** Low */
+            low: number;
+            /** Close */
+            close: number;
+            /** Volume */
+            volume: number;
         };
         /**
          * DateRange
@@ -6457,41 +6504,12 @@ export interface components {
             /** Beta */
             beta: number;
         };
-        /**
-         * OHLCVRecord
-         * @description OHLCVレコード
-         */
-        src__server__schemas__indicators__OHLCVRecord: {
-            /**
-             * Date
-             * @description 日付 (YYYY-MM-DD)
-             */
-            date: string;
-            /**
-             * Open
-             * @description 始値
-             */
-            open: number;
-            /**
-             * High
-             * @description 高値
-             */
-            high: number;
-            /**
-             * Low
-             * @description 安値
-             */
-            low: number;
-            /**
-             * Close
-             * @description 終値
-             */
-            close: number;
-            /**
-             * Volume
-             * @description 出来高
-             */
-            volume: number;
+        /** DateRange */
+        src__server__schemas__portfolio_factor_regression__DateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
         };
         /** DateRange */
         src__server__schemas__portfolio_performance__DateRange: {
@@ -11220,7 +11238,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: components["schemas"]["OHLCVRecord"][];
+                        [key: string]: components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                     };
                 };
             };
@@ -11283,7 +11301,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["OHLCVRecord"][];
+                    "application/json": components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                 };
             };
             /** @description Bad Request */

--- a/apps/ts/packages/shared/src/types/api-types.ts
+++ b/apps/ts/packages/shared/src/types/api-types.ts
@@ -178,6 +178,10 @@ export interface ApiFundamentalDataPoint {
   adjustedForecastEps?: number | null;
   /** Adjusted BPS using share count (円) */
   adjustedBps?: number | null;
+  /** FY dividend per share (円) */
+  dividendFy?: number | null;
+  /** Adjusted FY dividend per share using share count (円) */
+  adjustedDividendFy?: number | null;
   /** Price to Earnings Ratio (倍) - calculated with disclosure date price */
   per: number | null;
   /** Price to Book Ratio (倍) - calculated with disclosure date price */

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.test.tsx
@@ -248,7 +248,7 @@ describe('FundamentalsHistoryPanel', () => {
     const rows = screen.getAllByRole('row');
     const dataRow = rows[1];
     const cells = dataRow?.querySelectorAll('td');
-    // forecastEps is the 3rd column (index 2)
-    expect(cells?.[2]?.textContent).toBe('-');
+    // forecastEps is the 4th column (index 3) after adding disclosedDate
+    expect(cells?.[3]?.textContent).toBe('-');
   });
 });

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.tsx
@@ -105,9 +105,11 @@ export function FundamentalsHistoryPanel({ symbol, enabled = true }: Fundamental
           <thead>
             <tr className="border-b border-border/30 text-xs text-muted-foreground">
               <th className="text-left py-2 px-3 font-medium">FY期</th>
+              <th className="text-left py-2 px-3 font-medium">発表日</th>
               <th className="text-right py-2 px-3 font-medium">EPS</th>
               <th className="text-right py-2 px-3 font-medium">来期予想EPS</th>
               <th className="text-right py-2 px-3 font-medium">BPS</th>
+              <th className="text-right py-2 px-3 font-medium">1株配当</th>
               <th className="text-right py-2 px-3 font-medium">ROE</th>
               <th className="text-right py-2 px-3 font-medium">営業CF</th>
               <th className="text-right py-2 px-3 font-medium">投資CF</th>
@@ -118,6 +120,7 @@ export function FundamentalsHistoryPanel({ symbol, enabled = true }: Fundamental
             {fyHistory.map((fy) => (
               <tr key={fy.date} className="border-b border-border/20 hover:bg-background/40">
                 <td className="py-2.5 px-3 font-medium text-foreground">{formatFyLabel(fy.date)}</td>
+                <td className="py-2.5 px-3 text-xs text-muted-foreground">{fy.disclosedDate}</td>
                 <td className="py-2.5 px-3 text-right text-foreground">
                   {formatFundamentalValue(fy.adjustedEps ?? fy.eps, 'yen')}
                 </td>
@@ -126,6 +129,9 @@ export function FundamentalsHistoryPanel({ symbol, enabled = true }: Fundamental
                 </td>
                 <td className="py-2.5 px-3 text-right text-foreground">
                   {formatFundamentalValue(fy.adjustedBps ?? fy.bps, 'yen')}
+                </td>
+                <td className="py-2.5 px-3 text-right text-foreground">
+                  {formatFundamentalValue(fy.adjustedDividendFy ?? fy.dividendFy, 'yen')}
                 </td>
                 <td className="py-2.5 px-3 text-right text-foreground">{formatFundamentalValue(fy.roe, 'percent')}</td>
                 <td className={cn('py-2.5 px-3 text-right', getFundamentalColor(fy.cashFlowOperating, 'cashFlow'))}>

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.tsx
@@ -131,7 +131,7 @@ export function FundamentalsHistoryPanel({ symbol, enabled = true }: Fundamental
                   {formatFundamentalValue(fy.adjustedBps ?? fy.bps, 'yen')}
                 </td>
                 <td className="py-2.5 px-3 text-right text-foreground">
-                  {formatFundamentalValue(fy.adjustedDividendFy ?? fy.dividendFy, 'yen')}
+                  {formatFundamentalValue(fy.adjustedDividendFy ?? fy.dividendFy ?? null, 'yen')}
                 </td>
                 <td className="py-2.5 px-3 text-right text-foreground">{formatFundamentalValue(fy.roe, 'percent')}</td>
                 <td className={cn('py-2.5 px-3 text-right', getFundamentalColor(fy.cashFlowOperating, 'cashFlow'))}>

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -101,6 +101,7 @@ export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: Fu
   const displayEps = metrics.adjustedEps ?? metrics.eps;
   const displayForecastEps = metrics.adjustedForecastEps ?? metrics.forecastEps;
   const displayBps = metrics.adjustedBps ?? metrics.bps;
+  const displayDividendFy = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;
 
   return (
     <div className="h-full min-h-0 flex flex-col">
@@ -117,6 +118,7 @@ export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: Fu
             changeRate={metrics.forecastEpsChangeRate}
           />
           <MetricCard label="BPS" value={displayBps} format="yen" />
+          <MetricCard label="1株配当" value={displayDividendFy} format="yen" />
           <MetricCard label="営業利益率" value={metrics.operatingMargin} format="percent" />
           <MetricCard label="純利益率" value={metrics.netMargin} format="percent" />
 


### PR DESCRIPTION
### Motivation
- Add annual dividend-per-share to the fundamentals pipeline and surface it in the UI so users can see per-share dividend alongside EPS/BPS.
- Ensure dividend history is comparable across corporate actions by applying the same share-count (split) adjustment logic used for EPS/BPS.
- Surface disclosure dates for FY rows in the FY-5 history to make it clear which announcement each FY row corresponds to.

### Description
- Ingest `DivAnn` from J-Quants raw statements by adding `DivAnn` to `JQuantsStatement` and mapping it in the J-Quants proxy service. (`apps/bt/src/api/jquants_client.py`, `apps/bt/src/server/services/jquants_proxy_service.py`, `apps/bt/src/server/schemas/jquants.py`).
- Extend the fundamentals schema with `dividendFy` and `adjustedDividendFy` and populate them when building `FundamentalDataPoint`. (`apps/bt/src/server/schemas/fundamentals.py`, `apps/bt/src/server/services/fundamentals_service.py`).
- Apply the existing share-adjustment formula to dividends by adding a dividend shares parameter to `_build_adjusted_datapoint` and wiring it through `_apply_share_adjustments` so historical dividends are adjusted for splits/changes in share counts (same approach as EPS/BPS). (`apps/bt/src/server/services/fundamentals_service.py`).
- Update frontend UI to show `1株配当` in the fundamentals summary card and add a `発表日` (disclosed date) column plus `1株配当` to the FY-5 history table. (`apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx`, `apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.tsx`).
- Sync OpenAPI snapshot and regenerate shared TypeScript API types so `ApiFundamentalDataPoint` includes `dividendFy`/`adjustedDividendFy`. (`apps/ts/packages/shared/openapi/bt-openapi.json`, generated types and `apps/ts/packages/shared/src/types/api-types.ts`).
- Add unit tests covering extraction of `DivAnn` and split-aware adjustment of dividends in `FundamentalsService`. (`apps/bt/tests/server/services/test_fundamentals_service.py`).

### Testing
- Ran fundamentals unit tests: `uv run pytest tests/server/services/test_fundamentals_service.py` — all tests passed (101 passed).
- Ran linter checks: `uv run ruff check ...` — lint checks passed.
- Synced OpenAPI and regenerated TS types: `bun run --filter @trading25/shared bt:fetch-schema` and `bun run --filter @trading25/shared bt:generate-types` — both succeeded and snapshot/types updated.
- Type checking (`bun typecheck:all` / web package `tsc --noEmit`) failed in this environment due to a missing `bun-types` ambient type dependency; this is an environment-specific issue and not caused by the change.
- Attempt to start the web dev server failed due to local Node.js version mismatch required by Vite (environment constraint), so live UI smoke was not captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c206aea6483318d88b792149dbb22)