### PR TITLE
fix(bt): harden indices sync payload extraction

### DIFF
--- a/apps/bt/src/server/clients/jquants_client.py
+++ b/apps/bt/src/server/clients/jquants_client.py
@@ -123,8 +123,9 @@ class JQuantsAsyncClient:
         未知の場合はリスト型の最初のキーを返す。
         """
         # 既知のエンドポイントマッピング
-        if path in self._DATA_KEYS:
-            return self._DATA_KEYS[path]
+        mapped_key = self._DATA_KEYS.get(path)
+        if mapped_key and isinstance(body.get(mapped_key), list):
+            return mapped_key
         # フォールバック: 最初のリスト型フィールド
         for key, value in body.items():
             if isinstance(value, list):

--- a/apps/bt/tests/unit/server/clients/test_jquants_client.py
+++ b/apps/bt/tests/unit/server/clients/test_jquants_client.py
@@ -214,6 +214,12 @@ class TestDataKeyExtraction:
         key = client._extract_data_key("/equities/bars/daily", body)
         assert key == "data"
 
+    def test_known_endpoint_falls_back_when_mapped_key_missing(self, client):
+        """既知エンドポイントでも data が無い場合は最初の配列キーへフォールバック"""
+        body = {"indices": [{"Date": "2024-01-01"}]}
+        key = client._extract_data_key("/indices/bars/daily", body)
+        assert key == "indices"
+
     def test_unknown_endpoint_fallback(self, client):
         """未知のエンドポイントのフォールバック"""
         body = {"some_data": [{"id": 1}], "count": 5}

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -16,6 +16,7 @@ from src.server.services.sync_strategies import (
     _convert_indices_data_rows,
     _convert_stock_rows,
     _date_sort_key,
+    _extract_list_items,
     _is_date_after,
     _parse_date,
     _to_jquants_date_param,
@@ -720,6 +721,14 @@ def test_data_conversion_helpers_handle_aliases_and_invalid_rows() -> None:
     assert len(index_rows) == 1
     assert index_rows[0]["date"] == "2026-02-10"
     assert index_rows[0]["open"] == 1
+
+
+def test_extract_list_items_handles_key_aliases_and_fallback() -> None:
+    assert _extract_list_items({"data": [{"code": "0000"}]}) == [{"code": "0000"}]
+    assert _extract_list_items({"indices": [{"code": "0000"}]}, preferred_keys=("data", "indices")) == [{"code": "0000"}]
+    assert _extract_list_items({"other": [{"code": "0000"}]}) == [{"code": "0000"}]
+    assert _extract_list_items({"data": ["not-dict", {"code": "0001"}]}) == [{"code": "0001"}]
+    assert _extract_list_items({"count": 0}) == []
 
 
 def test_date_helpers_cover_parse_and_fallback_paths() -> None:


### PR DESCRIPTION
## Summary
- make JQuants paginated payload extraction fall back to the first list key when mapped key is missing
- make sync strategies read index master list with key alias/fallback support (data/indices)
- add unit tests for payload-key fallback and list extraction helper

## Testing
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/clients/test_jquants_client.py apps/bt/tests/unit/server/test_routes_db_sync.py -q
- uv run --project apps/bt ruff check apps/bt/src/server/clients/jquants_client.py apps/bt/src/server/services/sync_strategies.py apps/bt/tests/unit/server/clients/test_jquants_client.py apps/bt/tests/unit/server/services/test_sync_strategies.py
- uv run --project apps/bt pyright apps/bt/src/server/clients/jquants_client.py apps/bt/src/server/services/sync_strategies.py
- uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/clients/test_jquants_client.py -q
- uv run --project apps/bt coverage report -m --include='*/src/server/services/sync_strategies.py,*/src/server/clients/jquants_client.py'
