### PR TITLE
test(web): add Playwright smoke E2E and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,39 @@ jobs:
         run: ./scripts/test-apps.sh
         env:
           CI_DEPS_READY: "1"
+      - name: Install Playwright browser (Chromium)
+        run: bunx --bun playwright install --with-deps chromium
+        working-directory: apps/ts/packages/web
+      - name: Start bt server for web e2e
+        run: |
+          uv run bt server --port 3002 > /tmp/bt-server.log 2>&1 &
+          echo $! > /tmp/bt-server.pid
+          for i in {1..60}; do
+            if curl -fsS http://127.0.0.1:3002/api/health > /dev/null; then
+              echo "bt server is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "bt server failed to start"
+          cat /tmp/bt-server.log
+          exit 1
+        working-directory: apps/bt
+      - name: Run web e2e smoke tests
+        run: bun run --filter @trading25/web e2e:smoke
+        working-directory: apps/ts
+      - name: Stop bt server
+        if: always()
+        run: |
+          if [[ -f /tmp/bt-server.pid ]]; then
+            kill "$(cat /tmp/bt-server.pid)" || true
+          fi
+      - name: Upload Playwright reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            apps/ts/packages/web/playwright-report
+            apps/ts/packages/web/test-results
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ htmlcov/
 **/.mypy_cache/
 **/.ruff_cache/
 **/coverage/
+**/playwright-report/
+**/test-results/
 
 # === Jupyter ===
 .ipynb_checkpoints/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ bun dev:full                     # bt:sync + dev
 bun run test                     # テスト
 bun typecheck:all                # 型チェック
 bun lint && bun check:fix        # リント（Biome）
+bun run --filter @trading25/web e2e:smoke  # web E2E smoke（Playwright）
 bun run cli backtest attribution run <strategy> --wait
 ```
 
@@ -131,6 +132,7 @@ bun run cli backtest attribution run <strategy> --wait
 `.github/workflows/ci.yml` により全ブランチ push / PR で自動実行。
 - **skills**: audit（stale検知 / frontmatter検証 / legacy変更検知）
 - **ts**: lint → 型生成 → build → typecheck → test + coverage
+- **web e2e**: Playwright Chromium smoke（bt server :3002 を起動して実行）
 - **bt**: lint → typecheck → test + coverage（ゲート70%）
 
 ## ロードマップ

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ bun run --filter @trading25/shared bt:sync
 3. Typecheck
 4. Package unit tests
 5. App integration tests
+6. Web E2E smoke tests（Playwright Chromium + bt server）

--- a/apps/ts/README.md
+++ b/apps/ts/README.md
@@ -49,6 +49,7 @@ bun run test
 bun run test:packages
 bun run test:apps
 bun run test:coverage
+bun run --filter @trading25/web e2e:smoke
 
 # Build
 bun run build

--- a/apps/ts/TESTING.md
+++ b/apps/ts/TESTING.md
@@ -15,6 +15,23 @@ bun run test:ui
 bun run test:coverage
 ```
 
+## E2E Smoke (Web)
+
+Web package has Playwright smoke tests for browser-level critical paths.
+
+```bash
+cd packages/web
+
+# Install Chromium browser used by CI/local smoke
+bun run e2e:install
+
+# Run smoke scenarios only
+bun run e2e:smoke
+
+# Open Playwright UI
+bun run e2e:ui
+```
+
 ## Package-specific Testing
 
 ### Shared Package (`packages/shared/`)

--- a/apps/ts/bun.lock
+++ b/apps/ts/bun.lock
@@ -75,6 +75,7 @@
         "zustand": "^5.0.7",
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@tailwindcss/vite": "^4.1.16",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^14.3.1",
@@ -257,6 +258,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -890,6 +893,10 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
@@ -1157,6 +1164,8 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/apps/ts/packages/web/e2e/backtest-health.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/backtest-health.smoke.spec.ts
@@ -7,6 +7,6 @@ test.describe('backtest health smoke', () => {
     await page.getByRole('button', { name: 'Status' }).click();
     await expect(page.getByRole('heading', { name: 'Backtest Server' })).toBeVisible();
     await expect(page.getByText('Connected')).toBeVisible();
-    await expect(page.getByText('trading25-bt')).toBeVisible();
+    await expect(page.getByText('trading25-bt', { exact: true })).toBeVisible();
   });
 });

--- a/apps/ts/packages/web/e2e/backtest-health.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/backtest-health.smoke.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('backtest health smoke', () => {
+  test('@smoke shows connected backtest server via /api proxy', async ({ page }) => {
+    await page.goto('/?tab=backtest');
+
+    await page.getByRole('button', { name: 'Status' }).click();
+    await expect(page.getByRole('heading', { name: 'Backtest Server' })).toBeVisible();
+    await expect(page.getByText('Connected')).toBeVisible();
+    await expect(page.getByText('trading25-bt')).toBeVisible();
+  });
+});

--- a/apps/ts/packages/web/e2e/navigation.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/navigation.smoke.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('navigation smoke', () => {
+  test('@smoke syncs tab state with URL and browser history', async ({ page }) => {
+    await page.goto('/?tab=history');
+
+    await expect(page.getByRole('heading', { name: 'Trading History' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page).toHaveURL(/tab=settings/);
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+
+    await page.goBack();
+    await expect(page).toHaveURL(/tab=history/);
+    await expect(page.getByRole('heading', { name: 'Trading History' })).toBeVisible();
+  });
+});

--- a/apps/ts/packages/web/e2e/portfolio-crud.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/portfolio-crud.smoke.spec.ts
@@ -144,7 +144,7 @@ test.describe('portfolio CRUD smoke', () => {
     await page.getByRole('button', { name: 'Create' }).click();
 
     await expect(page.getByRole('button', { name: `Select ${portfolioName} portfolio` })).toBeVisible();
-    await expect(page.getByRole('heading', { name: portfolioName })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 2, name: portfolioName })).toBeVisible();
 
     await page.getByRole('button', { name: 'Delete' }).click();
     const deleteDialog = page.getByRole('dialog', { name: 'Delete Portfolio' });

--- a/apps/ts/packages/web/e2e/portfolio-crud.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/portfolio-crud.smoke.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Route } from '@playwright/test';
+
+type MockPortfolio = {
+  id: number;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  };
+}
+
+function notFound(route: Route) {
+  return route.fulfill(jsonResponse({ message: 'Not Found' }, 404));
+}
+
+function parsePortfolioId(pathname: string): number | null {
+  const match = pathname.match(/^\/api\/portfolio\/(\d+)$/);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function parsePortfolioPerformanceId(pathname: string): number | null {
+  const match = pathname.match(/^\/api\/portfolio\/(\d+)\/performance$/);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+test.describe('portfolio CRUD smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    const portfolios: MockPortfolio[] = [];
+    let nextId = 1;
+
+    await page.route('**/api/portfolio**', async (route) => {
+      const request = route.request();
+      const method = request.method();
+      const url = new URL(request.url());
+      const path = url.pathname;
+
+      if (method === 'GET' && path === '/api/portfolio') {
+        const summaries = portfolios.map((portfolio) => ({
+          id: portfolio.id,
+          name: portfolio.name,
+          description: portfolio.description,
+          stockCount: 0,
+          totalShares: 0,
+          createdAt: portfolio.createdAt,
+          updatedAt: portfolio.updatedAt,
+        }));
+        await route.fulfill(jsonResponse({ portfolios: summaries }));
+        return;
+      }
+
+      if (method === 'POST' && path === '/api/portfolio') {
+        const payload = JSON.parse(request.postData() ?? '{}') as {
+          name?: string;
+          description?: string;
+        };
+        const now = new Date().toISOString();
+        const created: MockPortfolio = {
+          id: nextId,
+          name: payload.name ?? `Portfolio ${nextId}`,
+          description: payload.description,
+          createdAt: now,
+          updatedAt: now,
+        };
+        nextId += 1;
+        portfolios.push(created);
+        await route.fulfill(jsonResponse(created, 201));
+        return;
+      }
+
+      const detailId = parsePortfolioId(path);
+      if (detailId !== null) {
+        const id = detailId;
+        const portfolio = portfolios.find((candidate) => candidate.id === id);
+        if (!portfolio) {
+          await notFound(route);
+          return;
+        }
+        if (method === 'GET') {
+          await route.fulfill(jsonResponse({ ...portfolio, items: [] }));
+          return;
+        }
+        if (method === 'DELETE') {
+          const index = portfolios.findIndex((candidate) => candidate.id === id);
+          if (index >= 0) {
+            portfolios.splice(index, 1);
+          }
+          await route.fulfill(jsonResponse({ success: true, message: 'Portfolio deleted successfully' }));
+          return;
+        }
+      }
+
+      const performanceId = parsePortfolioPerformanceId(path);
+      if (method === 'GET' && performanceId !== null) {
+        const id = performanceId;
+        const portfolio = portfolios.find((candidate) => candidate.id === id);
+        if (!portfolio) {
+          await notFound(route);
+          return;
+        }
+        await route.fulfill(
+          jsonResponse({
+            portfolioId: id,
+            portfolioName: portfolio.name,
+            portfolioDescription: portfolio.description,
+            summary: {
+              totalCost: 0,
+              currentValue: 0,
+              totalPnL: 0,
+              returnRate: 0,
+            },
+            holdings: [],
+            timeSeries: [],
+            benchmark: null,
+            benchmarkTimeSeries: null,
+            analysisDate: new Date().toISOString().slice(0, 10),
+            dateRange: null,
+            dataPoints: 0,
+            warnings: [],
+          })
+        );
+        return;
+      }
+
+      await route.continue();
+    });
+  });
+
+  test('@smoke creates and deletes a portfolio from the portfolio page', async ({ page }) => {
+    const portfolioName = `Smoke Portfolio ${Date.now()}`;
+
+    await page.goto('/?tab=portfolio');
+    await expect(page.getByRole('button', { name: 'New Portfolio' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'New Portfolio' }).click();
+    await page.getByLabel('Name').fill(portfolioName);
+    await page.getByLabel('Description (optional)').fill('Playwright smoke');
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    await expect(page.getByRole('button', { name: `Select ${portfolioName} portfolio` })).toBeVisible();
+    await expect(page.getByRole('heading', { name: portfolioName })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+    const deleteDialog = page.getByRole('dialog', { name: 'Delete Portfolio' });
+    await expect(deleteDialog).toBeVisible();
+    await deleteDialog.getByRole('button', { name: 'Delete Portfolio' }).click();
+
+    await expect(page.getByText('Select a portfolio to view details')).toBeVisible();
+    await expect(page.getByRole('button', { name: `Select ${portfolioName} portfolio` })).toHaveCount(0);
+  });
+});

--- a/apps/ts/packages/web/package.json
+++ b/apps/ts/packages/web/package.json
@@ -10,6 +10,10 @@
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "e2e": "playwright test",
+    "e2e:smoke": "playwright test --grep @smoke",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install chromium",
     "check": "biome check . --write",
     "typecheck": "tsc --noEmit"
   },
@@ -39,6 +43,7 @@
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/js-yaml": "^4.0.9",
+    "@playwright/test": "^1.52.0",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.1.0",

--- a/apps/ts/packages/web/playwright.config.ts
+++ b/apps/ts/packages/web/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const isCI = !!process.env.CI;
+const webCwd = fileURLToPath(new URL('.', import.meta.url));
+const webPort = Number(process.env.PLAYWRIGHT_WEB_PORT ?? '4173');
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${webPort}`;
+const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEBSERVER === '1';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  forbidOnly: isCI,
+  retries: isCI ? 1 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? [['github'], ['html', { open: 'never' }]] : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  ...(skipWebServer
+    ? {}
+    : {
+        webServer: {
+          command: `bunx --bun vite --configLoader native --port ${webPort}`,
+          url: baseURL,
+          reuseExistingServer: !isCI,
+          cwd: webCwd,
+          timeout: 120_000,
+        },
+      }),
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/issues/ts-127-web-e2e-rollout-hardening.md
+++ b/issues/ts-127-web-e2e-rollout-hardening.md
@@ -1,0 +1,35 @@
+---
+id: ts-127
+title: "Web E2E rollout hardening (post-smoke)"
+status: open
+priority: medium
+labels: [test, e2e]
+project: ts
+created: 2026-02-12
+updated: 2026-02-12
+depends_on: []
+blocks: []
+---
+
+# ts-127 Web E2E rollout hardening (post-smoke)
+
+## 目的
+- Playwright smoke 導入後の運用安定化を進め、required check 化と対象シナリオ拡張を安全に実施する。
+
+## 受け入れ条件
+- CI の web e2e smoke 実行結果を一定期間（目安: 1 週間）観測し、flake 原因を潰した上で required check に昇格する。
+- Nightly などで実行する拡張E2E（最低 2 シナリオ）を追加する。
+- E2E 運用手順（失敗時の切り分け・再実行・artifact確認）を `apps/ts/TESTING.md` か runbook に追記する。
+
+## 実施内容
+- [ ] CI 実行結果を観測し、失敗パターンを分類（app起動/プロキシ/API遅延/テスト実装由来）
+- [ ] `@smoke` 以外の拡張シナリオを追加
+  - [ ] Backtest attribution のポーリング遷移（pending/running/completed）
+  - [ ] Lab SSE の接続・再接続・終了状態
+- [ ] required check 化のPRを作成し、運用ルールを文書化
+
+## 結果
+- 未着手
+
+## 補足
+- 初期 smoke はこのworktreeで導入済み（navigation/backtest-health/portfolio-crud）。


### PR DESCRIPTION
## Summary
- add Playwright configuration and Chromium smoke tests for web critical paths
- integrate web smoke E2E into CI with bt server startup and report upload
- document E2E commands in README/TESTING and update AGENTS CI notes
- add follow-up local issue for post-smoke rollout hardening (ts-127)

## Test
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test
- bun run --filter @trading25/web test:coverage
- PLAYWRIGHT_SKIP_WEBSERVER=1 bun run --filter @trading25/web e2e --list