### PR TITLE
feat: strict strategy validation on backend and editor validation unification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
+- Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う
 - **ts/web** は `/api` パスを FastAPI (:3002) にプロキシ
 - **Hono サーバー** (:3001) は廃止済み（`apps/ts/packages/api` は archived・read-only）

--- a/apps/bt/src/lib/strategy_runtime/__init__.py
+++ b/apps/bt/src/lib/strategy_runtime/__init__.py
@@ -10,8 +10,11 @@ from src.lib.strategy_runtime.loader import ConfigLoader
 from src.lib.strategy_runtime.models import (
     ExecutionConfig,
     StrategyConfig,
+    StrategyConfigStrictValidationError,
     try_validate_strategy_config_dict,
+    try_validate_strategy_config_dict_strict,
     validate_strategy_config_dict,
+    validate_strategy_config_dict_strict,
 )
 from src.lib.strategy_runtime.parameter_extractor import (
     extract_entry_filter_params,
@@ -62,5 +65,7 @@ __all__ = [
     "save_yaml_file",
     "validate_strategy_config_dict",
     "try_validate_strategy_config_dict",
+    "validate_strategy_config_dict_strict",
+    "try_validate_strategy_config_dict_strict",
+    "StrategyConfigStrictValidationError",
 ]
-

--- a/apps/bt/src/lib/strategy_runtime/loader.py
+++ b/apps/bt/src/lib/strategy_runtime/loader.py
@@ -14,6 +14,10 @@ from src.lib.strategy_runtime.file_operations import (
     load_yaml_file,
     save_yaml_file,
 )
+from src.lib.strategy_runtime.models import (
+    StrategyConfigStrictValidationError,
+    validate_strategy_config_dict_strict,
+)
 from src.lib.strategy_runtime.parameter_extractor import (
     extract_entry_filter_params,
     extract_exit_trigger_params,
@@ -214,6 +218,14 @@ class ConfigLoader:
 
         validate_path_within_strategies(strategy_path, self.config_dir)
         strategy_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            validate_strategy_config_dict_strict(config)
+        except StrategyConfigStrictValidationError as e:
+            raise ValueError(
+                "戦略設定の厳密バリデーションに失敗しました: "
+                + "; ".join(e.errors)
+            ) from e
 
         if strategy_path.exists() and not force:
             logger.warning(f"既存ファイルを上書きします: {strategy_path}")

--- a/apps/bt/src/lib/strategy_runtime/models.py
+++ b/apps/bt/src/lib/strategy_runtime/models.py
@@ -6,7 +6,7 @@ YAML戦略設定の構造バリデーションを提供する。
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -42,6 +42,102 @@ class StrategyConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class StrategyConfigStrictValidationError(ValueError):
+    """厳密バリデーションエラー（未知キー検出を含む）"""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("\n".join(errors))
+
+
+def _format_pydantic_error(error: ValidationError) -> list[str]:
+    """ValidationErrorを可読なエラーメッセージへ整形"""
+    messages: list[str] = []
+
+    for item in error.errors():
+        loc = item.get("loc", ())
+        path = ".".join(str(p) for p in loc if p != "__root__")
+        msg = str(item.get("msg", "Invalid value"))
+        messages.append(f"{path}: {msg}" if path else msg)
+
+    return messages
+
+
+def _extract_base_model(annotation: Any) -> type[BaseModel] | None:
+    """フィールド型からネストされたBaseModel型を抽出"""
+    origin = get_origin(annotation)
+
+    if origin is None:
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return annotation
+        return None
+
+    for arg in get_args(annotation):
+        if arg is type(None):
+            continue
+        nested = _extract_base_model(arg)
+        if nested is not None:
+            return nested
+
+    return None
+
+
+def _collect_unknown_paths(
+    data: Any,
+    model_cls: type[BaseModel],
+    path: str = "",
+) -> list[str]:
+    """辞書データを再帰走査して未知キーのパスを収集"""
+    if not isinstance(data, dict):
+        return []
+
+    errors: list[str] = []
+    fields = model_cls.model_fields
+
+    for key, value in data.items():
+        current_path = f"{path}.{key}" if path else key
+        field_info = fields.get(key)
+        if field_info is None:
+            errors.append(current_path)
+            continue
+
+        nested_model = _extract_base_model(field_info.annotation)
+        if nested_model is not None and isinstance(value, dict):
+            errors.extend(_collect_unknown_paths(value, nested_model, current_path))
+
+    return errors
+
+
+def _dedupe(messages: list[str]) -> list[str]:
+    """順序を保持して重複を除去"""
+    seen: set[str] = set()
+    deduped: list[str] = []
+
+    for message in messages:
+        if message in seen:
+            continue
+        seen.add(message)
+        deduped.append(message)
+
+    return deduped
+
+
+def _build_strict_validation_errors(config: dict[str, Any]) -> tuple[StrategyConfig | None, list[str]]:
+    """型検証と未知キー検出をまとめて実行"""
+    validated: StrategyConfig | None = None
+    errors: list[str] = []
+
+    try:
+        validated = validate_strategy_config_dict(config)
+    except ValidationError as e:
+        errors.extend(_format_pydantic_error(e))
+
+    unknown_paths = _collect_unknown_paths(config, StrategyConfig)
+    errors.extend(f"{path} is not a valid parameter name" for path in unknown_paths)
+
+    return validated, _dedupe(errors)
+
+
 def validate_strategy_config_dict(config: dict[str, Any]) -> StrategyConfig:
     """辞書をStrategyConfigとして検証（stock_codes解決は行わない）"""
     return StrategyConfig.model_validate(
@@ -56,3 +152,26 @@ def try_validate_strategy_config_dict(config: dict[str, Any]) -> tuple[bool, str
         return True, None
     except ValidationError as e:
         return False, str(e)
+
+
+def validate_strategy_config_dict_strict(config: dict[str, Any]) -> StrategyConfig:
+    """辞書を厳密検証（未知キーを許容しない）"""
+    validated, errors = _build_strict_validation_errors(config)
+    if errors:
+        raise StrategyConfigStrictValidationError(errors)
+
+    if validated is None:
+        raise StrategyConfigStrictValidationError(["Strategy config validation failed"])
+
+    return validated
+
+
+def try_validate_strategy_config_dict_strict(config: dict[str, Any]) -> tuple[bool, list[str]]:
+    """厳密検証の結果とエラー一覧を返す"""
+    validated, errors = _build_strict_validation_errors(config)
+    if errors or validated is None:
+        if not errors:
+            return False, ["Strategy config validation failed"]
+        return False, errors
+
+    return True, []

--- a/apps/bt/src/lib/strategy_runtime/validator.py
+++ b/apps/bt/src/lib/strategy_runtime/validator.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from loguru import logger
 
-from .models import try_validate_strategy_config_dict
+from .models import try_validate_strategy_config_dict_strict
 
 
 # 戦略名の最大長
@@ -53,9 +53,16 @@ def validate_strategy_config(config: dict[str, Any]) -> bool:
     Returns:
         妥当性チェック結果
     """
-    is_valid, error = try_validate_strategy_config_dict(config)
+    is_valid, errors = try_validate_strategy_config_dict_strict(config)
     if not is_valid:
-        logger.error(f"戦略設定バリデーションエラー: {error}")
+        error_messages = (
+            errors
+            if isinstance(errors, list)
+            else [str(errors)] if errors is not None else []
+        )
+        logger.error(
+            "戦略設定バリデーションエラー: {}", "; ".join(error_messages)
+        )
         return False
 
     # entry_filter_params の構造チェック（基本的な構造の存在確認）

--- a/apps/bt/src/server/routes/strategies.py
+++ b/apps/bt/src/server/routes/strategies.py
@@ -23,6 +23,7 @@ from src.server.schemas.strategy import (
     StrategyValidationResponse,
 )
 from src.lib.strategy_runtime.loader import ConfigLoader
+from src.lib.strategy_runtime.models import try_validate_strategy_config_dict_strict
 
 router = APIRouter(tags=["Strategies"])
 
@@ -129,6 +130,11 @@ async def validate_strategy(
             config = request.config
         else:
             config = _config_loader.load_strategy_config(strategy_name)
+
+        # 厳密バリデーション（深いネスト未知キー検出を含む）
+        strict_valid, strict_errors = try_validate_strategy_config_dict_strict(config)
+        if not strict_valid:
+            errors.extend(strict_errors)
 
         # 基本的な検証
         if "entry_filter_params" not in config and "exit_trigger_params" not in config:

--- a/apps/bt/src/strategy_config/models.py
+++ b/apps/bt/src/strategy_config/models.py
@@ -3,13 +3,19 @@
 from src.lib.strategy_runtime.models import (
     ExecutionConfig,
     StrategyConfig,
+    StrategyConfigStrictValidationError,
     try_validate_strategy_config_dict,
+    try_validate_strategy_config_dict_strict,
     validate_strategy_config_dict,
+    validate_strategy_config_dict_strict,
 )
 
 __all__ = [
     "ExecutionConfig",
     "StrategyConfig",
+    "StrategyConfigStrictValidationError",
     "validate_strategy_config_dict",
     "try_validate_strategy_config_dict",
+    "validate_strategy_config_dict_strict",
+    "try_validate_strategy_config_dict_strict",
 ]

--- a/apps/bt/src/strategy_config/validator.py
+++ b/apps/bt/src/strategy_config/validator.py
@@ -4,7 +4,9 @@ from typing import Any
 
 from loguru import logger
 
-from src.lib.strategy_runtime.models import try_validate_strategy_config_dict
+from src.lib.strategy_runtime.models import (
+    try_validate_strategy_config_dict_strict as try_validate_strategy_config_dict,
+)
 from src.lib.strategy_runtime.validator import (
     DANGEROUS_PATH_PATTERNS,
     MAX_STRATEGY_NAME_LENGTH,
@@ -29,9 +31,16 @@ def validate_strategy_config(config: dict[str, Any]) -> bool:
     Keep this function in the legacy module so monkeypatch targets like
     `src.strategy_config.validator.try_validate_strategy_config_dict` remain valid.
     """
-    is_valid, error = try_validate_strategy_config_dict(config)
+    is_valid, errors = try_validate_strategy_config_dict(config)
     if not is_valid:
-        logger.error(f"戦略設定バリデーションエラー: {error}")
+        error_messages = (
+            errors
+            if isinstance(errors, list)
+            else [str(errors)] if errors is not None else []
+        )
+        logger.error(
+            "戦略設定バリデーションエラー: {}", "; ".join(error_messages)
+        )
         return False
 
     entry_filter_params = config.get("entry_filter_params", {})

--- a/apps/bt/tests/unit/server/routes/test_strategies.py
+++ b/apps/bt/tests/unit/server/routes/test_strategies.py
@@ -86,6 +86,35 @@ class TestValidateStrategy:
         assert data["valid"] is False
         assert any("kelly_fraction" in e for e in data["errors"])
 
+    def test_strict_nested_typo(self, client, mock_config_loader):
+        with patch("src.lib.backtest_core.runner.BacktestRunner") as mock_runner_cls:
+            mock_runner = MagicMock()
+            mock_runner.get_execution_info.return_value = {}
+            mock_runner_cls.return_value = mock_runner
+            resp = client.post(
+                "/api/strategies/test/validate",
+                json={
+                    "config": {
+                        "entry_filter_params": {
+                            "fundamental": {
+                                "foward_eps_growth": {
+                                    "enabled": True,
+                                    "threshold": 0.2,
+                                    "condition": "above",
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is False
+        assert any(
+            "entry_filter_params.fundamental.foward_eps_growth" in e
+            for e in data["errors"]
+        )
+
 
 class TestUpdateStrategy:
     def test_success(self, client, mock_config_loader):

--- a/apps/ts/bun.lock
+++ b/apps/ts/bun.lock
@@ -71,6 +71,7 @@
         "lucide-react": "^0.539.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-json-view-lite": "^2.5.0",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.7",
       },
@@ -918,6 +919,8 @@
     "react-dom": ["react-dom@19.2.1", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.1" } }, "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-json-view-lite": ["react-json-view-lite@2.5.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 

--- a/apps/ts/packages/web/package.json
+++ b/apps/ts/packages/web/package.json
@@ -34,6 +34,7 @@
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-json-view-lite": "^2.5.0",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.7"
   },

--- a/apps/ts/packages/web/src/components/Backtest/AttributionArtifactBrowser.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/AttributionArtifactBrowser.test.tsx
@@ -75,6 +75,16 @@ describe('AttributionArtifactBrowser', () => {
             strategy: {
               name: strategy,
               yaml_path: '/tmp/strategies/experimental/range_break_v18.yaml',
+              effective_parameters: {
+                entry_filter_params: {
+                  volume: {
+                    enabled: true,
+                    direction: 'surge',
+                    threshold: 1.7,
+                  },
+                },
+                exit_trigger_params: {},
+              },
             },
             runtime: {
               shapley_top_n: 5,
@@ -85,6 +95,18 @@ describe('AttributionArtifactBrowser', () => {
               dataset_name: 'prime_202601',
               market_db: { name: 'market.db' },
               portfolio_db: { name: 'portfolio.db' },
+            },
+            result: {
+              top_n_selection: {
+                scores: [{ signal_id: 'entry.volume', score: 0.8924636742 }],
+              },
+              signals: [
+                {
+                  signal_id: 'entry.volume',
+                  scope: 'entry',
+                  signal_name: '出来高',
+                },
+              ],
             },
           },
         },
@@ -100,7 +122,10 @@ describe('AttributionArtifactBrowser', () => {
     expect(screen.getByText('/tmp/strategies/experimental/range_break_v18.yaml')).toBeInTheDocument();
     expect(screen.getByText('prime_202601')).toBeInTheDocument();
     expect(screen.getByText('portfolio.db')).toBeInTheDocument();
-    expect(screen.getByText('JSON').nextElementSibling).toHaveTextContent(/"shapley_top_n":\s*5/);
+    expect(screen.getByText('Best Signal Parameters')).toBeInTheDocument();
+    expect(screen.getByText('entry.volume')).toBeInTheDocument();
+    expect(screen.getByText('Top-N Score')).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('saved_at'))).toBeInTheDocument();
     expect(screen.getByText((content) => /2\.0\s*KB/.test(content))).toBeInTheDocument();
   });
 
@@ -131,5 +156,97 @@ describe('AttributionArtifactBrowser', () => {
     const { container } = render(<AttributionArtifactBrowser />);
     await user.click(screen.getByText('attribution_20260112_120000_job-1.json'));
     expect(container.querySelector('svg.animate-spin')).toBeInTheDocument();
+  });
+
+  it('filters files by search query and shows total count hint', async () => {
+    const user = userEvent.setup();
+    mockUseAttributionArtifactFiles.mockReturnValue({
+      data: {
+        files: [
+          {
+            strategy_name: 'experimental/range_break_v18',
+            filename: 'attribution_20260112_120000_job-1.json',
+            created_at: '2026-01-12T12:00:00Z',
+            size_bytes: 2048,
+            job_id: 'job-1',
+          },
+          {
+            strategy_name: 'experimental/range_break_v18',
+            filename: 'attribution_20260112_120100_job-2.json',
+            created_at: '2026-01-12T12:01:00Z',
+            size_bytes: 2048,
+            job_id: 'job-2',
+          },
+        ],
+        total: 10,
+      },
+      isLoading: false,
+    });
+
+    render(<AttributionArtifactBrowser />);
+
+    expect(screen.getByText('2 files (10 total)')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('Search attribution artifacts...'), 'job-1');
+
+    expect(screen.getByText('attribution_20260112_120000_job-1.json')).toBeInTheDocument();
+    expect(screen.queryByText('attribution_20260112_120100_job-2.json')).not.toBeInTheDocument();
+  });
+
+  it('handles unresolved best signal parameter and non-object artifact safely', async () => {
+    const user = userEvent.setup();
+    mockUseAttributionArtifactFiles.mockReturnValue({
+      data: {
+        files: [
+          {
+            strategy_name: 'experimental/range_break_v18',
+            filename: 'attribution_20260112_120000_job-1.json',
+            created_at: '2026-01-12T12:00:00Z',
+            size_bytes: 2 * 1024 * 1024,
+            job_id: 'job-1',
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+    });
+    mockUseAttributionArtifactContent.mockImplementation((strategy: string | null, filename: string | null) => {
+      if (!strategy || !filename) {
+        return { data: null, isLoading: false };
+      }
+      return {
+        data: {
+          artifact: {
+            strategy: {
+              name: strategy,
+              effective_parameters: {
+                entry_filter_params: {},
+              },
+            },
+            runtime: {
+              random_seed: 'not-number',
+            },
+            result: {
+              top_n_selection: {
+                scores: [
+                  { signal_id: 'entry.unknown_param', score: 0.9 },
+                  { signal_id: 'entry.volume', score: 0.1 },
+                ],
+              },
+              signals: [],
+            },
+          },
+        },
+        isLoading: false,
+      };
+    });
+
+    render(<AttributionArtifactBrowser />);
+
+    await user.click(screen.getByText('attribution_20260112_120000_job-1.json'));
+
+    expect(screen.getByText('Best Signal Parameters')).toBeInTheDocument();
+    expect(screen.getByText('entry.unknown_param')).toBeInTheDocument();
+    expect(screen.getByText((content) => /2\.0\s*MB/.test(content))).toBeInTheDocument();
+    expect(screen.getByText('Random Seed')).toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/Backtest/StrategyEditor.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/StrategyEditor.test.tsx
@@ -1,0 +1,263 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StrategyEditor } from './StrategyEditor';
+
+const mockValidateMutateAsync = vi.fn();
+const mockValidateReset = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockUpdateReset = vi.fn();
+
+const mockBacktestHooks = {
+  strategyData: {
+    config: {
+      entry_filter_params: {
+        volume: {
+          enabled: true,
+        },
+      },
+    },
+  } as { config: Record<string, unknown> } | null,
+  isLoadingStrategy: false,
+  validatePending: false,
+  updatePending: false,
+  updateError: null as Error | null,
+};
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useStrategy: () => ({
+    data: mockBacktestHooks.strategyData,
+    isLoading: mockBacktestHooks.isLoadingStrategy,
+  }),
+  useValidateStrategy: () => ({
+    mutateAsync: mockValidateMutateAsync,
+    isPending: mockBacktestHooks.validatePending,
+    reset: mockValidateReset,
+  }),
+  useUpdateStrategy: () => ({
+    mutate: mockUpdateMutate,
+    isPending: mockBacktestHooks.updatePending,
+    isError: !!mockBacktestHooks.updateError,
+    error: mockBacktestHooks.updateError,
+    reset: mockUpdateReset,
+  }),
+}));
+
+vi.mock('@/components/Editor/MonacoYamlEditor', () => ({
+  MonacoYamlEditor: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="YAML Editor"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: ReactNode;
+  }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    variant,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled} data-variant={variant}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('./SignalReferencePanel', () => ({
+  SignalReferencePanel: () => <div>Signal Reference</div>,
+}));
+
+describe('StrategyEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBacktestHooks.strategyData = {
+      config: {
+        entry_filter_params: {
+          volume: {
+            enabled: true,
+          },
+        },
+      },
+    };
+    mockBacktestHooks.isLoadingStrategy = false;
+    mockBacktestHooks.validatePending = false;
+    mockBacktestHooks.updatePending = false;
+    mockBacktestHooks.updateError = null;
+    mockValidateMutateAsync.mockResolvedValue({
+      valid: true,
+      errors: [],
+      warnings: [],
+    });
+  });
+
+  it('blocks save when backend validation reports errors', async () => {
+    const user = userEvent.setup();
+    mockValidateMutateAsync.mockResolvedValueOnce({
+      valid: false,
+      errors: ['entry_filter_params.fundamental.foward_eps_growth is not a valid parameter name'],
+      warnings: [],
+    });
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value).toContain('entry_filter_params');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockValidateMutateAsync).toHaveBeenCalledWith({
+      name: 'experimental/sample',
+      request: expect.objectContaining({
+        config: expect.any(Object),
+      }),
+    });
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText('entry_filter_params.fundamental.foward_eps_growth is not a valid parameter name')
+    ).toBeInTheDocument();
+  });
+
+  it('blocks save when backend validation request fails', async () => {
+    const user = userEvent.setup();
+    mockValidateMutateAsync.mockRejectedValueOnce(new Error('network down'));
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value).toContain('entry_filter_params');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+    expect(await screen.findByText('Validation request failed: network down')).toBeInTheDocument();
+  });
+
+  it('shows parse error and skips backend validation when YAML is invalid', async () => {
+    const user = userEvent.setup();
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value).toContain('entry_filter_params');
+    });
+
+    await user.clear(screen.getByLabelText('YAML Editor'));
+    fireEvent.change(screen.getByLabelText('YAML Editor'), {
+      target: { value: '{invalid' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(mockValidateMutateAsync).not.toHaveBeenCalled();
+    expect(await screen.findByText(/YAML parse error:/)).toBeInTheDocument();
+  });
+
+  it('shows validation passed with warnings from backend response', async () => {
+    const user = userEvent.setup();
+    mockValidateMutateAsync.mockResolvedValueOnce({
+      valid: true,
+      errors: [],
+      warnings: ['signal reference stale'],
+    });
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await user.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Validation passed with warnings')).toBeInTheDocument();
+    expect(screen.getByText('signal reference stale')).toBeInTheDocument();
+  });
+
+  it('saves when backend validation passes', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn();
+    mockUpdateMutate.mockImplementation((_payload, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(
+      <StrategyEditor
+        open
+        onOpenChange={onOpenChange}
+        strategyName="experimental/sample"
+        onSuccess={onSuccess}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockValidateMutateAsync).toHaveBeenCalled();
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      {
+        name: 'experimental/sample',
+        request: expect.objectContaining({
+          config: expect.any(Object),
+        }),
+      },
+      expect.any(Object)
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('calls reset handlers on cancel', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(<StrategyEditor open onOpenChange={onOpenChange} strategyName="experimental/sample" />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockValidateReset).toHaveBeenCalled();
+    expect(mockUpdateReset).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders loading state', () => {
+    mockBacktestHooks.isLoadingStrategy = true;
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    expect(screen.queryByLabelText('YAML Editor')).not.toBeInTheDocument();
+  });
+
+  it('renders update error banner', () => {
+    mockBacktestHooks.updateError = new Error('update failed');
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    expect(screen.getByText('Error: update failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
+++ b/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
@@ -1,3 +1,4 @@
+import yaml from 'js-yaml';
 import type { SignalDefinition, SignalFieldDefinition } from '@/types/backtest';
 
 export interface StrategyValidationResult {
@@ -40,6 +41,134 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function isNumericConstraint(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
+}
+
+type FundamentalSpec = {
+  childFieldMap: Map<string, Map<string, SignalFieldDefinition>>;
+  parentFieldMap: Map<string, SignalFieldDefinition>;
+};
+
+const FUNDAMENTAL_PARENT_FIELD_FALLBACK = ['enabled', 'period_type', 'use_adjusted'];
+
+function extractFundamentalParentFieldNames(fundamentalDefs: SignalDefinition[]): string[] {
+  let inferredParentFields: Set<string> | null = null;
+
+  for (const signal of fundamentalDefs) {
+    try {
+      const parsed = yaml.load(signal.yaml_snippet);
+      const parsedRecord = isPlainObject(parsed) ? parsed : null;
+      const snippetRoot =
+        parsedRecord && isPlainObject(parsedRecord.fundamental)
+          ? parsedRecord.fundamental
+          : null;
+      const childKey = signal.key.replace(/^fundamental_/, '');
+      const currentParentFields = new Set(
+        snippetRoot ? Object.keys(snippetRoot).filter((key) => key !== childKey) : []
+      );
+
+      if (currentParentFields.size === 0) {
+        continue;
+      }
+      if (!inferredParentFields) {
+        inferredParentFields = currentParentFields;
+        continue;
+      }
+      inferredParentFields = new Set(
+        [...inferredParentFields].filter((fieldName) => currentParentFields.has(fieldName))
+      );
+    } catch {
+      // Ignore snippet parse failures and fall back to known parent fields.
+    }
+  }
+
+  if (inferredParentFields && inferredParentFields.size > 0) {
+    return [...inferredParentFields];
+  }
+
+  return FUNDAMENTAL_PARENT_FIELD_FALLBACK.filter((fieldName) =>
+    fundamentalDefs.every((signal) => signal.fields.some((field) => field.name === fieldName))
+  );
+}
+
+function buildFundamentalSpec(signalDefinitions: SignalDefinition[]): FundamentalSpec {
+  const fundamentalDefs = signalDefinitions.filter((signal) => signal.key.startsWith('fundamental_'));
+  const childFieldMaps = fundamentalDefs.map((signal) => new Map(signal.fields.map((field) => [field.name, field])));
+
+  const parentFieldNames = extractFundamentalParentFieldNames(fundamentalDefs);
+
+  const parentFieldMap = new Map<string, SignalFieldDefinition>();
+  const firstChildFieldMap = childFieldMaps[0];
+  for (const fieldName of parentFieldNames) {
+    const field = firstChildFieldMap?.get(fieldName);
+    if (field) {
+      parentFieldMap.set(fieldName, field);
+    }
+  }
+
+  const childFieldMap = new Map<string, Map<string, SignalFieldDefinition>>();
+  for (const signal of fundamentalDefs) {
+    const rawChildKey = signal.key.replace(/^fundamental_/, '');
+    const childFields = new Map(signal.fields.map((field) => [field.name, field]));
+    for (const parentFieldName of parentFieldNames) {
+      if (parentFieldName !== 'enabled') {
+        childFields.delete(parentFieldName);
+      }
+    }
+    childFieldMap.set(rawChildKey, childFields);
+  }
+
+  return {
+    childFieldMap,
+    parentFieldMap,
+  };
+}
+
+function validateFundamentalSection(
+  sectionName: 'entry_filter_params' | 'exit_trigger_params',
+  signalKey: string,
+  signalConfig: unknown,
+  spec: FundamentalSpec,
+  errors: string[]
+): void {
+  if (!isPlainObject(signalConfig)) {
+    errors.push(`${sectionName}.${signalKey} must be an object`);
+    return;
+  }
+
+  const allowedFundamentalKeys = new Set([...spec.parentFieldMap.keys(), ...spec.childFieldMap.keys()]);
+
+  for (const [fundamentalKey, fundamentalValue] of Object.entries(signalConfig)) {
+    if (!allowedFundamentalKeys.has(fundamentalKey)) {
+      errors.push(`${sectionName}.${signalKey}.${fundamentalKey} is not a valid parameter name`);
+      continue;
+    }
+
+    const parentFieldDef = spec.parentFieldMap.get(fundamentalKey);
+    if (parentFieldDef) {
+      validateFieldValue(sectionName, signalKey, parentFieldDef, fundamentalValue, errors);
+      continue;
+    }
+
+    const childFieldDefs = spec.childFieldMap.get(fundamentalKey);
+    if (!childFieldDefs) {
+      errors.push(`${sectionName}.${signalKey}.${fundamentalKey} is not a valid parameter name`);
+      continue;
+    }
+
+    if (!isPlainObject(fundamentalValue)) {
+      errors.push(`${sectionName}.${signalKey}.${fundamentalKey} must be an object`);
+      continue;
+    }
+
+    for (const [fieldName, fieldValue] of Object.entries(fundamentalValue)) {
+      const childFieldDef = childFieldDefs.get(fieldName);
+      if (!childFieldDef) {
+        errors.push(`${sectionName}.${signalKey}.${fundamentalKey}.${fieldName} is not a valid parameter name`);
+        continue;
+      }
+      validateFieldValue(sectionName, `${signalKey}.${fundamentalKey}`, childFieldDef, fieldValue, errors);
+    }
+  }
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Validation logic needs explicit branch handling
@@ -112,13 +241,13 @@ function validateSignalSection(
   }
 
   const signalMap = new Map(signalDefinitions.map((signal) => [signal.key, signal]));
+  let fundamentalSpec: FundamentalSpec | null = null;
 
   for (const [signalKey, signalConfig] of Object.entries(sectionValue)) {
-    // fundamentalは子シグナル構造（per/roe/...)を持つため、トップレベル名の検証は除外
+    // fundamental は子シグナル構造（per/roe/...)を持つため専用検証を行う
     if (signalKey === 'fundamental') {
-      if (!isPlainObject(signalConfig)) {
-        errors.push(`${sectionName}.${signalKey} must be an object`);
-      }
+      fundamentalSpec ??= buildFundamentalSpec(signalDefinitions);
+      validateFundamentalSection(sectionName, signalKey, signalConfig, fundamentalSpec, errors);
       continue;
     }
 
@@ -146,6 +275,10 @@ function validateSignalSection(
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Validation combines schema/key/type/range checks in one pass
+/**
+ * @deprecated Backend strict validation (`/api/strategies/{name}/validate`) is the source of truth.
+ * Keep this only for temporary compatibility and tests.
+ */
 export function validateStrategyConfigLocally(
   config: Record<string, unknown>,
   signalDefinitions: SignalDefinition[]
@@ -200,6 +333,9 @@ export function validateStrategyConfigLocally(
   };
 }
 
+/**
+ * @deprecated Use backend validation response directly when possible.
+ */
 export function mergeValidationResults(
   ...results: Array<StrategyValidationResult | null | undefined>
 ): StrategyValidationResult | null {

--- a/issues/done/ts-128-strategy-editor-local-validation-deprecate.md
+++ b/issues/done/ts-128-strategy-editor-local-validation-deprecate.md
@@ -1,0 +1,44 @@
+---
+id: ts-128
+title: Strategy Editor local validation deprecate
+status: done
+priority: medium
+labels: [web, validation, backtest]
+project: ts
+created: 2026-02-13
+updated: 2026-02-13
+depends_on: []
+blocks: []
+parent: null
+---
+
+# ts-128 Strategy Editor local validation deprecate
+
+## 目的
+- Strategy Editor で backend strict validation が導入されたため、frontend の重複ローカル検証を整理し、検証ロジックの単一責務を backend に寄せる。
+
+## 受け入れ条件
+- `StrategyEditor` の保存/検証時判定が backend `/api/strategies/{name}/validate` を正として動作する。
+- frontend 側 `strategyValidation.ts` は削除または `@deprecated` 明示のどちらかに統一される。
+- UX 劣化（エラーメッセージ遅延、保存可否判定の不整合）がないことをテストで確認する。
+- ドキュメントまたはコードコメントで「検証の責務は backend」を明示する。
+
+## 実施内容
+- [x] 現状の `validateStrategyConfigLocally` 呼び出し箇所を整理し、削除/縮退方針を決める。
+- [x] `StrategyEditor` のバリデーションフローを backend 優先へ一本化する。
+- [x] 必要に応じてローカル側は YAML parse と最小限の型ガードのみに限定する。
+- [x] `strategyValidation` のテストを更新し、不要テストを削除する。
+- [x] E2E or component test で typo（例: `foward_eps_growth`）の検出が backend 経由で維持されることを確認する。
+
+## 結果
+- `StrategyEditor` から `validateStrategyConfigLocally` / `mergeValidationResults` の依存を削除し、保存/検証の判定源を backend `/api/strategies/{name}/validate` に一本化。
+- ローカル側は YAML parse（オブジェクト判定）だけを継続。
+- backend 検証リクエスト失敗時は `Validation request failed: ...` を UI 表示し、保存を停止。
+- `strategyValidation.ts` に `@deprecated` を追加し、backend が source of truth である旨を明記。
+- 追加テスト:
+  - `apps/ts/packages/web/src/components/Backtest/StrategyEditor.test.tsx`
+  - backend validation NG時/通信失敗時に保存されないことを検証。
+
+## 補足
+- backend strict validation は実装済み（`/api/strategies/{name}/validate` と保存経路で適用）。
+- 本Issueは frontend 側の重複検証整理に限定する。

--- a/issues/ts-014c-coverage-cli-90-90.md
+++ b/issues/ts-014c-coverage-cli-90-90.md
@@ -3,12 +3,13 @@ id: ts-014c
 title: "Coverage Gate: cli 90/90"
 status: open
 priority: medium
-labels: [test]
+labels: [test, coverage]
 project: ts
 created: 2026-01-31
-updated: 2026-01-31
-depends_on: []
+updated: 2026-02-13
+depends_on: [ts-113]
 blocks: []
+parent: ts-129
 ---
 
 # ts-014c Coverage Gate: cli 90/90
@@ -29,3 +30,7 @@ blocks: []
 
 ## 受け入れ条件
 - `bun run check:coverage` が新閾値で通る
+
+## 整理メモ
+- `ts-113`（CLI 70/70）を先行タスクとして依存関係を設定。
+- 本Issueは CLI coverage の最終ストレッチ（90/90）として管理する。

--- a/issues/ts-111-coverage-shared-80-80.md
+++ b/issues/ts-111-coverage-shared-80-80.md
@@ -3,12 +3,13 @@ id: ts-111
 title: "Coverage Gate: shared 80/80"
 status: open
 priority: medium
-labels: [test]
+labels: [test, coverage]
 project: ts
 created: 2026-02-01
-updated: 2026-02-01
+updated: 2026-02-13
 depends_on: []
 blocks: []
+parent: ts-129
 ---
 
 # ts-111 Coverage Gate: shared 80/80
@@ -27,3 +28,6 @@ blocks: []
 ## 受け入れ条件
 - `bun run test` 全パス
 - `bun run check:coverage` が新閾値で通る
+
+## 整理メモ
+- coverage backlog 整理用の親Issue: `ts-129`

--- a/issues/ts-113-coverage-cli-70-70.md
+++ b/issues/ts-113-coverage-cli-70-70.md
@@ -3,12 +3,13 @@ id: ts-113
 title: "Coverage Gate: cli 70/70"
 status: open
 priority: medium
-labels: [test]
+labels: [test, coverage]
 project: ts
 created: 2026-02-01
-updated: 2026-02-01
+updated: 2026-02-13
 depends_on: []
-blocks: []
+blocks: [ts-014c]
+parent: ts-129
 ---
 
 # ts-113 Coverage Gate: cli 70/70
@@ -26,3 +27,6 @@ blocks: []
 ## 受け入れ条件
 - `bun run test` 全パス
 - `bun run check:coverage` が新閾値で通る
+
+## 整理メモ
+- `ts-014c`（CLI 90/90）は本Issue（70/70）達成後のストレッチ目標として扱う。

--- a/issues/ts-114-coverage-web-45-70.md
+++ b/issues/ts-114-coverage-web-45-70.md
@@ -3,12 +3,13 @@ id: ts-114
 title: "Coverage Gate: web 45/70"
 status: open
 priority: medium
-labels: [test]
+labels: [test, coverage]
 project: ts
 created: 2026-02-01
-updated: 2026-02-01
+updated: 2026-02-13
 depends_on: []
 blocks: []
+parent: ts-129
 ---
 
 # ts-114 Coverage Gate: web 45/70
@@ -32,3 +33,6 @@ blocks: []
 ## 受け入れ条件
 - `bun run test` 全パス
 - `bun run check:coverage` が新閾値で通る
+
+## 整理メモ
+- coverage backlog 整理用の親Issue: `ts-129`

--- a/issues/ts-129-coverage-backlog-reorg.md
+++ b/issues/ts-129-coverage-backlog-reorg.md
@@ -1,0 +1,54 @@
+---
+id: ts-129
+title: Coverage backlog reorganization
+status: open
+priority: medium
+labels: [test, coverage, maintenance]
+project: ts
+created: 2026-02-13
+updated: 2026-02-13
+depends_on: [ts-111, ts-113, ts-114, ts-014c]
+blocks: []
+parent: null
+---
+
+# ts-129 Coverage backlog reorganization
+
+## 目的
+- 既存の coverage 関連Issue（open/done）を棚卸しし、重複や依存関係の曖昧さを解消する。
+- 今後の実行順序が迷わない状態に整理する。
+
+## 対象（open）
+- `ts-111` shared 80/80
+- `ts-113` cli 70/70
+- `ts-114` web 45/70
+- `ts-014c` cli 90/90（stretch）
+
+## 整理方針
+- CLI は段階目標として管理:
+  - `ts-113` (70/70) → `ts-014c` (90/90)
+- shared/web は独立タスクとして並行可能:
+  - `ts-111`, `ts-114`
+- 上記4件を本Issueの子タスクとして統合管理する。
+
+## 受け入れ条件
+- coverage関連の open Issue に parent/depends_on/blocks が反映されている。
+- CLI の段階目標（70/70 → 90/90）の依存関係が明文化されている。
+- 既存 done Issue は履歴として維持し、open の重複管理がない状態になっている。
+
+## 実施内容
+- [x] coverage関連 open Issue の棚卸し
+- [x] `ts-111/113/114/014c` の frontmatter を統一（labels/updated/parent）
+- [x] CLI 目標の依存関係（`ts-113` blocks `ts-014c`、`ts-014c` depends_on `ts-113`）を設定
+- [ ] done履歴の `status: closed` を `done/wontfix` へ正規化（必要時）
+- [ ] 実測カバレッジを採取し、優先順位（shared/web/cli）を再評価
+
+## 結果
+- 進行中
+
+## 補足
+- done 履歴（coverage系）:
+  - `ts-001a` `ts-001b` `ts-001c` `ts-001d` `ts-001e`
+  - `ts-014a` `ts-014b` `ts-014d`
+  - `ts-112` `ts-117`
+  - `bt-015` `bt-016`


### PR DESCRIPTION
## Summary\n- enforce strict nested parameter validation on backend strategy validate/save paths\n- make Strategy Editor rely on backend validation as source of truth and add resilience for validation request failures\n- improve attribution artifact UX with rich JSON viewer and best-parameter display\n- reorganize local coverage issues under a parent backlog issue and close ts-128\n- document validation source-of-truth in AGENTS.md\n\n## Testing\n- bun run --filter @trading25/web typecheck\n- bun run --filter @trading25/web test src/components/Backtest/StrategyEditor.test.tsx src/components/Backtest/strategyValidation.test.ts src/components/Backtest/AttributionArtifactBrowser.test.tsx\n- bun run --filter @trading25/web test:coverage -- src/components/Backtest/StrategyEditor.test.tsx src/components/Backtest/strategyValidation.test.ts --coverage.include=src/components/Backtest/StrategyEditor.tsx --coverage.include=src/components/Backtest/strategyValidation.ts --coverage.reporter=text\n- uv run --project apps/bt pytest apps/bt/tests/unit/strategy_config/test_models.py apps/bt/tests/unit/strategy_config/test_loader.py apps/bt/tests/unit/server/routes/test_strategies.py\n- bunx --bun biome check apps/ts/packages/web/src/components/Backtest/StrategyEditor.tsx apps/ts/packages/web/src/components/Backtest/StrategyEditor.test.tsx apps/ts/packages/web/src/components/Backtest/strategyValidation.ts apps/ts/packages/web/src/components/Backtest/strategyValidation.test.ts\n\n## Notes\n- pytest-cov invocation for targeted backend module coverage intermittently failed at import-time in this environment; coverage for frontend target modules is included and meets 80/80 line/branch.