### PR TITLE
fix(bt): restore sortino in backtest html key metrics

### DIFF
--- a/apps/bt/notebooks/templates/marimo/strategy_analysis.py
+++ b/apps/bt/notebooks/templates/marimo/strategy_analysis.py
@@ -574,8 +574,10 @@ def export_metrics_json(json, Path, pd, kelly_portfolio, allocation_info, output
             metrics["total_return"] = _extract_stat(stats, "Total Return [%]")
             metrics["max_drawdown"] = _extract_stat(stats, "Max Drawdown [%]")
             metrics["sharpe_ratio"] = _extract_stat(stats, "Sharpe Ratio")
+            metrics["sortino_ratio"] = _extract_stat(stats, "Sortino Ratio")
             metrics["calmar_ratio"] = _extract_stat(stats, "Calmar Ratio")
             metrics["win_rate"] = _extract_stat(stats, "Win Rate [%]")
+            metrics["profit_factor"] = _extract_stat(stats, "Profit Factor")
             total_trades = _extract_stat(stats, "Total Trades")
             metrics["total_trades"] = int(total_trades) if total_trades is not None else None
 


### PR DESCRIPTION
## Summary
- fix extraction fallback to fill missing metrics from HTML when .metrics.json lacks fields
- add sortino_ratio and profit_factor to metrics JSON export from strategy analysis template
- add regression test for JSON-partial + HTML fallback path

## Verification
- uv run --project apps/bt pytest apps/bt/tests/unit/data/test_metrics_extractor.py -q
- uv run --project apps/bt ruff check apps/bt/src/data/metrics_extractor.py apps/bt/tests/unit/data/test_metrics_extractor.py apps/bt/notebooks/templates/marimo/strategy_analysis.py
- uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/data/test_metrics_extractor.py -q
- uv run --project apps/bt coverage report -m apps/bt/src/data/metrics_extractor.py (95% line / 90% branch)