### PR TITLE
feat(sync): prefer source-generated bt OpenAPI with tested fallback

### DIFF
--- a/apps/bt/scripts/export_openapi.py
+++ b/apps/bt/scripts/export_openapi.py
@@ -1,0 +1,66 @@
+"""Export OpenAPI schema directly from bt FastAPI source code.
+
+This script generates the OpenAPI document without starting the HTTP server.
+
+Usage:
+    uv run python scripts/export_openapi.py
+    uv run python scripts/export_openapi.py --output /path/to/openapi.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Ensure `src` package can be imported when running this script directly.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+project_root_str = str(PROJECT_ROOT)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
+
+def build_openapi_schema() -> dict[str, Any]:
+    """Create FastAPI app and return its OpenAPI schema."""
+    from src.server.app import create_app
+
+    app = create_app()
+    return app.openapi()
+
+
+def write_schema(schema: dict[str, Any], output: Path | None) -> None:
+    """Write schema to file or stdout."""
+    rendered = f"{json.dumps(schema, ensure_ascii=False, indent=2)}\n"
+
+    if output is None:
+        sys.stdout.write(rendered)
+        return
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export Trading25 bt FastAPI OpenAPI schema",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file path. If omitted, prints JSON to stdout.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    schema = build_openapi_schema()
+    write_schema(schema, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/bt/tests/unit/scripts/test_export_openapi_unittest.py
+++ b/apps/bt/tests/unit/scripts/test_export_openapi_unittest.py
@@ -1,0 +1,69 @@
+"""Unit tests for scripts/export_openapi.py using stdlib unittest."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_module():
+    bt_root = Path(__file__).resolve().parents[3]
+    module_path = bt_root / "scripts" / "export_openapi.py"
+    spec = importlib.util.spec_from_file_location("export_openapi", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load export_openapi module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestExportOpenApi(unittest.TestCase):
+    def test_build_openapi_schema_uses_create_app(self) -> None:
+        module = _load_module()
+
+        fake_app_module = types.ModuleType("src.server.app")
+
+        class _FakeApp:
+            def openapi(self) -> dict[str, str]:
+                return {"openapi": "3.1.0"}
+
+        fake_app_module.create_app = lambda: _FakeApp()
+
+        with patch.dict(sys.modules, {"src.server.app": fake_app_module}):
+            schema = module.build_openapi_schema()
+
+        self.assertEqual(schema, {"openapi": "3.1.0"})
+
+    def test_write_schema_writes_stdout_when_output_is_none(self) -> None:
+        module = _load_module()
+        buffer = io.StringIO()
+
+        with patch.object(module.sys, "stdout", buffer):
+            module.write_schema({"openapi": "3.1.0"}, None)
+
+        self.assertEqual(buffer.getvalue(), '{\n  "openapi": "3.1.0"\n}\n')
+
+    def test_write_schema_writes_file_when_output_path_provided(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "openapi.json"
+            module.write_schema({"openapi": "3.1.0"}, output)
+            self.assertTrue(output.exists())
+            self.assertEqual(json.loads(output.read_text()), {"openapi": "3.1.0"})
+
+    def test_parse_args_parses_output_option(self) -> None:
+        module = _load_module()
+        with patch.object(sys, "argv", ["export_openapi.py", "--output", "/tmp/schema.json"]):
+            args = module.parse_args()
+        self.assertEqual(str(args.output), "/tmp/schema.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/ts/AGENTS.md
+++ b/apps/ts/AGENTS.md
@@ -87,8 +87,8 @@ bun cli backtest cancel <job-id>
 bun cli backtest list
 bun cli backtest results <job-id>
 
-# bt contract sync (requires trading25-bt backend for fetch)
-bun run --filter @trading25/shared bt:sync  # Fetch schema + generate types
+# bt contract sync (serverless local generation first; HTTP fetch is fallback)
+bun run --filter @trading25/shared bt:sync  # Generate schema + generate types
 ```
 
 `bun dev:api` は互換のため残っている archived notice であり、API サーバーの起動コマンドではない。

--- a/apps/ts/README.md
+++ b/apps/ts/README.md
@@ -28,7 +28,7 @@ bun install
 bun run dev
 ```
 
-`bun run dev:full` は起動前に `bt:sync` を実行し、FastAPI の OpenAPI から型を再生成します。
+`bun run dev:full` は起動前に `bt:sync` を実行し、まず `apps/bt` ソースから OpenAPI を直接生成して型を再生成します（失敗時は `http://localhost:3002/openapi.json` 取得にフォールバック）。
 
 ## Common Commands
 
@@ -61,6 +61,7 @@ bun run build
 - Web は `/api` を `http://localhost:3002` にプロキシ
 - CLI の既定 API URL は `http://localhost:3002`（`API_BASE_URL` で上書き可）
 - API ドキュメントは FastAPI 側 `http://localhost:3002/doc`
+- `bt:sync` はサーバー起動不要（`apps/bt` ソースから OpenAPI 生成）。生成不能時のみ FastAPI 取得にフォールバック
 - スキーマ変更時は以下を実行
 
 ```bash

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -20622,24 +20622,6 @@
         ],
         "title": "DateRange"
       },
-      "src__server__schemas__portfolio_factor_regression__DateRange": {
-        "properties": {
-          "from": {
-            "type": "string",
-            "title": "From"
-          },
-          "to": {
-            "type": "string",
-            "title": "To"
-          }
-        },
-        "type": "object",
-        "required": [
-          "from",
-          "to"
-        ],
-        "title": "DateRange"
-      },
       "src__server__schemas__portfolio_performance__DateRange": {
         "properties": {
           "from": {

--- a/apps/ts/packages/shared/scripts/fetch-bt-openapi.test.ts
+++ b/apps/ts/packages/shared/scripts/fetch-bt-openapi.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, test } from 'bun:test';
+import { rm } from 'node:fs/promises';
+
+import {
+  main,
+  normalizeOpenApiText,
+  resolveConfig,
+  summarizeStderr,
+  syncOpenApiSnapshot,
+  tryFetchFromServer,
+  tryGenerateFromBtSource,
+  type FetchBtOpenApiConfig,
+  type SyncDeps,
+} from './fetch-bt-openapi';
+
+function streamFrom(text: string): ReadableStream<Uint8Array> {
+  return new Response(text).body as ReadableStream<Uint8Array>;
+}
+
+function spawnResult(stdout: string, stderr: string, exitCode: number) {
+  return {
+    stdout: streamFrom(stdout),
+    stderr: streamFrom(stderr),
+    exited: Promise.resolve(exitCode),
+  };
+}
+
+function baseConfig(): FetchBtOpenApiConfig {
+  return {
+    btProjectPath: '/tmp/project',
+    btApiUrl: 'http://localhost:3002',
+    uvCacheDir: '/tmp/uv-cache',
+    outputPath: '/tmp/openapi.json',
+    openapiUrl: 'http://localhost:3002/openapi.json',
+    btVenvPython: '/tmp/project/.venv/bin/python',
+  };
+}
+
+function silentLogger() {
+  return {
+    log: (_message: string) => {},
+    warn: (_message: string) => {},
+    error: (_message: string) => {},
+  };
+}
+
+describe('fetch-bt-openapi helpers', () => {
+  test('resolveConfig uses defaults and optional output override', () => {
+    const config = resolveConfig({
+      BT_PROJECT_PATH: '/repo/apps/bt',
+      BT_API_URL: 'http://127.0.0.1:3002',
+      UV_CACHE_DIR: '/tmp/custom-uv',
+      BT_OPENAPI_OUTPUT_PATH: '/tmp/custom-openapi.json',
+    });
+
+    expect(config.btProjectPath).toBe('/repo/apps/bt');
+    expect(config.btApiUrl).toBe('http://127.0.0.1:3002');
+    expect(config.uvCacheDir).toBe('/tmp/custom-uv');
+    expect(config.outputPath).toBe('/tmp/custom-openapi.json');
+    expect(config.openapiUrl).toBe('http://127.0.0.1:3002/openapi.json');
+    expect(config.btVenvPython).toBe('/repo/apps/bt/.venv/bin/python');
+  });
+
+  test('normalizeOpenApiText canonicalizes JSON', () => {
+    const normalized = normalizeOpenApiText('{"b":2,"a":1}');
+    expect(normalized).toBe('{\n  "b": 2,\n  "a": 1\n}\n');
+  });
+
+  test('summarizeStderr returns last non-empty line or exit code', () => {
+    expect(summarizeStderr('\nfoo\nbar\n', 1)).toBe('bar');
+    expect(summarizeStderr('', 7)).toBe('exit code 7');
+  });
+});
+
+describe('tryGenerateFromBtSource', () => {
+  test('returns generated schema via .venv python when available', async () => {
+    const config = baseConfig();
+    const commands: string[][] = [];
+
+    const generated = await tryGenerateFromBtSource(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.btVenvPython,
+      spawn: (command) => {
+        commands.push(command);
+        return spawnResult('{"openapi":"3.1.0"}', '', 0);
+      },
+    });
+
+    expect(generated).toBe('{\n  "openapi": "3.1.0"\n}\n');
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toEqual([config.btVenvPython, 'scripts/export_openapi.py']);
+  });
+
+  test('falls back to uv run after .venv failure', async () => {
+    const config = baseConfig();
+    const commands: string[][] = [];
+    let callCount = 0;
+
+    const generated = await tryGenerateFromBtSource(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.btVenvPython,
+      spawn: (command) => {
+        commands.push(command);
+        callCount += 1;
+        if (callCount === 1) {
+          return spawnResult('', 'ModuleNotFoundError', 1);
+        }
+        return spawnResult('{"openapi":"3.1.0"}', '', 0);
+      },
+    });
+
+    expect(generated).toBe('{\n  "openapi": "3.1.0"\n}\n');
+    expect(commands).toHaveLength(2);
+    expect(commands[1]).toEqual(['uv', 'run', 'python', 'scripts/export_openapi.py']);
+  });
+
+  test('returns null when all generation methods fail', async () => {
+    const config = baseConfig();
+
+    const generated = await tryGenerateFromBtSource(config, {
+      logger: silentLogger(),
+      exists: async () => false,
+      spawn: () => spawnResult('', 'failed', 1),
+    });
+
+    expect(generated).toBeNull();
+  });
+
+  test('returns null when spawn throws', async () => {
+    const config = baseConfig();
+
+    const generated = await tryGenerateFromBtSource(config, {
+      logger: silentLogger(),
+      exists: async () => false,
+      spawn: () => {
+        throw new Error('spawn crashed');
+      },
+    });
+
+    expect(generated).toBeNull();
+  });
+});
+
+describe('tryFetchFromServer', () => {
+  test('returns normalized schema on successful fetch', async () => {
+    const config = baseConfig();
+    const fetched = await tryFetchFromServer(config, {
+      logger: silentLogger(),
+      fetch: async () => new Response('{"openapi":"3.1.0"}', { status: 200 }),
+    });
+
+    expect(fetched).toBe('{\n  "openapi": "3.1.0"\n}\n');
+  });
+
+  test('returns null when fetch fails', async () => {
+    const config = baseConfig();
+    const fetched = await tryFetchFromServer(config, {
+      logger: silentLogger(),
+      fetch: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    expect(fetched).toBeNull();
+  });
+
+  test('returns null when server responds with non-OK status', async () => {
+    const config = baseConfig();
+    const fetched = await tryFetchFromServer(config, {
+      logger: silentLogger(),
+      fetch: async () => new Response('oops', { status: 503, statusText: 'Service Unavailable' }),
+    });
+
+    expect(fetched).toBeNull();
+  });
+});
+
+describe('syncOpenApiSnapshot', () => {
+  test('returns 1 when refresh fails and snapshot is missing', async () => {
+    const config = baseConfig();
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async () => false,
+      spawn: () => spawnResult('', 'failed', 1),
+      fetch: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  test('returns 1 when existing snapshot is invalid JSON', async () => {
+    const config = baseConfig();
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.outputPath,
+      readText: async () => '{invalid json',
+      spawn: () => spawnResult('', 'failed', 1),
+      fetch: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  test('normalizes existing snapshot when refresh fails', async () => {
+    const config = baseConfig();
+    let written: string | null = null;
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.outputPath,
+      readText: async () => '{"openapi":"3.1.0"}',
+      writeText: async (_path, text) => {
+        written = text;
+      },
+      spawn: () => spawnResult('', 'failed', 1),
+      fetch: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(written).toBe('{\n  "openapi": "3.1.0"\n}\n');
+  });
+
+  test('keeps existing snapshot when already normalized and refresh fails', async () => {
+    const config = baseConfig();
+    let writeCalled = false;
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.outputPath,
+      readText: async () => '{\n  "openapi": "3.1.0"\n}\n',
+      writeText: async () => {
+        writeCalled = true;
+      },
+      spawn: () => spawnResult('', 'failed', 1),
+      fetch: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(writeCalled).toBe(false);
+  });
+
+  test('writes updated snapshot when fetched content changed', async () => {
+    const config = baseConfig();
+    let written: string | null = null;
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.outputPath,
+      readText: async () => '{"openapi":"3.0.0"}\n',
+      writeText: async (_path, text) => {
+        written = text;
+      },
+      spawn: () => spawnResult('{"openapi":"3.1.0"}', '', 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(written).toBe('{\n  "openapi": "3.1.0"\n}\n');
+  });
+
+  test('does not write when snapshot is already up to date', async () => {
+    const config = baseConfig();
+    let writeCalled = false;
+
+    const normalized = '{\n  "openapi": "3.1.0"\n}\n';
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async (path) => path === config.outputPath,
+      readText: async () => normalized,
+      writeText: async () => {
+        writeCalled = true;
+      },
+      spawn: () => spawnResult('{"openapi":"3.1.0"}', '', 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(writeCalled).toBe(false);
+  });
+
+  test('creates initial snapshot when none exists', async () => {
+    const config = baseConfig();
+    let written: string | null = null;
+
+    const exitCode = await syncOpenApiSnapshot(config, {
+      logger: silentLogger(),
+      exists: async () => false,
+      writeText: async (_path, text) => {
+        written = text;
+      },
+      spawn: () => spawnResult('{"openapi":"3.1.0"}', '', 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(written).toBe('{\n  "openapi": "3.1.0"\n}\n');
+  });
+
+  test('uses default deps safely with local temp output path', async () => {
+    const outputPath = `${process.cwd()}/packages/shared/.tmp-openapi.json`;
+    await Bun.write(outputPath, '{"openapi":"3.1.0"}');
+
+    const config: FetchBtOpenApiConfig = {
+      btProjectPath: '/path/that/does/not/exist',
+      btApiUrl: 'http://127.0.0.1:3002',
+      uvCacheDir: '/tmp/uv-cache',
+      outputPath,
+      openapiUrl: 'http://127.0.0.1:9/openapi.json',
+      btVenvPython: '/path/that/does/not/exist/.venv/bin/python',
+    };
+
+    const exitCode = await syncOpenApiSnapshot(config, { logger: silentLogger() });
+    expect(exitCode).toBe(0);
+
+    const text = await Bun.file(outputPath).text();
+    expect(text).toBe('{\n  "openapi": "3.1.0"\n}\n');
+    await rm(outputPath, { force: true });
+  });
+});
+
+describe('main', () => {
+  test('exits with sync result code', async () => {
+    const outputPath = `${process.cwd()}/packages/shared/.tmp-openapi-main.json`;
+    await Bun.write(outputPath, '{\n  "openapi": "3.1.0"\n}\n');
+
+    const previous = {
+      BT_PROJECT_PATH: process.env.BT_PROJECT_PATH,
+      BT_API_URL: process.env.BT_API_URL,
+      BT_OPENAPI_OUTPUT_PATH: process.env.BT_OPENAPI_OUTPUT_PATH,
+      UV_CACHE_DIR: process.env.UV_CACHE_DIR,
+    };
+    process.env.BT_PROJECT_PATH = '/path/that/does/not/exist';
+    process.env.BT_API_URL = 'http://127.0.0.1:9';
+    process.env.BT_OPENAPI_OUTPUT_PATH = outputPath;
+    process.env.UV_CACHE_DIR = '/tmp/uv-cache';
+
+    const originalExit = process.exit;
+    let capturedCode: number | undefined;
+    process.exit = ((code?: number) => {
+      capturedCode = code;
+      throw new Error('process.exit called');
+    }) as typeof process.exit;
+
+    try {
+      await main();
+      throw new Error('main should have called process.exit');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(capturedCode).toBe(0);
+    } finally {
+      process.exit = originalExit;
+      process.env.BT_PROJECT_PATH = previous.BT_PROJECT_PATH;
+      process.env.BT_API_URL = previous.BT_API_URL;
+      process.env.BT_OPENAPI_OUTPUT_PATH = previous.BT_OPENAPI_OUTPUT_PATH;
+      process.env.UV_CACHE_DIR = previous.UV_CACHE_DIR;
+      await rm(outputPath, { force: true });
+    }
+  });
+});

--- a/apps/ts/packages/shared/scripts/fetch-bt-openapi.ts
+++ b/apps/ts/packages/shared/scripts/fetch-bt-openapi.ts
@@ -1,55 +1,246 @@
 /**
- * Fetch OpenAPI schema from trading25-bt FastAPI server
- * and save as snapshot for offline type generation.
+ * Resolve bt OpenAPI schema and save as snapshot for offline type generation.
+ *
+ * Resolution order:
+ * 1) Generate directly from apps/bt source (prefer .venv python, then uv)
+ * 2) Fetch from running FastAPI server (/openapi.json) as fallback
+ * 3) If both fail and snapshot exists, keep existing snapshot
  *
  * Usage: bun scripts/fetch-bt-openapi.ts
  *
  * Environment:
- *   BT_API_URL - bt server URL (default: http://localhost:3002)
+ *   BT_PROJECT_PATH - bt project path (default: ../../../../bt from this script)
+ *   BT_API_URL - bt server URL for fallback fetch (default: http://localhost:3002)
+ *   BT_OPENAPI_OUTPUT_PATH - output snapshot path override
+ *   UV_CACHE_DIR - uv cache directory (default: /tmp/uv-cache)
  */
 
 import { resolve } from 'node:path';
 
-const BT_API_URL = process.env.BT_API_URL ?? 'http://localhost:3002';
-const OPENAPI_URL = `${BT_API_URL}/openapi.json`;
-const OUTPUT_PATH = resolve(import.meta.dir, '../openapi/bt-openapi.json');
+export interface FetchBtOpenApiConfig {
+  btProjectPath: string;
+  btApiUrl: string;
+  uvCacheDir: string;
+  outputPath: string;
+  openapiUrl: string;
+  btVenvPython: string;
+}
 
-const outputFile = Bun.file(OUTPUT_PATH);
+interface SpawnOptions {
+  cwd: string;
+  stdout: 'pipe';
+  stderr: 'pipe';
+  env?: Record<string, string | undefined>;
+}
 
-async function main(): Promise<void> {
-  console.log(`Fetching OpenAPI schema from ${OPENAPI_URL} ...`);
+interface SpawnResult {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+}
 
-  let fetched: string;
+type SpawnFn = (command: string[], options: SpawnOptions) => SpawnResult;
+type ExistsFn = (path: string) => Promise<boolean>;
+type ReadTextFn = (path: string) => Promise<string>;
+type WriteTextFn = (path: string, text: string) => Promise<void>;
+type FetchFn = typeof fetch;
+
+interface LoggerLike {
+  log(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+export interface SyncDeps {
+  spawn: SpawnFn;
+  exists: ExistsFn;
+  readText: ReadTextFn;
+  writeText: WriteTextFn;
+  fetch: FetchFn;
+  logger: LoggerLike;
+}
+
+export function resolveConfig(env: NodeJS.ProcessEnv = process.env): FetchBtOpenApiConfig {
+  const btProjectPath = env.BT_PROJECT_PATH ?? resolve(import.meta.dir, '../../../../bt');
+  const btApiUrl = env.BT_API_URL ?? 'http://localhost:3002';
+  const uvCacheDir = env.UV_CACHE_DIR ?? '/tmp/uv-cache';
+  const outputPath = env.BT_OPENAPI_OUTPUT_PATH ?? resolve(import.meta.dir, '../openapi/bt-openapi.json');
+  return {
+    btProjectPath,
+    btApiUrl,
+    uvCacheDir,
+    outputPath,
+    openapiUrl: `${btApiUrl}/openapi.json`,
+    btVenvPython: resolve(btProjectPath, '.venv/bin/python'),
+  };
+}
+
+export function toMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function normalizeOpenApiText(text: string): string {
+  const parsed = JSON.parse(text);
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+export function summarizeStderr(stderr: string, exitCode: number): string {
+  const lines = stderr
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return `exit code ${exitCode}`;
+  }
+  return lines[lines.length - 1];
+}
+
+function defaultDeps(): SyncDeps {
+  return {
+    spawn: (command: string[], options: SpawnOptions): SpawnResult => Bun.spawn(command, options),
+    exists: async (path: string) => Bun.file(path).exists(),
+    readText: async (path: string) => Bun.file(path).text(),
+    writeText: async (path: string, text: string) => {
+      await Bun.write(path, text);
+    },
+    fetch,
+    logger: console,
+  };
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  return new Response(stream).text();
+}
+
+export async function tryGenerateFromBtSource(
+  config: FetchBtOpenApiConfig,
+  depsOverrides: Partial<SyncDeps> = {},
+): Promise<string | null> {
+  const deps = { ...defaultDeps(), ...depsOverrides };
+  deps.logger.log(`Generating OpenAPI schema from bt source (${config.btProjectPath}) ...`);
+
+  const attempts: Array<{ command: string[]; label: string; env?: Record<string, string | undefined> }> = [];
+  if (await deps.exists(config.btVenvPython)) {
+    attempts.push({
+      command: [config.btVenvPython, 'scripts/export_openapi.py'],
+      label: '.venv python',
+    });
+  }
+  attempts.push({
+    command: ['uv', 'run', 'python', 'scripts/export_openapi.py'],
+    label: 'uv run',
+    env: { ...process.env, UV_CACHE_DIR: config.uvCacheDir },
+  });
+
+  for (const attempt of attempts) {
+    try {
+      const proc = deps.spawn(
+        attempt.command,
+        {
+          cwd: config.btProjectPath,
+          stdout: 'pipe',
+          stderr: 'pipe',
+          env: attempt.env,
+        },
+      );
+      const [stdout, stderr, exitCode] = await Promise.all([
+        readStream(proc.stdout),
+        readStream(proc.stderr),
+        proc.exited,
+      ]);
+
+      if (exitCode !== 0) {
+        const reason = summarizeStderr(stderr, exitCode);
+        deps.logger.warn(`⚠ Local generation via ${attempt.label} failed (${reason}).`);
+        continue;
+      }
+
+      const generated = normalizeOpenApiText(stdout);
+      deps.logger.log(`✓ Generated OpenAPI schema from bt source via ${attempt.label}.`);
+      return generated;
+    } catch (err) {
+      deps.logger.warn(`⚠ Local generation via ${attempt.label} failed (${toMessage(err)}).`);
+      continue;
+    }
+  }
+
+  deps.logger.warn('⚠ Local generation failed for all methods. Falling back to HTTP fetch.');
+  return null;
+}
+
+export async function tryFetchFromServer(
+  config: FetchBtOpenApiConfig,
+  depsOverrides: Partial<SyncDeps> = {},
+): Promise<string | null> {
+  const deps = { ...defaultDeps(), ...depsOverrides };
+  deps.logger.log(`Fetching OpenAPI schema from ${config.openapiUrl} ...`);
   try {
-    const res = await fetch(OPENAPI_URL, { signal: AbortSignal.timeout(5000) });
+    const res = await deps.fetch(config.openapiUrl, { signal: AbortSignal.timeout(5000) });
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`);
     }
-    const json = await res.json();
-    fetched = `${JSON.stringify(json, null, 2)}\n`;
+
+    const body = await res.text();
+    const fetched = normalizeOpenApiText(body);
+    deps.logger.log('✓ Fetched OpenAPI schema from running server.');
+    return fetched;
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (await outputFile.exists()) {
-      console.warn(`⚠ bt server unreachable (${msg}). Using existing snapshot.`);
-      process.exit(0);
-    }
-    console.error(`✗ bt server unreachable (${msg}) and no existing snapshot found.`);
-    process.exit(1);
+    deps.logger.warn(`⚠ HTTP fetch failed (${toMessage(err)}).`);
+    return null;
   }
-
-  if (await outputFile.exists()) {
-    const existing = await outputFile.text();
-    if (existing === fetched) {
-      console.log('✓ Snapshot is up to date (no changes).');
-      return;
-    }
-    console.log('⚠ Snapshot has changed — updating.');
-  } else {
-    console.log('Creating initial snapshot.');
-  }
-
-  await Bun.write(OUTPUT_PATH, fetched);
-  console.log(`✓ Saved to ${OUTPUT_PATH}`);
 }
 
-main();
+export async function syncOpenApiSnapshot(
+  config: FetchBtOpenApiConfig = resolveConfig(),
+  depsOverrides: Partial<SyncDeps> = {},
+): Promise<number> {
+  const deps = { ...defaultDeps(), ...depsOverrides };
+  const generated = await tryGenerateFromBtSource(config, deps);
+  const fetched = generated ?? (await tryFetchFromServer(config, deps));
+
+  if (fetched === null) {
+    if (await deps.exists(config.outputPath)) {
+      const existing = await deps.readText(config.outputPath);
+      try {
+        const normalizedExisting = normalizeOpenApiText(existing);
+        if (normalizedExisting !== existing) {
+          await deps.writeText(config.outputPath, normalizedExisting);
+          deps.logger.warn('⚠ Could not refresh schema. Normalized existing snapshot and continued.');
+        } else {
+          deps.logger.warn('⚠ Could not refresh schema. Using existing snapshot.');
+        }
+        return 0;
+      } catch {
+        deps.logger.error('✗ Could not refresh schema. Existing snapshot is not valid JSON.');
+        return 1;
+      }
+    }
+
+    deps.logger.error('✗ Could not generate/fetch bt OpenAPI schema and no snapshot exists.');
+    return 1;
+  }
+
+  if (await deps.exists(config.outputPath)) {
+    const existing = await deps.readText(config.outputPath);
+    if (existing === fetched) {
+      deps.logger.log('✓ Snapshot is up to date (no changes).');
+      return 0;
+    }
+    deps.logger.log('⚠ Snapshot has changed — updating.');
+  } else {
+    deps.logger.log('Creating initial snapshot.');
+  }
+
+  await deps.writeText(config.outputPath, fetched);
+  deps.logger.log(`✓ Saved to ${config.outputPath}`);
+  return 0;
+}
+
+export async function main(): Promise<void> {
+  const exitCode = await syncOpenApiSnapshot(resolveConfig());
+  process.exit(exitCode);
+}
+
+if (import.meta.main) {
+  void main();
+}

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -5076,7 +5076,7 @@ export interface components {
             benchmarkTimeSeries?: components["schemas"]["BenchmarkTimeSeriesPoint"][] | null;
             /** Analysisdate */
             analysisDate: string;
-            dateRange?: components["schemas"]["PortfolioDateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__portfolio_performance__DateRange"] | null;
             /** Datapoints */
             dataPoints: number;
             /** Warnings */
@@ -6933,7 +6933,7 @@ export interface components {
             to: string;
         };
         /** DateRange */
-        PortfolioDateRange: {
+        src__server__schemas__portfolio_performance__DateRange: {
             /** From */
             from: string;
             /** To */

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -63,7 +63,7 @@ bun run --filter @trading25/shared bt:sync
 ## OpenAPI Snapshot
 
 - `apps/ts/packages/shared/openapi/bt-openapi.json`  
-  `bt:sync` で更新される FastAPI スナップショット。
+  `bt:sync` で更新される FastAPI 契約スナップショット（`apps/bt` ソースからの直接生成を優先し、失敗時のみ `/openapi.json` 取得にフォールバック）。
 
 ## Dataset Note
 

--- a/scripts/dep-direction-allowlist.txt
+++ b/scripts/dep-direction-allowlist.txt
@@ -14,6 +14,8 @@
 # [permanent] bt:sync tooling — required for OpenAPI schema → TS type generation
 # ─────────────────────────────────────────────────────────
 apps/ts/packages/shared/scripts/fetch-bt-openapi.ts
+# PR #28: bt:sync source-first fallback behavior tests
+apps/ts/packages/shared/scripts/fetch-bt-openapi.test.ts
 apps/ts/packages/shared/scripts/check-bt-types.ts
 apps/ts/packages/shared/src/clients/backtest/generated/type-compatibility-check.ts
 


### PR DESCRIPTION
Summary
- add apps/bt/scripts/export_openapi.py to generate FastAPI OpenAPI from source without starting the server
- redesign shared fetch-bt-openapi.ts to prefer local source generation (.venv python then uv run) and fallback to HTTP fetch
- harden sync behavior for stale and invalid snapshots and return non-zero when no valid schema is available
- add focused tests for TS sync script and Python exporter
- update docs in apps/ts/README.md, apps/ts/AGENTS.md, contracts/README.md

Validation
- bun test ./packages/shared/scripts/fetch-bt-openapi.test.ts
- bun test --coverage ./packages/shared/scripts/fetch-bt-openapi.test.ts
- bun run --filter @trading25/shared bt:sync
- bun run --filter @trading25/shared bt:check
- python3 -m unittest apps/bt/tests/unit/scripts/test_export_openapi_unittest.py
- python3 -m trace --count --summary -C /tmp/trace-aicheck --ignore-dir=/usr,/Library --module unittest apps/bt/tests/unit/scripts/test_export_openapi_unittest.py