### PR TITLE
fix(bt): sync indices during incremental market db sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **market.db**: 読み書き（SQLAlchemy Core）
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
+- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する（`indices-only` は指数再同期専用モード）
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う

--- a/apps/bt/src/lib/market_db/market_db.py
+++ b/apps/bt/src/lib/market_db/market_db.py
@@ -89,6 +89,22 @@ class MarketDb(BaseDbAccess):
             row = conn.execute(select(func.max(stock_data.c.date))).fetchone()
             return row[0] if row else None
 
+    def get_latest_indices_data_dates(self) -> dict[str, str]:
+        """indices_data の銘柄コードごとの最新取引日を取得"""
+        with self.engine.connect() as conn:
+            rows = conn.execute(
+                select(
+                    indices_data.c.code,
+                    func.max(indices_data.c.date).label("max_date"),
+                )
+                .group_by(indices_data.c.code)
+            ).fetchall()
+        return {
+            row.code: row.max_date
+            for row in rows
+            if row.code and row.max_date
+        }
+
     # --- Write ---
 
     def upsert_stocks(self, rows: list[dict[str, Any]]) -> int:

--- a/apps/bt/tests/unit/server/db/test_market_db.py
+++ b/apps/bt/tests/unit/server/db/test_market_db.py
@@ -140,6 +140,140 @@ class TestMarketDbUpsert:
         ])
         assert count == 1
 
+    def test_upsert_empty_for_all_tables(self, market_db: MarketDb) -> None:
+        assert market_db.upsert_stock_data([]) == 0
+        assert market_db.upsert_topix_data([]) == 0
+        assert market_db.upsert_indices_data([]) == 0
+        assert market_db.upsert_index_master([]) == 0
+
+
+class TestMarketDbAnalyticsAndValidation:
+    def test_latest_dates_and_indices_latest_date_map(self, market_db: MarketDb) -> None:
+        assert market_db.get_latest_stock_data_date() is None
+        assert market_db.get_latest_indices_data_dates() == {}
+
+        market_db.upsert_stock_data([
+            {"code": "7203", "date": "2024-01-15", "open": 2500.0, "high": 2510.0, "low": 2490.0, "close": 2505.0, "volume": 1000000},
+            {"code": "7203", "date": "2024-01-16", "open": 2510.0, "high": 2520.0, "low": 2500.0, "close": 2515.0, "volume": 1200000},
+        ])
+        market_db.upsert_indices_data([
+            {"code": "0000", "date": "2024-01-15", "open": 2500.0, "high": 2510.0, "low": 2490.0, "close": 2505.0},
+            {"code": "0000", "date": "2024-01-16", "open": 2510.0, "high": 2520.0, "low": 2500.0, "close": 2515.0},
+            {"code": "0001", "date": "2024-01-14", "open": 1100.0, "high": 1120.0, "low": 1090.0, "close": 1110.0},
+        ])
+
+        assert market_db.get_latest_stock_data_date() == "2024-01-16"
+        assert market_db.get_latest_indices_data_dates() == {
+            "0000": "2024-01-16",
+            "0001": "2024-01-14",
+        }
+
+    def test_range_stats_market_counts_and_indices_summary(self, market_db: MarketDb) -> None:
+        assert market_db.get_topix_date_range() is None
+        assert market_db.get_stock_data_date_range() is None
+        empty_indices = market_db.get_indices_data_range()
+        assert empty_indices["dataCount"] == 0
+        assert empty_indices["dateRange"] is None
+
+        market_db.upsert_stocks([
+            {
+                "code": "7203",
+                "company_name": "トヨタ",
+                "market_code": "0111",
+                "market_name": "プライム",
+                "sector_17_code": "6",
+                "sector_17_name": "自動車",
+                "sector_33_code": "3700",
+                "sector_33_name": "輸送用機器",
+                "listed_date": "1949-05-16",
+            },
+            {
+                "code": "6501",
+                "company_name": "日立",
+                "market_code": "0112",
+                "market_name": "スタンダード",
+                "sector_17_code": "8",
+                "sector_17_name": "電気機器",
+                "sector_33_code": "3600",
+                "sector_33_name": "電気機器",
+                "listed_date": "1949-05-16",
+            },
+        ])
+        market_db.upsert_topix_data([
+            {"date": "2024-01-15", "open": 2500.0, "high": 2510.0, "low": 2490.0, "close": 2505.0},
+            {"date": "2024-01-16", "open": 2510.0, "high": 2520.0, "low": 2500.0, "close": 2515.0},
+        ])
+        market_db.upsert_stock_data([
+            {"code": "7203", "date": "2024-01-15", "open": 2500.0, "high": 2510.0, "low": 2490.0, "close": 2505.0, "volume": 1000000},
+            {"code": "6501", "date": "2024-01-15", "open": 8000.0, "high": 8100.0, "low": 7900.0, "close": 8050.0, "volume": 500000},
+            {"code": "7203", "date": "2024-01-16", "open": 2510.0, "high": 2520.0, "low": 2500.0, "close": 2515.0, "volume": 1200000},
+        ])
+        market_db.upsert_index_master([
+            {"code": "0000", "name": "TOPIX", "category": "topix"},
+            {"code": "0001", "name": "電気機器", "category": "sector33"},
+        ])
+        market_db.upsert_indices_data([
+            {"code": "0000", "date": "2024-01-15", "open": 2500.0, "high": 2510.0, "low": 2490.0, "close": 2505.0},
+            {"code": "0001", "date": "2024-01-15", "open": 1200.0, "high": 1220.0, "low": 1190.0, "close": 1210.0},
+        ])
+
+        topix_range = market_db.get_topix_date_range()
+        assert topix_range == {"count": 2, "min": "2024-01-15", "max": "2024-01-16"}
+
+        stock_range = market_db.get_stock_data_date_range()
+        assert stock_range["count"] == 3
+        assert stock_range["dateCount"] == 2
+        assert stock_range["averageStocksPerDay"] == 1.5
+
+        by_market = market_db.get_stock_count_by_market()
+        assert by_market == {"スタンダード": 1, "プライム": 1}
+
+        indices_range = market_db.get_indices_data_range()
+        assert indices_range["masterCount"] == 2
+        assert indices_range["dataCount"] == 2
+        assert indices_range["dateRange"] == {"min": "2024-01-15", "max": "2024-01-15"}
+        assert indices_range["byCategory"] == {"sector33": 1, "topix": 1}
+
+    def test_initialization_and_validation_helpers(self, market_db: MarketDb) -> None:
+        assert market_db.is_initialized() is False
+        market_db.set_sync_metadata("init_completed", "true")
+        assert market_db.is_initialized() is True
+
+        market_db.upsert_topix_data([
+            {"date": "2024-01-15", "open": 2500.0, "high": 2510.0, "low": 2490.0, "close": 2505.0},
+            {"date": "2024-01-16", "open": 2510.0, "high": 2520.0, "low": 2500.0, "close": 2515.0},
+        ])
+        market_db.upsert_stock_data([
+            {
+                "code": "7203",
+                "date": "2024-01-16",
+                "open": 2510.0,
+                "high": 2520.0,
+                "low": 2500.0,
+                "close": 2515.0,
+                "volume": 1200000,
+                "adjustment_factor": 0.5,
+            },
+            {
+                "code": "6501",
+                "date": "2024-01-16",
+                "open": 8000.0,
+                "high": 8100.0,
+                "low": 7900.0,
+                "close": 8050.0,
+                "volume": 500000,
+                "adjustment_factor": 1.5,
+            },
+        ])
+
+        assert market_db.get_missing_stock_data_dates() == ["2024-01-15"]
+        events = market_db.get_adjustment_events()
+        assert len(events) == 2
+        assert {event["eventType"] for event in events} == {"stock_split", "reverse_split"}
+        assert set(market_db.get_stocks_needing_refresh()) == {"6501", "7203"}
+        assert market_db.get_stock_data_unique_date_count() == 1
+        assert market_db.get_db_file_size() > 0
+
 
 class TestMarketDbReadOnly:
     def test_read_only_prevents_write(self, tmp_path: Path) -> None:
@@ -164,3 +298,10 @@ class TestMarketDbReadOnly:
                 "listed_date": "1949-05-16",
             }])
         ro.close()
+
+    def test_get_db_file_size_handles_os_error(self, market_db: MarketDb, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise_os_error(_path: str) -> int:
+            raise OSError("stat failed")
+
+        monkeypatch.setattr("src.lib.market_db.market_db.os.path.getsize", _raise_os_error)
+        assert market_db.get_db_file_size() == 0


### PR DESCRIPTION
## Summary
- add indices incremental fetch/update path to IncrementalSyncStrategy
- add MarketDb.get_latest_indices_data_dates() to anchor per-index incremental fetches
- harden index row conversion against missing date/key aliases
- extend tests for sync strategies and market db analytics/validation paths
- update AGENTS.md with incremental indices sync behavior

## Validation
- uv run ruff check tests/unit/server/services/test_sync_strategies.py tests/unit/server/db/test_market_db.py
- uv run pytest --confcutdir=tests/unit/server/services tests/unit/server/services/test_sync_strategies.py -q
- uv run pytest --confcutdir=tests/unit/server/db tests/unit/server/db/test_market_db.py -q
- uv run pyright src/server/services/sync_strategies.py src/lib/market_db/market_db.py
- coverage (targeted):
  - sync_strategies.py: statements 96.25%, branches 86.61%
  - market_db.py: statements 99.25%, branches 96.67%