### PR TITLE
feat: support fundamental-only filters in lab generate/improve

### DIFF
--- a/.codex/skills/bt-agent-system/SKILL.md
+++ b/.codex/skills/bt-agent-system/SKILL.md
@@ -21,3 +21,9 @@ description: bt の戦略自動生成・進化最適化（agent/lab 系）を扱
 
 - API 契約は OpenAPI を正とする。
 - `uv run bt server --port 3002` 前提を崩さない。
+
+## Lab Constraints
+
+- `bt lab generate` は `--entry-filter-only` と `--allowed-category` を受け付ける。
+- `bt lab improve` も同様に `--entry-filter-only` と `--allowed-category` を受け付ける。
+- API は `/api/lab/generate` と `/api/lab/improve` の `entry_filter_only`, `allowed_categories` を SoT とする。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ FastAPI サーバー（:3002）とtyper CLI を提供。
 uv sync                          # 環境セットアップ
 uv run bt server --port 3002     # APIサーバー起動
 uv run bt backtest <strategy>    # バックテスト実行
+uv run bt lab generate --entry-filter-only --allowed-category fundamental
+uv run bt lab improve <strategy> --entry-filter-only --allowed-category fundamental
 uv run pytest tests/             # テスト
 uv run ruff check src/           # リント
 uv run pyright src/              # 型チェック

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ bun run cli backtest attribution cancel <job-id>
 ```
 - 保存先（XDG）: `~/.local/share/trading25/backtest/attribution/<strategy>/`
 
+### 4) Lab（fundamental 制約付き生成/改善）
+```bash
+cd apps/bt
+uv run bt lab generate --count 50 --top 5 --entry-filter-only --allowed-category fundamental
+uv run bt lab improve experimental/base_strategy_01 --entry-filter-only --allowed-category fundamental --no-apply
+```
+- API では `/api/lab/generate` と `/api/lab/improve` に `entry_filter_only` と `allowed_categories` を指定可能
+
 ## Monorepo Commands (root)
 
 ```bash

--- a/apps/bt/src/agent/models.py
+++ b/apps/bt/src/agent/models.py
@@ -4,9 +4,20 @@
 戦略生成・最適化・改善に必要なデータ構造を型安全に管理
 """
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+SignalCategory = Literal[
+    "breakout",
+    "trend",
+    "oscillator",
+    "volatility",
+    "volume",
+    "macro",
+    "fundamental",
+    "sector",
+]
 
 
 class SignalConstraints(BaseModel):
@@ -26,6 +37,12 @@ class SignalConstraints(BaseModel):
 
     # Entryのみ/Exitのみ/両用
     usage: str = Field(default="both", description="entry/exit/both")
+
+    # シグナルカテゴリ（制約指定用）
+    category: SignalCategory = Field(
+        default="breakout",
+        description="signal category",
+    )
 
 
 class GeneratorConfig(BaseModel):
@@ -50,6 +67,12 @@ class GeneratorConfig(BaseModel):
 
     # 必須シグナル（必ず含める）
     required_signals: list[str] = Field(default_factory=list)
+
+    # Entryフィルターのみ生成（Exitは空）
+    entry_filter_only: bool = Field(default=False)
+
+    # 許可カテゴリ（空なら全カテゴリ許可）
+    allowed_categories: list[SignalCategory] = Field(default_factory=list)
 
 
 class EvolutionConfig(BaseModel):

--- a/apps/bt/src/server/routes/lab.py
+++ b/apps/bt/src/server/routes/lab.py
@@ -119,6 +119,8 @@ async def run_lab_generate(request: LabGenerateRequest) -> LabJobResponse:
             "direction": request.direction,
             "timeframe": request.timeframe,
             "dataset": request.dataset,
+            "entry_filter_only": request.entry_filter_only,
+            "allowed_categories": request.allowed_categories,
         },
         error_label="generate",
     )
@@ -163,6 +165,8 @@ async def run_lab_improve(request: LabImproveRequest) -> LabJobResponse:
         {
             "strategy_name": request.strategy_name,
             "auto_apply": request.auto_apply,
+            "entry_filter_only": request.entry_filter_only,
+            "allowed_categories": request.allowed_categories,
         },
         error_label="improve",
     )

--- a/apps/bt/src/server/schemas/lab.py
+++ b/apps/bt/src/server/schemas/lab.py
@@ -10,6 +10,17 @@ from pydantic import BaseModel, Field
 
 from src.server.schemas.common import BaseJobResponse
 
+LabSignalCategory = Literal[
+    "breakout",
+    "trend",
+    "oscillator",
+    "volatility",
+    "volume",
+    "macro",
+    "fundamental",
+    "sector",
+]
+
 
 # ============================================
 # Request Models
@@ -28,6 +39,14 @@ class LabGenerateRequest(BaseModel):
     )
     timeframe: Literal["daily", "weekly"] = Field(default="daily", description="タイムフレーム")
     dataset: str = Field(default="primeExTopix500", description="データセット名")
+    entry_filter_only: bool = Field(
+        default=False,
+        description="Entryフィルターのみ生成（Exitシグナルを生成しない）",
+    )
+    allowed_categories: list[LabSignalCategory] | None = Field(
+        default=None,
+        description="許可するシグナルカテゴリ（未指定時は全カテゴリ）",
+    )
 
 
 class LabEvolveRequest(BaseModel):
@@ -56,6 +75,14 @@ class LabImproveRequest(BaseModel):
 
     strategy_name: str = Field(..., min_length=1, description="改善対象の戦略名")
     auto_apply: bool = Field(default=True, description="改善を自動適用")
+    entry_filter_only: bool = Field(
+        default=False,
+        description="Entryフィルターの改善のみを許可",
+    )
+    allowed_categories: list[LabSignalCategory] | None = Field(
+        default=None,
+        description="改善対象として許可するカテゴリ（未指定時は全カテゴリ）",
+    )
 
 
 # ============================================

--- a/apps/bt/tests/unit/agent/test_models.py
+++ b/apps/bt/tests/unit/agent/test_models.py
@@ -29,6 +29,8 @@ class TestGeneratorConfig:
         assert config.exit_signal_min == 2
         assert config.exit_signal_max == 4
         assert config.seed is None
+        assert config.entry_filter_only is False
+        assert config.allowed_categories == []
 
     def test_custom_values(self):
         """カスタム値が正しく設定されることを確認"""
@@ -37,10 +39,14 @@ class TestGeneratorConfig:
             entry_signal_min=3,
             entry_signal_max=4,
             seed=42,
+            entry_filter_only=True,
+            allowed_categories=["fundamental"],
         )
         assert config.n_strategies == 50
         assert config.entry_signal_min == 3
         assert config.seed == 42
+        assert config.entry_filter_only is True
+        assert config.allowed_categories == ["fundamental"]
 
     def test_validation_n_strategies_min(self):
         """n_strategies の最小値バリデーション"""

--- a/apps/bt/tests/unit/cli_bt/test_lab_cli.py
+++ b/apps/bt/tests/unit/cli_bt/test_lab_cli.py
@@ -1,5 +1,6 @@
 """lab CLI コマンドのテスト"""
 
+import re
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -7,6 +8,11 @@ from typer.testing import CliRunner
 from src.cli_bt import app
 
 runner = CliRunner()
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
 
 
 def _make_eval_result() -> MagicMock:
@@ -88,8 +94,9 @@ def test_lab_generate_rejects_invalid_timeframe() -> None:
 def test_lab_generate_help_includes_new_options() -> None:
     result = runner.invoke(app, ["lab", "generate", "--help"])
     assert result.exit_code == 0
-    assert "--entry-filter-only" in result.stdout
-    assert "--allowed-category" in result.stdout
+    output = _strip_ansi(result.stdout)
+    assert "--entry-filter-only" in output
+    assert "--allowed-category" in output
 
 
 def test_lab_evolve_command_runs() -> None:
@@ -322,5 +329,6 @@ def test_lab_improve_renders_details_and_auto_applies() -> None:
 def test_lab_improve_help_includes_new_options() -> None:
     result = runner.invoke(app, ["lab", "improve", "--help"])
     assert result.exit_code == 0
-    assert "--entry-filter-only" in result.stdout
-    assert "--allowed-category" in result.stdout
+    output = _strip_ansi(result.stdout)
+    assert "--entry-filter-only" in output
+    assert "--allowed-category" in output

--- a/apps/bt/tests/unit/cli_bt/test_lab_cli.py
+++ b/apps/bt/tests/unit/cli_bt/test_lab_cli.py
@@ -1,0 +1,326 @@
+"""lab CLI コマンドのテスト"""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from src.cli_bt import app
+
+runner = CliRunner()
+
+
+def _make_eval_result() -> MagicMock:
+    candidate = MagicMock()
+    candidate.strategy_id = "auto_test"
+    candidate.shared_config = {}
+
+    result = MagicMock()
+    result.success = True
+    result.candidate = candidate
+    result.score = 1.2
+    result.sharpe_ratio = 1.0
+    result.calmar_ratio = 0.8
+    result.total_return = 0.12
+    result.max_drawdown = -0.05
+    return result
+
+
+def test_lab_generate_accepts_fundamental_constraints() -> None:
+    with (
+        patch("src.agent.StrategyGenerator") as MockGenerator,
+        patch("src.agent.StrategyEvaluator") as MockEvaluator,
+    ):
+        MockGenerator.return_value.generate.return_value = [MagicMock()]
+        MockEvaluator.return_value.evaluate_batch.return_value = [_make_eval_result()]
+
+        result = runner.invoke(
+            app,
+            [
+                "lab",
+                "generate",
+                "--count",
+                "5",
+                "--top",
+                "1",
+                "--entry-filter-only",
+                "--allowed-category",
+                "fundamental",
+                "--no-save",
+            ],
+        )
+
+    assert result.exit_code == 0
+    config = MockGenerator.call_args.kwargs["config"]
+    assert config.entry_filter_only is True
+    assert config.allowed_categories == ["fundamental"]
+
+
+def test_lab_generate_rejects_invalid_category() -> None:
+    result = runner.invoke(
+        app,
+        ["lab", "generate", "--allowed-category", "invalid"],
+    )
+
+    assert result.exit_code == 1
+    assert "無効な --allowed-category" in result.stdout
+
+
+def test_lab_generate_rejects_invalid_direction() -> None:
+    result = runner.invoke(
+        app,
+        ["lab", "generate", "--direction", "invalid"],
+    )
+
+    assert result.exit_code == 1
+    assert "--direction は" in result.stdout
+
+
+def test_lab_generate_rejects_invalid_timeframe() -> None:
+    result = runner.invoke(
+        app,
+        ["lab", "generate", "--timeframe", "monthly"],
+    )
+
+    assert result.exit_code == 1
+    assert "--timeframe は" in result.stdout
+
+
+def test_lab_generate_help_includes_new_options() -> None:
+    result = runner.invoke(app, ["lab", "generate", "--help"])
+    assert result.exit_code == 0
+    assert "--entry-filter-only" in result.stdout
+    assert "--allowed-category" in result.stdout
+
+
+def test_lab_evolve_command_runs() -> None:
+    with (
+        patch("src.agent.parameter_evolver.ParameterEvolver") as MockEvolver,
+        patch("src.agent.yaml_updater.YamlUpdater") as MockYaml,
+    ):
+        candidate = MagicMock()
+        candidate.strategy_id = "evolved_x"
+        MockEvolver.return_value.evolve.return_value = (candidate, [])
+        MockEvolver.return_value.get_evolution_history.return_value = [
+            {"generation": 1, "best_score": 1.0, "avg_score": 0.5}
+        ]
+        MockYaml.return_value.save_evolution_result.return_value = (
+            "/tmp/strategy.yaml",
+            "/tmp/history.yaml",
+        )
+
+        result = runner.invoke(
+            app,
+            ["lab", "evolve", "experimental/base_strategy_01", "--generations", "2", "--population", "10"],
+        )
+
+    assert result.exit_code == 0
+
+
+def test_lab_evolve_command_runs_without_save() -> None:
+    with patch("src.agent.parameter_evolver.ParameterEvolver") as MockEvolver:
+        candidate = MagicMock()
+        candidate.strategy_id = "evolved_x"
+        MockEvolver.return_value.evolve.return_value = (candidate, [])
+        MockEvolver.return_value.get_evolution_history.return_value = [
+            {"generation": 1, "best_score": 1.0, "avg_score": 0.5}
+        ]
+
+        result = runner.invoke(
+            app,
+            [
+                "lab",
+                "evolve",
+                "experimental/base_strategy_01",
+                "--generations",
+                "2",
+                "--population",
+                "10",
+                "--no-save",
+            ],
+        )
+
+    assert result.exit_code == 0
+
+
+def test_lab_optimize_command_runs() -> None:
+    with (
+        patch("src.agent.optuna_optimizer.OptunaOptimizer") as MockOptimizer,
+        patch("src.agent.yaml_updater.YamlUpdater") as MockYaml,
+    ):
+        candidate = MagicMock()
+        study = MagicMock()
+        study.best_value = 1.5
+        study.best_params = {"period": 20}
+        MockOptimizer.return_value.optimize.return_value = (candidate, study)
+        MockOptimizer.return_value.get_optimization_history.return_value = []
+        MockYaml.return_value.save_optuna_result.return_value = (
+            "/tmp/strategy.yaml",
+            "/tmp/history.yaml",
+        )
+
+        result = runner.invoke(
+            app,
+            ["lab", "optimize", "experimental/base_strategy_01", "--trials", "10"],
+        )
+
+    assert result.exit_code == 0
+
+
+def test_lab_optimize_command_runs_without_save() -> None:
+    with patch("src.agent.optuna_optimizer.OptunaOptimizer") as MockOptimizer:
+        candidate = MagicMock()
+        study = MagicMock()
+        study.best_value = 1.5
+        study.best_params = {"period": 20}
+        MockOptimizer.return_value.optimize.return_value = (candidate, study)
+
+        result = runner.invoke(
+            app,
+            [
+                "lab",
+                "optimize",
+                "experimental/base_strategy_01",
+                "--trials",
+                "10",
+                "--no-save",
+            ],
+        )
+
+    assert result.exit_code == 0
+
+
+def test_lab_generate_handles_failed_results() -> None:
+    with (
+        patch("src.agent.StrategyGenerator") as MockGenerator,
+        patch("src.agent.StrategyEvaluator") as MockEvaluator,
+    ):
+        mock_candidate = MagicMock()
+        mock_candidate.strategy_id = "auto_failed"
+        MockGenerator.return_value.generate.return_value = [mock_candidate]
+
+        failed_result = MagicMock()
+        failed_result.success = False
+        failed_result.candidate = mock_candidate
+        MockEvaluator.return_value.evaluate_batch.return_value = [failed_result]
+
+        result = runner.invoke(
+            app,
+            ["lab", "generate", "--count", "1", "--top", "1", "--no-save"],
+        )
+
+    assert result.exit_code == 0
+
+
+def test_lab_generate_saves_best_strategy() -> None:
+    with (
+        patch("src.agent.StrategyGenerator") as MockGenerator,
+        patch("src.agent.StrategyEvaluator") as MockEvaluator,
+        patch("src.agent.yaml_updater.YamlUpdater") as MockYaml,
+    ):
+        mock_candidate = MagicMock()
+        mock_candidate.strategy_id = "auto_success"
+        mock_candidate.shared_config = {}
+        MockGenerator.return_value.generate.return_value = [mock_candidate]
+
+        success_result = _make_eval_result()
+        success_result.candidate = mock_candidate
+        MockEvaluator.return_value.evaluate_batch.return_value = [success_result]
+        MockYaml.return_value.save_candidate.return_value = "/tmp/auto.yaml"
+
+        result = runner.invoke(
+            app,
+            ["lab", "generate", "--count", "1", "--top", "1"],
+        )
+
+    assert result.exit_code == 0
+    MockYaml.return_value.save_candidate.assert_called_once()
+
+
+def test_lab_improve_accepts_fundamental_constraints() -> None:
+    with (
+        patch("src.agent.strategy_improver.StrategyImprover") as MockImprover,
+        patch("src.lib.strategy_runtime.loader.ConfigLoader") as MockLoader,
+    ):
+        report = MagicMock()
+        report.max_drawdown = 0.1
+        report.max_drawdown_duration_days = 0
+        report.losing_trade_patterns = []
+        report.suggested_improvements = []
+        MockImprover.return_value.analyze.return_value = report
+        MockImprover.return_value.suggest_improvements.return_value = []
+        MockLoader.return_value.load_strategy_config.return_value = {
+            "entry_filter_params": {},
+            "exit_trigger_params": {},
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "lab",
+                "improve",
+                "experimental/base_strategy_01",
+                "--entry-filter-only",
+                "--allowed-category",
+                "fundamental",
+                "--no-apply",
+            ],
+        )
+
+    assert result.exit_code == 0
+    MockImprover.return_value.analyze.assert_called_once_with(
+        "experimental/base_strategy_01",
+        entry_filter_only=True,
+        allowed_categories=["fundamental"],
+    )
+    MockImprover.return_value.suggest_improvements.assert_called_once()
+
+
+def test_lab_improve_rejects_invalid_category() -> None:
+    result = runner.invoke(
+        app,
+        ["lab", "improve", "experimental/base_strategy_01", "--allowed-category", "invalid"],
+    )
+
+    assert result.exit_code == 1
+    assert "無効な --allowed-category" in result.stdout
+
+
+def test_lab_improve_renders_details_and_auto_applies() -> None:
+    with (
+        patch("src.agent.strategy_improver.StrategyImprover") as MockImprover,
+        patch("src.lib.strategy_runtime.loader.ConfigLoader") as MockLoader,
+        patch("src.agent.yaml_updater.YamlUpdater") as MockYaml,
+    ):
+        report = MagicMock()
+        report.max_drawdown = 0.2
+        report.max_drawdown_duration_days = 12
+        report.losing_trade_patterns = [{"type": "worst_trade", "return": -0.1}]
+        report.suggested_improvements = ["volume を追加"]
+        MockImprover.return_value.analyze.return_value = report
+        MockLoader.return_value.load_strategy_config.return_value = {
+            "entry_filter_params": {},
+            "exit_trigger_params": {},
+        }
+
+        improvement = MagicMock()
+        improvement.improvement_type = "add_signal"
+        improvement.target = "entry"
+        improvement.signal_name = "fundamental"
+        improvement.reason = "テスト理由"
+        MockImprover.return_value.suggest_improvements.return_value = [improvement]
+        MockYaml.return_value.apply_improvements.return_value = "/tmp/improved.yaml"
+
+        result = runner.invoke(
+            app,
+            ["lab", "improve", "experimental/base_strategy_01"],
+        )
+
+    assert result.exit_code == 0
+    MockYaml.return_value.apply_improvements.assert_called_once()
+
+
+def test_lab_improve_help_includes_new_options() -> None:
+    result = runner.invoke(app, ["lab", "improve", "--help"])
+    assert result.exit_code == 0
+    assert "--entry-filter-only" in result.stdout
+    assert "--allowed-category" in result.stdout

--- a/apps/ts/packages/clients-ts/src/backtest/index.ts
+++ b/apps/ts/packages/clients-ts/src/backtest/index.ts
@@ -44,6 +44,7 @@ export type {
   LabOptimizeRequest,
   LabOptimizeResult,
   LabResultData,
+  LabSignalCategory,
   LabSSEEvent,
   LabType,
   OHLCVRecord,

--- a/apps/ts/packages/clients-ts/src/backtest/types.ts
+++ b/apps/ts/packages/clients-ts/src/backtest/types.ts
@@ -418,6 +418,15 @@ export interface DefaultConfigUpdateResponse {
 // ============================================
 
 export type LabType = 'generate' | 'evolve' | 'optimize' | 'improve';
+export type LabSignalCategory =
+  | 'breakout'
+  | 'trend'
+  | 'oscillator'
+  | 'volatility'
+  | 'volume'
+  | 'macro'
+  | 'fundamental'
+  | 'sector';
 
 // Request types
 
@@ -429,6 +438,8 @@ export interface LabGenerateRequest {
   direction?: 'longonly' | 'shortonly' | 'both';
   timeframe?: string;
   dataset?: string;
+  entry_filter_only?: boolean;
+  allowed_categories?: LabSignalCategory[];
 }
 
 export interface LabEvolveRequest {
@@ -449,6 +460,8 @@ export interface LabOptimizeRequest {
 export interface LabImproveRequest {
   strategy_name: string;
   auto_apply?: boolean;
+  entry_filter_only?: boolean;
+  allowed_categories?: LabSignalCategory[];
 }
 
 // Result item types

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -7180,7 +7180,7 @@
                   "additionalProperties": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/OHLCVRecord"
+                      "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                     }
                   },
                   "title": "Response Get Dataset Ohlcv Batch Api Dataset  Name  Stocks Ohlcv Batch Get"
@@ -7300,7 +7300,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/OHLCVRecord"
+                    "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                   },
                   "title": "Response Get Dataset Stock Ohlcv Api Dataset  Name  Stocks  Code  Ohlcv Get"
                 }
@@ -14239,6 +14239,37 @@
             "title": "Dataset",
             "description": "データセット名",
             "default": "primeExTopix500"
+          },
+          "entry_filter_only": {
+            "type": "boolean",
+            "title": "Entry Filter Only",
+            "description": "Entryフィルターのみ生成（Exitシグナルを生成しない）",
+            "default": false
+          },
+          "allowed_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "breakout",
+                    "trend",
+                    "oscillator",
+                    "volatility",
+                    "volume",
+                    "macro",
+                    "fundamental",
+                    "sector"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Categories",
+            "description": "許可するシグナルカテゴリ（未指定時は全カテゴリ）"
           }
         },
         "type": "object",
@@ -14300,6 +14331,37 @@
             "title": "Auto Apply",
             "description": "改善を自動適用",
             "default": true
+          },
+          "entry_filter_only": {
+            "type": "boolean",
+            "title": "Entry Filter Only",
+            "description": "Entryフィルターの改善のみを許可",
+            "default": false
+          },
+          "allowed_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "breakout",
+                    "trend",
+                    "oscillator",
+                    "volatility",
+                    "volume",
+                    "macro",
+                    "fundamental",
+                    "sector"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Categories",
+            "description": "改善対象として許可するカテゴリ（未指定時は全カテゴリ）"
           }
         },
         "type": "object",
@@ -15480,27 +15542,33 @@
         "properties": {
           "date": {
             "type": "string",
-            "title": "Date"
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
           },
           "open": {
             "type": "number",
-            "title": "Open"
+            "title": "Open",
+            "description": "始値"
           },
           "high": {
             "type": "number",
-            "title": "High"
+            "title": "High",
+            "description": "高値"
           },
           "low": {
             "type": "number",
-            "title": "Low"
+            "title": "Low",
+            "description": "安値"
           },
           "close": {
             "type": "number",
-            "title": "Close"
+            "title": "Close",
+            "description": "終値"
           },
           "volume": {
-            "type": "integer",
-            "title": "Volume"
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
           }
         },
         "type": "object",
@@ -15512,7 +15580,8 @@
           "close",
           "volume"
         ],
-        "title": "OHLCVRecord"
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
       },
       "OHLCVResampleRequest": {
         "properties": {
@@ -15633,7 +15702,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__indicators__OHLCVRecord"
+              "$ref": "#/components/schemas/OHLCVRecord"
             },
             "type": "array",
             "title": "Data",
@@ -16224,7 +16293,7 @@
             "title": "Datapoints"
           },
           "dateRange": {
-            "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__DateRange"
+            "$ref": "#/components/schemas/DateRange"
           },
           "excludedStocks": {
             "items": {
@@ -16523,7 +16592,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__portfolio_performance__DateRange"
               },
               {
                 "type": "null"
@@ -20805,6 +20874,44 @@
         ],
         "title": "DateRange"
       },
+      "src__server__schemas__dataset_data__OHLCVRecord": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date"
+          },
+          "open": {
+            "type": "number",
+            "title": "Open"
+          },
+          "high": {
+            "type": "number",
+            "title": "High"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close"
+          },
+          "volume": {
+            "type": "integer",
+            "title": "Volume"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
+        ],
+        "title": "OHLCVRecord"
+      },
       "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
@@ -20842,69 +20949,6 @@
         "title": "DateRange",
         "description": "分析期間"
       },
-      "src__server__schemas__indicators__OHLCVRecord": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
-          },
-          "open": {
-            "type": "number",
-            "title": "Open",
-            "description": "始値"
-          },
-          "high": {
-            "type": "number",
-            "title": "High",
-            "description": "高値"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low",
-            "description": "安値"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close",
-            "description": "終値"
-          },
-          "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
-        ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
-      },
-      "src__server__schemas__portfolio_factor_regression__DateRange": {
-        "properties": {
-          "from": {
-            "type": "string",
-            "title": "From"
-          },
-          "to": {
-            "type": "string",
-            "title": "To"
-          }
-        },
-        "type": "object",
-        "required": [
-          "from",
-          "to"
-        ],
-        "title": "DateRange"
-      },
       "src__server__schemas__portfolio_factor_regression__IndexMatch": {
         "properties": {
           "code": {
@@ -20927,6 +20971,24 @@
           "rSquared"
         ],
         "title": "IndexMatch"
+      },
+      "src__server__schemas__portfolio_performance__DateRange": {
+        "properties": {
+          "from": {
+            "type": "string",
+            "title": "From"
+          },
+          "to": {
+            "type": "string",
+            "title": "To"
+          }
+        },
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "title": "DateRange"
       },
       "ErrorDetail": {
         "description": "バリデーションエラー詳細",

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -4086,6 +4086,17 @@ export interface components {
              * @default primeExTopix500
              */
             dataset: string;
+            /**
+             * Entry Filter Only
+             * @description Entryフィルターのみ生成（Exitシグナルを生成しない）
+             * @default false
+             */
+            entry_filter_only: boolean;
+            /**
+             * Allowed Categories
+             * @description 許可するシグナルカテゴリ（未指定時は全カテゴリ）
+             */
+            allowed_categories?: ("breakout" | "trend" | "oscillator" | "volatility" | "volume" | "macro" | "fundamental" | "sector")[] | null;
         };
         /**
          * LabGenerateResult
@@ -4129,6 +4140,17 @@ export interface components {
              * @default true
              */
             auto_apply: boolean;
+            /**
+             * Entry Filter Only
+             * @description Entryフィルターの改善のみを許可
+             * @default false
+             */
+            entry_filter_only: boolean;
+            /**
+             * Allowed Categories
+             * @description 改善対象として許可するカテゴリ（未指定時は全カテゴリ）
+             */
+            allowed_categories?: ("breakout" | "trend" | "oscillator" | "volatility" | "volume" | "macro" | "fundamental" | "sector")[] | null;
         };
         /**
          * LabImproveResult
@@ -4675,19 +4697,40 @@ export interface components {
             /** Close */
             close: number;
         };
-        /** OHLCVRecord */
+        /**
+         * OHLCVRecord
+         * @description OHLCVレコード
+         */
         OHLCVRecord: {
-            /** Date */
+            /**
+             * Date
+             * @description 日付 (YYYY-MM-DD)
+             */
             date: string;
-            /** Open */
+            /**
+             * Open
+             * @description 始値
+             */
             open: number;
-            /** High */
+            /**
+             * High
+             * @description 高値
+             */
             high: number;
-            /** Low */
+            /**
+             * Low
+             * @description 安値
+             */
             low: number;
-            /** Close */
+            /**
+             * Close
+             * @description 終値
+             */
             close: number;
-            /** Volume */
+            /**
+             * Volume
+             * @description 出来高
+             */
             volume: number;
         };
         /**
@@ -4766,7 +4809,7 @@ export interface components {
              * Data
              * @description OHLCVデータ
              */
-            data: components["schemas"]["src__server__schemas__indicators__OHLCVRecord"][];
+            data: components["schemas"]["OHLCVRecord"][];
         };
         /**
          * OptimizationGridConfig
@@ -5098,7 +5141,7 @@ export interface components {
             analysisDate: string;
             /** Datapoints */
             dataPoints: number;
-            dateRange: components["schemas"]["src__server__schemas__portfolio_factor_regression__DateRange"];
+            dateRange: components["schemas"]["DateRange"];
             /** Excludedstocks */
             excludedStocks: components["schemas"]["ExcludedStock"][];
         };
@@ -5178,7 +5221,7 @@ export interface components {
             benchmarkTimeSeries?: components["schemas"]["BenchmarkTimeSeriesPoint"][] | null;
             /** Analysisdate */
             analysisDate: string;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__portfolio_performance__DateRange"] | null;
             /** Datapoints */
             dataPoints: number;
             /** Warnings */
@@ -6996,6 +7039,21 @@ export interface components {
             /** Max */
             max: string;
         };
+        /** OHLCVRecord */
+        src__server__schemas__dataset_data__OHLCVRecord: {
+            /** Date */
+            date: string;
+            /** Open */
+            open: number;
+            /** High */
+            high: number;
+            /** Low */
+            low: number;
+            /** Close */
+            close: number;
+            /** Volume */
+            volume: number;
+        };
         /** DateRange */
         src__server__schemas__db__DateRange: {
             /** Min */
@@ -7013,49 +7071,6 @@ export interface components {
             /** To */
             to: string;
         };
-        /**
-         * OHLCVRecord
-         * @description OHLCVレコード
-         */
-        src__server__schemas__indicators__OHLCVRecord: {
-            /**
-             * Date
-             * @description 日付 (YYYY-MM-DD)
-             */
-            date: string;
-            /**
-             * Open
-             * @description 始値
-             */
-            open: number;
-            /**
-             * High
-             * @description 高値
-             */
-            high: number;
-            /**
-             * Low
-             * @description 安値
-             */
-            low: number;
-            /**
-             * Close
-             * @description 終値
-             */
-            close: number;
-            /**
-             * Volume
-             * @description 出来高
-             */
-            volume: number;
-        };
-        /** DateRange */
-        src__server__schemas__portfolio_factor_regression__DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
-        };
         /** IndexMatch */
         src__server__schemas__portfolio_factor_regression__IndexMatch: {
             /** Code */
@@ -7064,6 +7079,13 @@ export interface components {
             name: string;
             /** Rsquared */
             rSquared: number;
+        };
+        /** DateRange */
+        src__server__schemas__portfolio_performance__DateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
         };
         /**
          * ErrorDetail
@@ -12195,7 +12217,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: components["schemas"]["OHLCVRecord"][];
+                        [key: string]: components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                     };
                 };
             };
@@ -12258,7 +12280,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["OHLCVRecord"][];
+                    "application/json": components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                 };
             };
             /** @description Bad Request */

--- a/apps/ts/packages/web/src/components/Lab/LabGenerateForm.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabGenerateForm.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { LabGenerateForm } from './LabGenerateForm';
+
+describe('LabGenerateForm', () => {
+  it('submits default payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabGenerateForm onSubmit={onSubmit} />);
+    await user.click(screen.getByRole('button', { name: 'Generate Strategies' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      count: 10,
+      top: 5,
+      direction: 'longonly',
+      timeframe: 'daily',
+    });
+  });
+
+  it('falls back to defaults when count/top are invalid', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabGenerateForm onSubmit={onSubmit} />);
+
+    await user.clear(screen.getByLabelText('Count'));
+    await user.clear(screen.getByLabelText('Top'));
+    await user.click(screen.getByRole('button', { name: 'Generate Strategies' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      count: 10,
+      top: 5,
+      direction: 'longonly',
+      timeframe: 'daily',
+    });
+  });
+
+  it('submits fundamental-only constraints and trimmed dataset', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabGenerateForm onSubmit={onSubmit} />);
+
+    await user.clear(screen.getByLabelText('Dataset (optional)'));
+    await user.type(screen.getByLabelText('Dataset (optional)'), '  custom_dataset  ');
+    await user.click(screen.getByRole('switch', { name: 'Entry Filter Only' }));
+
+    const comboboxes = screen.getAllByRole('combobox');
+    const categoryCombobox = comboboxes.at(2);
+    expect(categoryCombobox).toBeDefined();
+    if (!categoryCombobox) {
+      return;
+    }
+    await user.click(categoryCombobox);
+    await user.click(screen.getByText('Fundamental Only'));
+
+    await user.click(screen.getByRole('button', { name: 'Generate Strategies' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      count: 10,
+      top: 5,
+      direction: 'longonly',
+      timeframe: 'daily',
+      dataset: 'custom_dataset',
+      entry_filter_only: true,
+      allowed_categories: ['fundamental'],
+    });
+  });
+
+  it('respects disabled state', () => {
+    const onSubmit = vi.fn();
+    render(<LabGenerateForm onSubmit={onSubmit} disabled />);
+
+    expect(screen.getByRole('button', { name: 'Generate Strategies' })).toBeDisabled();
+  });
+});

--- a/apps/ts/packages/web/src/components/Lab/LabGenerateForm.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabGenerateForm.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import type { LabGenerateRequest } from '@/types/backtest';
 
 interface LabGenerateFormProps {
@@ -16,6 +17,8 @@ export function LabGenerateForm({ onSubmit, disabled }: LabGenerateFormProps) {
   const [direction, setDirection] = useState<'longonly' | 'shortonly' | 'both'>('longonly');
   const [timeframe, setTimeframe] = useState('daily');
   const [dataset, setDataset] = useState('');
+  const [entryFilterOnly, setEntryFilterOnly] = useState(false);
+  const [categoryScope, setCategoryScope] = useState<'all' | 'fundamental'>('all');
 
   const handleSubmit = () => {
     const request: LabGenerateRequest = {
@@ -26,6 +29,12 @@ export function LabGenerateForm({ onSubmit, disabled }: LabGenerateFormProps) {
     };
     if (dataset.trim()) {
       request.dataset = dataset.trim();
+    }
+    if (entryFilterOnly) {
+      request.entry_filter_only = true;
+    }
+    if (categoryScope === 'fundamental') {
+      request.allowed_categories = ['fundamental'];
     }
     onSubmit(request);
   };
@@ -102,6 +111,35 @@ export function LabGenerateForm({ onSubmit, disabled }: LabGenerateFormProps) {
           onChange={(e) => setDataset(e.target.value)}
           disabled={disabled}
         />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Label htmlFor="gen-entry-only" className="text-xs">
+          Entry Filter Only
+        </Label>
+        <Switch
+          id="gen-entry-only"
+          checked={entryFilterOnly}
+          onCheckedChange={setEntryFilterOnly}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Allowed Categories</Label>
+        <Select
+          value={categoryScope}
+          onValueChange={(v) => setCategoryScope(v as typeof categoryScope)}
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="fundamental">Fundamental Only</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <Button className="w-full" onClick={handleSubmit} disabled={disabled}>

--- a/apps/ts/packages/web/src/components/Lab/LabImproveForm.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabImproveForm.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { LabImproveForm } from './LabImproveForm';
+
+describe('LabImproveForm', () => {
+  it('submits default payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabImproveForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+    await user.click(screen.getByRole('button', { name: 'Analyze & Improve' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      auto_apply: false,
+    });
+  });
+
+  it('submits fundamental-only constraints', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabImproveForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('switch', { name: 'Auto Apply' }));
+    await user.click(screen.getByRole('switch', { name: 'Entry Filter Only' }));
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText('Fundamental Only'));
+    await user.click(screen.getByRole('button', { name: 'Analyze & Improve' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      auto_apply: true,
+      entry_filter_only: true,
+      allowed_categories: ['fundamental'],
+    });
+  });
+
+  it('disables submit when strategy is not selected', () => {
+    const onSubmit = vi.fn();
+    render(<LabImproveForm strategyName={null} onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('button', { name: 'Analyze & Improve' })).toBeDisabled();
+  });
+});

--- a/apps/ts/packages/web/src/components/Lab/LabImproveForm.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabImproveForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import type { LabImproveRequest } from '@/types/backtest';
 
@@ -12,13 +13,22 @@ interface LabImproveFormProps {
 
 export function LabImproveForm({ strategyName, onSubmit, disabled }: LabImproveFormProps) {
   const [autoApply, setAutoApply] = useState(false);
+  const [entryFilterOnly, setEntryFilterOnly] = useState(false);
+  const [categoryScope, setCategoryScope] = useState<'all' | 'fundamental'>('all');
 
   const handleSubmit = () => {
     if (!strategyName) return;
-    onSubmit({
+    const request: LabImproveRequest = {
       strategy_name: strategyName,
       auto_apply: autoApply,
-    });
+    };
+    if (entryFilterOnly) {
+      request.entry_filter_only = true;
+    }
+    if (categoryScope === 'fundamental') {
+      request.allowed_categories = ['fundamental'];
+    }
+    onSubmit(request);
   };
 
   return (
@@ -28,6 +38,33 @@ export function LabImproveForm({ strategyName, onSubmit, disabled }: LabImproveF
           Auto Apply
         </Label>
         <Switch id="improve-auto" checked={autoApply} onCheckedChange={setAutoApply} disabled={disabled} />
+      </div>
+      <div className="flex items-center justify-between">
+        <Label htmlFor="improve-entry-only" className="text-xs">
+          Entry Filter Only
+        </Label>
+        <Switch
+          id="improve-entry-only"
+          checked={entryFilterOnly}
+          onCheckedChange={setEntryFilterOnly}
+          disabled={disabled}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs">Allowed Categories</Label>
+        <Select
+          value={categoryScope}
+          onValueChange={(v) => setCategoryScope(v as typeof categoryScope)}
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="fundamental">Fundamental Only</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
       <p className="text-xs text-muted-foreground">
         When enabled, suggested improvements will be automatically applied to the strategy.

--- a/apps/ts/packages/web/src/test-setup.ts
+++ b/apps/ts/packages/web/src/test-setup.ts
@@ -38,3 +38,14 @@ if (typeof global !== 'undefined') {
     disconnect: vi.fn(),
   }));
 }
+
+// Radix Select relies on pointer capture APIs that are not implemented in happy-dom.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}

--- a/apps/ts/packages/web/src/types/backtest.ts
+++ b/apps/ts/packages/web/src/types/backtest.ts
@@ -37,6 +37,7 @@ export type {
   LabOptimizeRequest,
   LabOptimizeResult,
   LabResultData,
+  LabSignalCategory,
   LabSSEEvent,
   LabType,
   OptimizationGridConfig,


### PR DESCRIPTION
## Summary
- add lab constraints for `entry_filter_only` and `allowed_categories` in bt agent models/generator/improver
- wire new fields through FastAPI lab schema/routes/service and bt CLI options
- update TS clients/web forms and sync OpenAPI-generated types for lab requests
- add/expand bt and web tests, including CLI tests and Lab form submission tests
- update README, AGENTS, and bt-agent-system skill docs with new lab options

## Validation
- uv run pytest tests/server/routes/test_lab.py tests/unit/agent/test_strategy_generator.py tests/unit/agent/test_strategy_improver.py tests/unit/agent/test_models.py tests/unit/cli_bt/test_lab_cli.py
- uv run ruff check src/agent src/server src/cli_bt tests/server/routes/test_lab.py tests/unit/agent/test_models.py tests/unit/agent/test_strategy_generator.py tests/unit/agent/test_strategy_improver.py tests/unit/cli_bt/test_lab_cli.py
- uv run pyright src/agent src/server src/cli_bt
- bun run --filter @trading25/clients-ts typecheck
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test src/hooks/useLab.test.tsx
- bun run --filter @trading25/web test --coverage --coverage.include='src/components/Lab/LabGenerateForm.tsx' --coverage.include='src/components/Lab/LabImproveForm.tsx' src/components/Lab/LabGenerateForm.test.tsx src/components/Lab/LabImproveForm.test.tsx