### PR TITLE
feat(bt): route backtest data loading through direct db access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **market.db**: 読み書き（SQLAlchemy Core）
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
+- Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う
 - **ts/web** は `/api` パスを FastAPI (:3002) にプロキシ
 - **Hono サーバー** (:3001) は廃止済み（`apps/ts/packages/api` は archived・read-only）

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - バックエンドは `apps/bt` の FastAPI に一本化済み
 - financial-analysis のロジック SoT は `apps/bt`（ts 側は API consumer / proxy）
 - `apps/ts/packages/api` は互換 API レイヤーとして bt API をプロキシ
+- Backtest 実行パスは `apps/bt` 内で dataset/market DB を直接参照し、内部HTTP self-call を回避
 
 ## Repository Layout
 

--- a/apps/bt/src/data/access/__init__.py
+++ b/apps/bt/src/data/access/__init__.py
@@ -1,0 +1,20 @@
+"""Data access helpers for loader/backtest paths."""
+
+from src.data.access.clients import get_dataset_client, get_market_client
+from src.data.access.mode import (
+    DATA_ACCESS_MODE_ENV,
+    data_access_mode_context,
+    get_data_access_mode,
+    normalize_data_access_mode,
+    should_use_direct_db,
+)
+
+__all__ = [
+    "DATA_ACCESS_MODE_ENV",
+    "get_dataset_client",
+    "get_market_client",
+    "get_data_access_mode",
+    "normalize_data_access_mode",
+    "should_use_direct_db",
+    "data_access_mode_context",
+]

--- a/apps/bt/src/data/access/clients.py
+++ b/apps/bt/src/data/access/clients.py
@@ -1,0 +1,442 @@
+"""Mode-aware data clients for loader paths.
+
+HTTP mode uses existing API clients.
+Direct mode bypasses internal HTTP and reads SQLite via DatasetDb/MarketDbReader.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Literal
+
+import pandas as pd
+
+from src.api.dataset_client import DatasetAPIClient
+from src.api.market_client import MarketAPIClient
+from src.config.settings import get_settings
+from src.lib.market_db.dataset_db import DatasetDb
+from src.lib.market_db.market_reader import MarketDbReader
+
+from .mode import should_use_direct_db
+
+_dataset_db_cache: dict[str, DatasetDb] = {}
+_dataset_db_lock = threading.Lock()
+
+_market_reader: MarketDbReader | None = None
+_market_reader_lock = threading.Lock()
+
+
+def _resolve_dataset_db(dataset_name: str) -> DatasetDb:
+    settings = get_settings()
+    stem = Path(dataset_name).stem
+    db_path = Path(settings.dataset_base_path) / f"{stem}.db"
+    cache_key = str(db_path.resolve())
+
+    with _dataset_db_lock:
+        db = _dataset_db_cache.get(cache_key)
+        if db is None:
+            if not db_path.exists():
+                raise FileNotFoundError(f"Dataset not found: {db_path}")
+            db = DatasetDb(str(db_path))
+            _dataset_db_cache[cache_key] = db
+        return db
+
+
+def _resolve_market_reader() -> MarketDbReader:
+    global _market_reader
+    settings = get_settings()
+    market_db_path = Path(settings.market_db_path)
+    if not market_db_path.exists():
+        raise FileNotFoundError(f"market.db not found: {market_db_path}")
+
+    with _market_reader_lock:
+        if _market_reader is None:
+            _market_reader = MarketDbReader(str(market_db_path))
+        return _market_reader
+
+
+def _to_ohlcv_df(rows: list[Any]) -> pd.DataFrame:
+    if not rows:
+        return pd.DataFrame()
+    index = pd.to_datetime([row.date for row in rows])
+    df = pd.DataFrame(
+        [
+            {
+                "Open": row.open,
+                "High": row.high,
+                "Low": row.low,
+                "Close": row.close,
+                "Volume": row.volume,
+            }
+            for row in rows
+        ]
+    )
+    df.index = index
+    df.index.name = "date"
+    return df
+
+
+def _to_ohlc_df(rows: list[Any]) -> pd.DataFrame:
+    if not rows:
+        return pd.DataFrame()
+    index = pd.to_datetime([row.date for row in rows])
+    df = pd.DataFrame(
+        [
+            {
+                "Open": row.open,
+                "High": row.high,
+                "Low": row.low,
+                "Close": row.close,
+            }
+            for row in rows
+        ]
+    )
+    df.index = index
+    df.index.name = "date"
+    return df
+
+
+def _to_margin_df(rows: list[Any]) -> pd.DataFrame:
+    if not rows:
+        return pd.DataFrame()
+    index = pd.to_datetime([row.date for row in rows])
+    df = pd.DataFrame(
+        [
+            {
+                "longMarginVolume": row.long_margin_volume,
+                "shortMarginVolume": row.short_margin_volume,
+            }
+            for row in rows
+        ]
+    )
+    df.index = index
+    df.index.name = "date"
+    return df
+
+
+def _to_statements_df(rows: list[Any]) -> pd.DataFrame:
+    if not rows:
+        return pd.DataFrame()
+    index = pd.to_datetime([row.disclosed_date for row in rows])
+    df = pd.DataFrame(
+        [
+            {
+                "code": row.code,
+                "earningsPerShare": row.earnings_per_share,
+                "profit": row.profit,
+                "equity": row.equity,
+                "typeOfCurrentPeriod": row.type_of_current_period,
+                "typeOfDocument": row.type_of_document,
+                "nextYearForecastEarningsPerShare": row.next_year_forecast_earnings_per_share,
+                "bps": row.bps,
+                "sales": row.sales,
+                "operatingProfit": row.operating_profit,
+                "ordinaryProfit": row.ordinary_profit,
+                "operatingCashFlow": row.operating_cash_flow,
+                "dividendFY": row.dividend_fy,
+                "forecastEps": row.forecast_eps,
+                "investingCashFlow": row.investing_cash_flow,
+                "financingCashFlow": row.financing_cash_flow,
+                "cashAndEquivalents": row.cash_and_equivalents,
+                "totalAssets": row.total_assets,
+                "sharesOutstanding": row.shares_outstanding,
+                "treasuryShares": row.treasury_shares,
+            }
+            for row in rows
+        ]
+    )
+    df.index = index
+    df.index.name = "disclosedDate"
+    return df
+
+
+class DirectDatasetClient:
+    """Dataset client backed by DatasetDb (no HTTP)."""
+
+    def __init__(self, dataset_name: str) -> None:
+        self.dataset_name = Path(dataset_name).stem
+        self._db = _resolve_dataset_db(self.dataset_name)
+
+    def __enter__(self) -> DirectDatasetClient:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any,
+    ) -> None:
+        # Cached DB stays open for reuse.
+        return None
+
+    def get_stock_ohlcv(
+        self,
+        stock_code: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        timeframe: Literal["daily", "weekly", "monthly"] = "daily",
+    ) -> pd.DataFrame:
+        _ = timeframe  # Current HTTP route ignores timeframe for dataset endpoint.
+        return _to_ohlcv_df(
+            self._db.get_stock_ohlcv(stock_code, start=start_date, end=end_date)
+        )
+
+    def get_stocks_ohlcv_batch(
+        self,
+        stock_codes: list[str],
+        start_date: str | None = None,
+        end_date: str | None = None,
+        timeframe: Literal["daily", "weekly", "monthly"] = "daily",
+    ) -> dict[str, pd.DataFrame]:
+        _ = (start_date, end_date, timeframe)
+        batch = self._db.get_ohlcv_batch(stock_codes)
+        return {code: _to_ohlcv_df(rows) for code, rows in batch.items() if rows}
+
+    def get_stock_list(
+        self,
+        min_records: int = 100,
+        limit: int | None = None,
+        detail: bool = False,
+    ) -> pd.DataFrame:
+        _ = detail
+        rows = self._db.get_stock_list_with_counts(min_records=min_records)
+        df = pd.DataFrame(
+            [
+                {
+                    "stockCode": row.stockCode,
+                    "record_count": row.record_count,
+                    "start_date": row.start_date,
+                    "end_date": row.end_date,
+                }
+                for row in rows
+            ]
+        )
+        if limit is not None and not df.empty:
+            return df.head(limit)
+        return df
+
+    def get_available_stocks(self, min_records: int = 100) -> pd.DataFrame:
+        return self.get_stock_list(min_records=min_records, detail=True)
+
+    def get_topix(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> pd.DataFrame:
+        return _to_ohlc_df(self._db.get_topix(start=start_date, end=end_date))
+
+    def get_index(
+        self,
+        index_code: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> pd.DataFrame:
+        return _to_ohlc_df(
+            self._db.get_index_data(index_code, start=start_date, end=end_date)
+        )
+
+    def get_index_list(
+        self,
+        min_records: int = 100,
+        codes: list[str] | None = None,
+    ) -> pd.DataFrame:
+        rows = self._db.get_index_list_with_counts(min_records=min_records)
+        df = pd.DataFrame(
+            [
+                {
+                    "indexCode": row.indexCode,
+                    "indexName": row.indexName,
+                    "record_count": row.record_count,
+                    "start_date": row.start_date,
+                    "end_date": row.end_date,
+                }
+                for row in rows
+            ]
+        )
+        if codes and not df.empty:
+            code_set = set(codes)
+            df = pd.DataFrame(
+                [record for record in df.to_dict(orient="records") if record["indexCode"] in code_set]
+            )
+        return df
+
+    def get_margin(
+        self,
+        stock_code: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> pd.DataFrame:
+        rows = self._db.get_margin(code=stock_code, start=start_date, end=end_date)
+        return _to_margin_df(rows)
+
+    def get_margin_batch(
+        self,
+        stock_codes: list[str],
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> dict[str, pd.DataFrame]:
+        _ = (start_date, end_date)
+        batch = self._db.get_margin_batch(stock_codes)
+        return {code: _to_margin_df(rows) for code, rows in batch.items() if rows}
+
+    def get_margin_list(
+        self,
+        min_records: int = 10,
+        codes: list[str] | None = None,
+    ) -> pd.DataFrame:
+        rows = self._db.get_margin_list(min_records=min_records)
+        df = pd.DataFrame(
+            [
+                {
+                    "stockCode": row.stockCode,
+                    "record_count": row.record_count,
+                    "start_date": row.start_date,
+                    "end_date": row.end_date,
+                    "avg_long_margin": row.avg_long_margin,
+                    "avg_short_margin": row.avg_short_margin,
+                }
+                for row in rows
+            ]
+        )
+        if codes and not df.empty:
+            code_set = set(codes)
+            df = pd.DataFrame(
+                [record for record in df.to_dict(orient="records") if record["stockCode"] in code_set]
+            )
+        return df
+
+    def get_statements(
+        self,
+        stock_code: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        period_type: str = "all",
+        actual_only: bool = True,
+    ) -> pd.DataFrame:
+        _ = (start_date, end_date, period_type, actual_only)
+        return _to_statements_df(self._db.get_statements(stock_code))
+
+    def get_statements_batch(
+        self,
+        stock_codes: list[str],
+        start_date: str | None = None,
+        end_date: str | None = None,
+        period_type: str = "all",
+        actual_only: bool = True,
+    ) -> dict[str, pd.DataFrame]:
+        _ = (start_date, end_date, period_type, actual_only)
+        batch = self._db.get_statements_batch(stock_codes)
+        return {code: _to_statements_df(rows) for code, rows in batch.items() if rows}
+
+    def get_sector_mapping(self) -> pd.DataFrame:
+        sectors = self._db.get_sectors()
+        indices = self._db.get_indices()
+        sector_code_by_name = {item["name"]: item["code"] for item in sectors}
+
+        records = [
+            {
+                "sector_code": sector_code_by_name.get(row.sector_name),
+                "sector_name": row.sector_name,
+                "index_code": row.code,
+                "index_name": row.sector_name,
+            }
+            for row in indices
+        ]
+        return pd.DataFrame(records)
+
+    def get_stock_sector_mapping(self) -> dict[str, str]:
+        sector_to_stocks = self._db.get_sector_stock_mapping()
+        result: dict[str, str] = {}
+        for sector_name, codes in sector_to_stocks.items():
+            for code in codes:
+                result[code] = sector_name
+        return result
+
+    def get_sector_stocks(self, sector_name: str) -> list[str]:
+        rows = self._db.get_sector_stocks(sector_name)
+        return [row.code for row in rows]
+
+    def get_all_sectors(self) -> pd.DataFrame:
+        mapping_df = self.get_sector_mapping()
+        counts = {row.sectorName: row.count for row in self._db.get_sectors_with_count()}
+
+        if mapping_df.empty:
+            return pd.DataFrame()
+
+        mapping_df = mapping_df.copy()
+        mapping_df["stock_count"] = mapping_df["sector_name"].map(counts).fillna(0).astype(int)
+        return mapping_df
+
+
+class DirectMarketClient:
+    """Market client backed by market.db reader (no HTTP)."""
+
+    def __enter__(self) -> DirectMarketClient:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any,
+    ) -> None:
+        return None
+
+    def get_topix(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> pd.DataFrame:
+        reader = _resolve_market_reader()
+        sql = "SELECT date, open, high, low, close FROM topix_data"
+        params: list[str] = []
+        conds: list[str] = []
+        if start_date:
+            conds.append("date >= ?")
+            params.append(start_date)
+        if end_date:
+            conds.append("date <= ?")
+            params.append(end_date)
+        if conds:
+            sql += " WHERE " + " AND ".join(conds)
+        sql += " ORDER BY date"
+
+        rows = reader.query(sql, tuple(params))
+        if not rows:
+            return pd.DataFrame()
+        index = pd.to_datetime([row["date"] for row in rows])
+
+        df = pd.DataFrame(
+            [
+                {
+                    "Open": row["open"],
+                    "High": row["high"],
+                    "Low": row["low"],
+                    "Close": row["close"],
+                }
+                for row in rows
+            ]
+        )
+        df.index = index
+        df.index.name = "date"
+        return df
+
+
+def get_dataset_client(
+    dataset_name: str,
+    http_client_factory: type[DatasetAPIClient] = DatasetAPIClient,
+) -> DatasetAPIClient | DirectDatasetClient:
+    """Return HTTP or direct dataset client based on active data-access mode."""
+    if should_use_direct_db():
+        return DirectDatasetClient(dataset_name)
+    return http_client_factory(dataset_name)
+
+
+def get_market_client(
+    http_client_factory: type[MarketAPIClient] = MarketAPIClient,
+) -> MarketAPIClient | DirectMarketClient:
+    """Return HTTP or direct market client based on active data-access mode."""
+    if should_use_direct_db():
+        return DirectMarketClient()
+    return http_client_factory()

--- a/apps/bt/src/data/access/mode.py
+++ b/apps/bt/src/data/access/mode.py
@@ -1,0 +1,54 @@
+"""Data access mode control for loader paths.
+
+This module allows switching between HTTP-based access and direct DB access
+without changing call sites. Backtest jobs can set mode="direct" to avoid
+FastAPI self-calls.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Literal
+
+DataAccessMode = Literal["http", "direct"]
+DATA_ACCESS_MODE_ENV = "BT_DATA_ACCESS_MODE"
+
+_mode_ctx: ContextVar[DataAccessMode | None] = ContextVar(
+    "bt_data_access_mode", default=None
+)
+
+
+def normalize_data_access_mode(mode: str | None) -> DataAccessMode:
+    """Normalize user/input mode into supported values."""
+    if mode and mode.lower() == "direct":
+        return "direct"
+    return "http"
+
+
+def get_data_access_mode() -> DataAccessMode:
+    """Resolve current access mode (contextvar first, then env, then default)."""
+    ctx_mode = _mode_ctx.get()
+    if ctx_mode is not None:
+        return ctx_mode
+    return normalize_data_access_mode(os.getenv(DATA_ACCESS_MODE_ENV))
+
+
+def should_use_direct_db() -> bool:
+    """True when current mode is direct DB access."""
+    return get_data_access_mode() == "direct"
+
+
+@contextmanager
+def data_access_mode_context(mode: str | None) -> Iterator[None]:
+    """Temporarily override access mode within current context."""
+    if mode is None:
+        yield
+        return
+
+    token = _mode_ctx.set(normalize_data_access_mode(mode))
+    try:
+        yield
+    finally:
+        _mode_ctx.reset(token)

--- a/apps/bt/src/data/loaders/data_preparation.py
+++ b/apps/bt/src/data/loaders/data_preparation.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
 from src.api.dataset.statements_mixin import APIPeriodType
+from src.data.access.clients import get_dataset_client
 from src.api.exceptions import APIError
 from src.exceptions import (
     BatchAPIError,
@@ -242,7 +243,7 @@ def prepare_multi_data(
     ohlcv_batch: Dict[str, pd.DataFrame] = {}
 
     try:
-        with DatasetAPIClient(dataset_name) as client:
+        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
             ohlcv_batch = client.get_stocks_ohlcv_batch(
                 stock_codes, start_date, end_date, timeframe
             )
@@ -269,7 +270,7 @@ def prepare_multi_data(
         logger.debug("信用残高データ読み込み開始（バッチAPI）")
         margin_codes = list(result.keys())
         try:
-            with DatasetAPIClient(dataset_name) as client:
+            with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
                 margin_batch = client.get_margin_batch(
                     margin_codes, start_date, end_date
                 )
@@ -302,7 +303,7 @@ def prepare_multi_data(
         logger.debug("財務諸表データ読み込み開始（バッチAPI）")
         statements_codes = list(result.keys())
         try:
-            with DatasetAPIClient(dataset_name) as client:
+            with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
                 statements_batch = client.get_statements_batch(
                     statements_codes, start_date, end_date,
                     period_type=period_type, actual_only=True,

--- a/apps/bt/src/data/loaders/index_loaders.py
+++ b/apps/bt/src/data/loaders/index_loaders.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
 from src.api.market_client import MarketAPIClient
+from src.data.access.clients import get_dataset_client, get_market_client
 from src.data.loaders.cache import cached_loader
 from src.data.loaders.utils import extract_dataset_name
 
@@ -45,7 +46,7 @@ def load_topix_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_topix(start_date, end_date)
 
     if df.empty:
@@ -84,7 +85,7 @@ def load_topix_data_from_market_db(
         - 直近1年間の市場データ（日次更新）
         - バックテスト用のload_topix_data()とはテーブル名・データソースが異なる
     """
-    with MarketAPIClient() as client:
+    with get_market_client(http_client_factory=MarketAPIClient) as client:
         df = client.get_topix(start_date, end_date)
 
     if df.empty:
@@ -122,7 +123,7 @@ def load_index_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_index(index_code, start_date, end_date)
 
     if df.empty:
@@ -148,7 +149,7 @@ def get_index_list(dataset: str, min_records: int = 100) -> list[str]:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_index_list(min_records)
 
     if df.empty:
@@ -170,7 +171,7 @@ def get_available_indices(dataset: str, min_records: int = 100) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_index_list(min_records)
 
     return df

--- a/apps/bt/src/data/loaders/margin_loaders.py
+++ b/apps/bt/src/data/loaders/margin_loaders.py
@@ -10,6 +10,7 @@ import pandas as pd
 from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
+from src.data.access.clients import get_dataset_client
 from src.data.loaders.cache import DataCache
 from src.data.loaders.utils import extract_dataset_name
 
@@ -66,7 +67,7 @@ def load_margin_data(
             return cached
 
     # API呼び出し
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_margin(stock_code, start_date, end_date)
 
     if df.empty:
@@ -104,7 +105,7 @@ def get_margin_available_stocks(dataset: str, min_records: int = 10) -> pd.DataF
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_margin_list(min_records)
 
     return df

--- a/apps/bt/src/data/loaders/multi_asset_loaders.py
+++ b/apps/bt/src/data/loaders/multi_asset_loaders.py
@@ -10,6 +10,7 @@ import pandas as pd
 from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
+from src.data.access.clients import get_dataset_client
 from src.exceptions import BatchAPIError, NoValidDataError
 
 from src.api.dataset.statements_mixin import APIPeriodType
@@ -53,7 +54,7 @@ def load_multiple_stocks(
     if use_batch_api and not cache.is_enabled():
         dataset_name = extract_dataset_name(dataset)
         try:
-            with DatasetAPIClient(dataset_name) as client:
+            with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
                 batch_data = client.get_stocks_ohlcv_batch(
                     stock_codes, start_date, end_date, timeframe
                 )
@@ -161,7 +162,7 @@ def load_multiple_margin_data(
 
     # バッチAPIを試行
     try:
-        with DatasetAPIClient(dataset_name) as client:
+        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
             batch_data = client.get_margin_batch(
                 stock_codes, start_date, end_date
             )
@@ -228,7 +229,7 @@ def load_multiple_statements_data(
 
     # バッチAPIを試行
     try:
-        with DatasetAPIClient(dataset_name) as client:
+        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
             batch_data = client.get_statements_batch(
                 stock_codes, start_date, end_date,
                 period_type=period_type, actual_only=True,

--- a/apps/bt/src/data/loaders/sector_loaders.py
+++ b/apps/bt/src/data/loaders/sector_loaders.py
@@ -8,6 +8,7 @@ import pandas as pd
 from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
+from src.data.access.clients import get_dataset_client
 from src.exceptions import IndexDataLoadError, SectorDataLoadError
 
 from .index_loaders import load_index_data
@@ -34,7 +35,7 @@ def get_sector_mapping(dataset: str) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_sector_mapping()
 
     return df
@@ -168,7 +169,7 @@ def get_stock_sector_mapping(dataset: str) -> dict[str, str]:
     logger.info("銘柄→セクターマッピング取得開始")
 
     try:
-        with DatasetAPIClient(dataset_name) as client:
+        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
             mapping = client.get_stock_sector_mapping()
 
         logger.info(f"銘柄→セクターマッピング取得完了: {len(mapping)}銘柄")

--- a/apps/bt/src/data/loaders/statements_loaders.py
+++ b/apps/bt/src/data/loaders/statements_loaders.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
 from src.api.dataset.statements_mixin import APIPeriodType
+from src.data.access.clients import get_dataset_client
 from src.data.loaders.utils import extract_dataset_name
 from src.models.types import normalize_period_type
 
@@ -177,7 +178,7 @@ def load_statements_data(
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_statements(
             stock_code,
             start_date,

--- a/apps/bt/src/data/loaders/stock_loaders.py
+++ b/apps/bt/src/data/loaders/stock_loaders.py
@@ -10,6 +10,7 @@ import pandas as pd
 from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
+from src.data.access.clients import get_dataset_client
 from src.data.loaders.cache import DataCache, cached_loader
 from src.data.loaders.utils import extract_dataset_name
 
@@ -36,7 +37,7 @@ def get_stock_list(dataset: str, min_records: int = 100) -> list[str]:
             return cached["stockCode"].tolist()
 
     # API呼び出し
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_stock_list(min_records=min_records)
 
     if df.empty:
@@ -75,7 +76,7 @@ def load_stock_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_stock_ohlcv(stock_code, start_date, end_date, timeframe)
 
     if df.empty:
@@ -100,7 +101,7 @@ def get_available_stocks(dataset: str, min_records: int = 1000) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_available_stocks(min_records=min_records)
 
     return df

--- a/apps/bt/src/lib/backtest_core/marimo_executor.py
+++ b/apps/bt/src/lib/backtest_core/marimo_executor.py
@@ -5,6 +5,7 @@ Marimoを使用したNotebook実行・HTML出力ラッパー
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -144,6 +145,7 @@ class MarimoExecutor:
         strategy_name: str | None = None,
         output_filename: str | None = None,
         timeout: int = 600,
+        extra_env: dict[str, str] | None = None,
     ) -> Path:
         """
         Marimo notebookを実行してHTML出力
@@ -154,6 +156,7 @@ class MarimoExecutor:
             strategy_name: 戦略名
             output_filename: 出力ファイル名（拡張子なし）
             timeout: タイムアウト秒数
+            extra_env: marimo subprocess に追加注入する環境変数
 
         Returns:
             html_path - 出力HTMLのパス
@@ -228,6 +231,7 @@ class MarimoExecutor:
                 text=True,
                 timeout=timeout,
                 stdin=subprocess.DEVNULL,
+                env={**os.environ, **(extra_env or {})},
             )
 
             logger.debug(

--- a/apps/bt/src/server/services/backtest_service.py
+++ b/apps/bt/src/server/services/backtest_service.py
@@ -171,6 +171,7 @@ class BacktestService:
             strategy=strategy_name,
             progress_callback=progress_callback,
             config_override=config_override,
+            data_access_mode="direct",
         )
 
     def _extract_result_summary(self, result: BacktestResult) -> BacktestResultSummary:

--- a/apps/bt/src/strategies/signals/sector.py
+++ b/apps/bt/src/strategies/signals/sector.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from src.api.dataset_client import DatasetAPIClient
 from src.data import get_sector_mapping, load_index_data
+from src.data.access.clients import get_dataset_client
 from src.data.loaders.utils import extract_dataset_name
 
 
@@ -53,7 +54,7 @@ def get_sector_stocks(dataset: str, sector_name: str) -> list[str]:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         stocks = client.get_sector_stocks(sector_name)
 
     if not stocks:
@@ -78,7 +79,7 @@ def get_all_sectors(dataset: str) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with DatasetAPIClient(dataset_name) as client:
+    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
         df = client.get_all_sectors()
 
     return df

--- a/apps/bt/tests/unit/data/test_access_mode_and_clients.py
+++ b/apps/bt/tests/unit/data/test_access_mode_and_clients.py
@@ -1,0 +1,422 @@
+"""Unit tests for src.data.access.mode and src.data.access.clients."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Generator, cast
+
+import pandas as pd
+import pytest
+
+from src.data.access import clients, mode
+
+
+@pytest.fixture(autouse=True)
+def _reset_access_caches() -> Generator[None, None, None]:  # pyright: ignore[reportUnusedFunction]
+    clients._dataset_db_cache.clear()
+    clients._market_reader = None
+    yield
+    clients._dataset_db_cache.clear()
+    clients._market_reader = None
+
+
+def _ns(**kwargs: Any) -> SimpleNamespace:
+    return SimpleNamespace(**kwargs)
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        clients,
+        "get_settings",
+        lambda: _ns(
+            dataset_base_path=str(tmp_path),
+            market_db_path=str(tmp_path / "market.db"),
+        ),
+    )
+
+
+def test_mode_normalization_and_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(mode.DATA_ACCESS_MODE_ENV, raising=False)
+
+    assert mode.normalize_data_access_mode(None) == "http"
+    assert mode.normalize_data_access_mode("DIRECT") == "direct"
+    assert mode.get_data_access_mode() == "http"
+
+    monkeypatch.setenv(mode.DATA_ACCESS_MODE_ENV, "direct")
+    assert mode.get_data_access_mode() == "direct"
+    assert mode.should_use_direct_db() is True
+
+    with mode.data_access_mode_context("http"):
+        assert mode.get_data_access_mode() == "http"
+        assert mode.should_use_direct_db() is False
+
+    with mode.data_access_mode_context(None):
+        assert mode.get_data_access_mode() == "direct"
+
+    assert mode.get_data_access_mode() == "direct"
+
+
+def test_resolve_dataset_db_raises_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_settings(monkeypatch, tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Dataset not found"):
+        clients._resolve_dataset_db("missing")
+
+
+def test_resolve_dataset_db_uses_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_settings(monkeypatch, tmp_path)
+    (tmp_path / "sample.db").write_text("", encoding="utf-8")
+
+    init_calls: list[str] = []
+
+    class _FakeDatasetDb:
+        def __init__(self, db_path: str) -> None:
+            init_calls.append(db_path)
+
+    monkeypatch.setattr(clients, "DatasetDb", _FakeDatasetDb)
+
+    first = clients._resolve_dataset_db("sample")
+    second = clients._resolve_dataset_db("sample.db")
+
+    assert first is second
+    assert len(init_calls) == 1
+
+
+def test_resolve_market_reader_raises_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_settings(monkeypatch, tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="market.db not found"):
+        clients._resolve_market_reader()
+
+
+def test_resolve_market_reader_uses_singleton(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_settings(monkeypatch, tmp_path)
+    (tmp_path / "market.db").write_text("", encoding="utf-8")
+
+    init_calls: list[str] = []
+
+    class _FakeMarketReader:
+        def __init__(self, db_path: str) -> None:
+            init_calls.append(db_path)
+
+    monkeypatch.setattr(clients, "MarketDbReader", _FakeMarketReader)
+
+    first = clients._resolve_market_reader()
+    second = clients._resolve_market_reader()
+
+    assert first is second
+    assert len(init_calls) == 1
+
+
+def test_conversion_helpers_empty_rows() -> None:
+    assert clients._to_ohlcv_df([]).empty
+    assert clients._to_ohlc_df([]).empty
+    assert clients._to_margin_df([]).empty
+    assert clients._to_statements_df([]).empty
+
+
+def test_direct_dataset_client_methods(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeDatasetDb:
+        def get_stock_ohlcv(self, code: str, start=None, end=None):  # noqa: ANN001, ANN202
+            assert code == "7203"
+            assert start == "2024-01-01"
+            assert end == "2024-12-31"
+            return [
+                _ns(
+                    date="2024-01-04",
+                    open=100.0,
+                    high=101.0,
+                    low=99.0,
+                    close=100.5,
+                    volume=1000,
+                )
+            ]
+
+        def get_ohlcv_batch(self, codes: list[str]) -> dict[str, list[SimpleNamespace]]:
+            assert codes == ["7203", "6501"]
+            return {
+                "7203": [
+                    _ns(
+                        date="2024-01-04",
+                        open=100.0,
+                        high=101.0,
+                        low=99.0,
+                        close=100.5,
+                        volume=1000,
+                    )
+                ],
+                "6501": [],
+            }
+
+        def get_stock_list_with_counts(self, min_records: int = 100) -> list[SimpleNamespace]:
+            assert min_records in {100, 50}
+            return [
+                _ns(
+                    stockCode="7203",
+                    record_count=200,
+                    start_date="2020-01-01",
+                    end_date="2024-12-31",
+                ),
+                _ns(
+                    stockCode="6501",
+                    record_count=180,
+                    start_date="2020-01-01",
+                    end_date="2024-12-31",
+                ),
+            ]
+
+        def get_topix(self, start=None, end=None):  # noqa: ANN001, ANN202
+            assert start == "2024-01-01"
+            assert end == "2024-12-31"
+            return [
+                _ns(date="2024-01-04", open=2000.0, high=2010.0, low=1990.0, close=2005.0)
+            ]
+
+        def get_index_data(self, code: str, start=None, end=None):  # noqa: ANN001, ANN202
+            assert code == "IDX-1"
+            assert start == "2024-01-01"
+            assert end == "2024-12-31"
+            return [
+                _ns(date="2024-01-04", open=3000.0, high=3010.0, low=2990.0, close=3005.0)
+            ]
+
+        def get_index_list_with_counts(self, min_records: int = 100) -> list[SimpleNamespace]:
+            assert min_records == 100
+            return [
+                _ns(
+                    indexCode="IDX-1",
+                    indexName="電気機器",
+                    record_count=200,
+                    start_date="2020-01-01",
+                    end_date="2024-12-31",
+                ),
+                _ns(
+                    indexCode="IDX-2",
+                    indexName="化学",
+                    record_count=180,
+                    start_date="2020-01-01",
+                    end_date="2024-12-31",
+                ),
+            ]
+
+        def get_margin(self, code: str, start=None, end=None):  # noqa: ANN001, ANN202
+            assert code == "7203"
+            assert start == "2024-01-01"
+            assert end == "2024-12-31"
+            return [
+                _ns(
+                    date="2024-01-04",
+                    long_margin_volume=100.0,
+                    short_margin_volume=50.0,
+                )
+            ]
+
+        def get_margin_batch(self, codes: list[str]) -> dict[str, list[SimpleNamespace]]:
+            assert codes == ["7203", "6501"]
+            return {
+                "7203": [
+                    _ns(
+                        date="2024-01-04",
+                        long_margin_volume=100.0,
+                        short_margin_volume=50.0,
+                    )
+                ],
+                "6501": [],
+            }
+
+        def get_margin_list(self, min_records: int = 10) -> list[SimpleNamespace]:
+            assert min_records == 10
+            return [
+                _ns(
+                    stockCode="7203",
+                    record_count=20,
+                    start_date="2024-01-01",
+                    end_date="2024-12-31",
+                    avg_long_margin=100.0,
+                    avg_short_margin=50.0,
+                )
+            ]
+
+        def get_statements(self, code: str) -> list[SimpleNamespace]:
+            assert code == "7203"
+            return [
+                _ns(
+                    code="7203",
+                    disclosed_date="2024-03-31",
+                    earnings_per_share=10.0,
+                    profit=1000.0,
+                    equity=5000.0,
+                    type_of_current_period="FY",
+                    type_of_document="Q1",
+                    next_year_forecast_earnings_per_share=12.0,
+                    bps=100.0,
+                    sales=20000.0,
+                    operating_profit=3000.0,
+                    ordinary_profit=2500.0,
+                    operating_cash_flow=1500.0,
+                    dividend_fy=40.0,
+                    forecast_eps=11.0,
+                    investing_cash_flow=-400.0,
+                    financing_cash_flow=-300.0,
+                    cash_and_equivalents=1200.0,
+                    total_assets=60000.0,
+                    shares_outstanding=100.0,
+                    treasury_shares=2.0,
+                )
+            ]
+
+        def get_statements_batch(self, codes: list[str]) -> dict[str, list[SimpleNamespace]]:
+            assert codes == ["7203", "6501"]
+            return {"7203": self.get_statements("7203"), "6501": []}
+
+        def get_sectors(self) -> list[dict[str, str]]:
+            return [{"code": "3250", "name": "電気機器"}]
+
+        def get_indices(self) -> list[SimpleNamespace]:
+            return [_ns(code="IDX-1", sector_name="電気機器")]
+
+        def get_sector_stock_mapping(self) -> dict[str, list[str]]:
+            return {"電気機器": ["7203", "6501"]}
+
+        def get_sector_stocks(self, sector_name: str) -> list[SimpleNamespace]:
+            assert sector_name == "電気機器"
+            return [_ns(code="7203"), _ns(code="6501")]
+
+        def get_sectors_with_count(self) -> list[SimpleNamespace]:
+            return [_ns(sectorName="電気機器", count=2)]
+
+    fake_db = _FakeDatasetDb()
+    monkeypatch.setattr(clients, "_resolve_dataset_db", lambda _dataset_name: fake_db)
+
+    client = clients.DirectDatasetClient("sample.db")
+    assert client.dataset_name == "sample"
+    assert client.__enter__() is client
+    assert client.__exit__(None, None, None) is None
+
+    stock_df = client.get_stock_ohlcv("7203", "2024-01-01", "2024-12-31")
+    assert list(stock_df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+    stock_batch = client.get_stocks_ohlcv_batch(["7203", "6501"])
+    assert list(stock_batch.keys()) == ["7203"]
+
+    stock_list = client.get_stock_list(min_records=50)
+    assert len(stock_list) == 2
+    stock_list_limited = client.get_stock_list(limit=1)
+    assert len(stock_list_limited) == 1
+    assert len(client.get_available_stocks(min_records=50)) == 2
+
+    topix_df = client.get_topix("2024-01-01", "2024-12-31")
+    assert list(topix_df.columns) == ["Open", "High", "Low", "Close"]
+
+    index_df = client.get_index("IDX-1", "2024-01-01", "2024-12-31")
+    assert list(index_df.columns) == ["Open", "High", "Low", "Close"]
+    assert len(client.get_index_list(codes=["IDX-1"])) == 1
+    assert client.get_index_list(codes=["UNKNOWN"]).empty
+
+    margin_df = client.get_margin("7203", "2024-01-01", "2024-12-31")
+    assert list(margin_df.columns) == ["longMarginVolume", "shortMarginVolume"]
+    assert list(client.get_margin_batch(["7203", "6501"]).keys()) == ["7203"]
+    assert len(client.get_margin_list(codes=["7203"])) == 1
+    assert client.get_margin_list(codes=["UNKNOWN"]).empty
+
+    statements_df = client.get_statements("7203")
+    assert "dividendFY" in statements_df.columns
+    assert list(client.get_statements_batch(["7203", "6501"]).keys()) == ["7203"]
+
+    sector_mapping = client.get_sector_mapping()
+    assert list(sector_mapping.columns) == [
+        "sector_code",
+        "sector_name",
+        "index_code",
+        "index_name",
+    ]
+    assert client.get_stock_sector_mapping() == {"7203": "電気機器", "6501": "電気機器"}
+    assert client.get_sector_stocks("電気機器") == ["7203", "6501"]
+
+    all_sectors = client.get_all_sectors()
+    assert list(all_sectors["stock_count"]) == [2]
+
+    monkeypatch.setattr(client, "get_sector_mapping", lambda: pd.DataFrame())
+    assert client.get_all_sectors().empty
+
+
+def test_direct_market_client_get_topix(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeMarketReader:
+        def query(self, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+            captured["sql"] = sql
+            captured["params"] = params
+            return [
+                {
+                    "date": "2024-01-04",
+                    "open": 2000.0,
+                    "high": 2010.0,
+                    "low": 1990.0,
+                    "close": 2005.0,
+                }
+            ]
+
+    monkeypatch.setattr(clients, "_resolve_market_reader", lambda: _FakeMarketReader())
+
+    market_client = clients.DirectMarketClient()
+    assert market_client.__enter__() is market_client
+    assert market_client.__exit__(None, None, None) is None
+
+    df = market_client.get_topix("2024-01-01", "2024-12-31")
+    assert list(df.columns) == ["Open", "High", "Low", "Close"]
+    assert "WHERE date >= ? AND date <= ?" in captured["sql"]
+    assert captured["params"] == ("2024-01-01", "2024-12-31")
+
+
+def test_direct_market_client_get_topix_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeMarketReader:
+        def query(self, _sql: str, _params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(clients, "_resolve_market_reader", lambda: _FakeMarketReader())
+
+    market_client = clients.DirectMarketClient()
+    assert market_client.get_topix().empty
+
+
+def test_client_factories_switch_by_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _HTTPDatasetClient:
+        def __init__(self, dataset_name: str) -> None:
+            self.dataset_name = dataset_name
+
+    class _HTTPMarketClient:
+        def __init__(self) -> None:
+            self.kind = "http"
+
+    class _DirectDatasetClient:
+        def __init__(self, dataset_name: str) -> None:
+            self.dataset_name = dataset_name
+
+    class _DirectMarketClient:
+        def __init__(self) -> None:
+            self.kind = "direct"
+
+    monkeypatch.setattr(clients, "DirectDatasetClient", _DirectDatasetClient)
+    monkeypatch.setattr(clients, "DirectMarketClient", _DirectMarketClient)
+
+    monkeypatch.setattr(clients, "should_use_direct_db", lambda: False)
+    http_dataset = clients.get_dataset_client("sample", cast(Any, _HTTPDatasetClient))
+    http_market = clients.get_market_client(cast(Any, _HTTPMarketClient))
+    assert isinstance(http_dataset, _HTTPDatasetClient)
+    assert isinstance(http_market, _HTTPMarketClient)
+
+    monkeypatch.setattr(clients, "should_use_direct_db", lambda: True)
+    direct_dataset = clients.get_dataset_client("sample", cast(Any, _HTTPDatasetClient))
+    direct_market = clients.get_market_client(cast(Any, _HTTPMarketClient))
+    assert isinstance(direct_dataset, _DirectDatasetClient)
+    assert isinstance(direct_market, _DirectMarketClient)

--- a/apps/bt/tests/unit/data/test_direct_access_mode.py
+++ b/apps/bt/tests/unit/data/test_direct_access_mode.py
@@ -1,0 +1,72 @@
+"""Tests for direct data-access mode (no internal HTTP self-call)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.api.client import BaseAPIClient
+from src.data.access.mode import data_access_mode_context
+from src.data.loaders.index_loaders import load_topix_data_from_market_db
+from src.data.loaders.stock_loaders import load_stock_data
+
+
+def test_load_stock_data_direct_mode_bypasses_http(monkeypatch):
+    class _FakeDatasetDb:
+        def get_stock_ohlcv(self, _code, start=None, end=None):  # noqa: ANN001, ANN202
+            _ = (start, end)
+            return [
+                SimpleNamespace(
+                    date="2024-01-04",
+                    open=100.0,
+                    high=101.0,
+                    low=99.0,
+                    close=100.5,
+                    volume=12345,
+                )
+            ]
+
+    monkeypatch.setattr(
+        "src.data.access.clients._resolve_dataset_db",
+        lambda _dataset_name: _FakeDatasetDb(),
+    )
+
+    def _fail_http_request(*args, **kwargs):  # noqa: ANN001, ANN002, ARG001
+        raise AssertionError("HTTP client must not be used in direct mode")
+
+    monkeypatch.setattr(BaseAPIClient, "_request", _fail_http_request)
+
+    with data_access_mode_context("direct"):
+        df = load_stock_data("sample", "7203")
+
+    assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+    assert not df.empty
+
+
+def test_load_topix_market_direct_mode_bypasses_http(monkeypatch):
+    class _FakeMarketReader:
+        def query(self, _sql, _params=()):  # noqa: ANN001, ANN202
+            return [
+                {
+                    "date": "2024-01-04",
+                    "open": 1000.0,
+                    "high": 1010.0,
+                    "low": 990.0,
+                    "close": 1005.0,
+                }
+            ]
+
+    monkeypatch.setattr(
+        "src.data.access.clients._resolve_market_reader",
+        lambda: _FakeMarketReader(),
+    )
+
+    def _fail_http_request(*args, **kwargs):  # noqa: ANN001, ANN002, ARG001
+        raise AssertionError("HTTP client must not be used in direct mode")
+
+    monkeypatch.setattr(BaseAPIClient, "_request", _fail_http_request)
+
+    with data_access_mode_context("direct"):
+        df = load_topix_data_from_market_db()
+
+    assert list(df.columns) == ["Open", "High", "Low", "Close"]
+    assert not df.empty

--- a/apps/bt/tests/unit/server/services/test_backtest_service.py
+++ b/apps/bt/tests/unit/server/services/test_backtest_service.py
@@ -5,7 +5,7 @@ BacktestService unit tests
 import asyncio
 from pathlib import Path
 
-from src.backtest.runner import BacktestResult
+from src.lib.backtest_core.runner import BacktestResult
 from src.server.services.backtest_service import BacktestService
 
 
@@ -25,8 +25,15 @@ def test_execute_backtest_sync_uses_threadsafe_progress(monkeypatch, tmp_path: P
         dataset_name="sample",
     )
 
-    def _fake_execute(strategy: str, progress_callback=None, config_override=None):
-        progress_callback("running", 0.1)
+    def _fake_execute(
+        strategy: str,
+        progress_callback=None,
+        config_override=None,
+        data_access_mode: str | None = None,
+    ):
+        _ = (config_override, data_access_mode)
+        if progress_callback is not None:
+            progress_callback("running", 0.1)
         return result
 
     service._runner.execute = _fake_execute  # type: ignore[assignment]
@@ -47,3 +54,31 @@ def test_execute_backtest_sync_uses_threadsafe_progress(monkeypatch, tmp_path: P
         loop.close()
 
     assert called["loop"] is loop
+
+
+def test_execute_backtest_sync_passes_direct_data_access_mode(tmp_path: Path):
+    service = BacktestService()
+
+    result = BacktestResult(
+        html_path=tmp_path / "result.html",
+        elapsed_time=1.0,
+        summary={},
+        strategy_name="test",
+        dataset_name="sample",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute(**kwargs):
+        captured.update(kwargs)
+        return result
+
+    service._runner.execute = _fake_execute  # type: ignore[assignment]
+
+    loop = asyncio.new_event_loop()
+    try:
+        service._execute_backtest_sync("job-1", "strategy-1", loop)
+    finally:
+        loop.close()
+
+    assert captured["data_access_mode"] == "direct"

--- a/issues/bt-031-backtest-direct-access-phase2-cleanup.md
+++ b/issues/bt-031-backtest-direct-access-phase2-cleanup.md
@@ -1,0 +1,37 @@
+---
+id: bt-031
+title: Backtest direct access Phase2 cleanup
+status: open
+priority: medium
+labels: [backtest, architecture, maintenance]
+project: bt
+created: 2026-02-12
+updated: 2026-02-12
+depends_on: []
+blocks: []
+parent: null
+---
+
+# bt-031 Backtest direct access Phase2 cleanup
+
+## 目的
+backtest 実行経路で導入した `http/direct` 二重モードを整理し、保守コストを下げる。
+
+## 受け入れ条件
+- backtest 実行経路で `direct` をデフォルト化し、`http` 分岐を削除または限定利用に縮小する。
+- `src/data/access/clients.py` の変換処理を共通化し、loader 側で重複した整形ロジックを持たない。
+- backtest 実行中に `BaseAPIClient._request` が呼ばれないことをテストで継続保証する。
+- 不要化した互換コード（コメント/legacy記述）を整理する。
+
+## 実施内容
+- `src/data/access/*` の API を最小公開面に再設計する。
+- loader から見たインターフェースを確定し、移行完了後に一時互換コードを削除する。
+- direct 経路のエラー型とメッセージを統一し、監視ログの可読性を上げる。
+- テストを `mode依存` から `振る舞い依存` に寄せる。
+
+## 結果
+未着手
+
+## 補足
+- Phase1 実装: backtest 実行時のみ `BT_DATA_ACCESS_MODE=direct` を有効化済み。
+- この Issue は「移行完了後の恒久化/簡素化」を扱う。


### PR DESCRIPTION
Backtest execution path now uses direct DatasetDb/MarketDb access to avoid internal FastAPI self-calls. Includes mode-aware client layer, runner env propagation, loader migration, tests, and docs updates.