### PR TITLE
feat: extend lab filter constraints to evolve/optimize and web UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ uv sync                          # 環境セットアップ
 uv run bt server --port 3002     # APIサーバー起動
 uv run bt backtest <strategy>    # バックテスト実行
 uv run bt lab generate --entry-filter-only --allowed-category fundamental
+uv run bt lab evolve <strategy> --entry-filter-only --allowed-category fundamental
+uv run bt lab optimize <strategy> --entry-filter-only --allowed-category fundamental
 uv run bt lab improve <strategy> --entry-filter-only --allowed-category fundamental
 uv run pytest tests/             # テスト
 uv run ruff check src/           # リント

--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ bun run cli backtest attribution cancel <job-id>
 ```
 - 保存先（XDG）: `~/.local/share/trading25/backtest/attribution/<strategy>/`
 
-### 4) Lab（fundamental 制約付き生成/改善）
+### 4) Lab（fundamental 制約付き生成/進化/最適化/改善）
 ```bash
 cd apps/bt
 uv run bt lab generate --count 50 --top 5 --entry-filter-only --allowed-category fundamental
+uv run bt lab evolve experimental/base_strategy_01 --entry-filter-only --allowed-category fundamental
+uv run bt lab optimize experimental/base_strategy_01 --entry-filter-only --allowed-category fundamental
 uv run bt lab improve experimental/base_strategy_01 --entry-filter-only --allowed-category fundamental --no-apply
 ```
-- API では `/api/lab/generate` と `/api/lab/improve` に `entry_filter_only` と `allowed_categories` を指定可能
+- API では `/api/lab/generate` `/api/lab/evolve` `/api/lab/optimize` `/api/lab/improve` に
+  `entry_filter_only` と `allowed_categories` を指定可能
 
 ## Monorepo Commands (root)
 

--- a/apps/bt/src/agent/models.py
+++ b/apps/bt/src/agent/models.py
@@ -102,6 +102,12 @@ class EvolutionConfig(BaseModel):
     # 評価タイムアウト（秒）
     timeout_seconds: int = Field(default=600, ge=60, le=3600)
 
+    # Entryフィルターのみ最適化（Exitパラメータは変更しない）
+    entry_filter_only: bool = Field(default=False)
+
+    # 最適化対象として許可するシグナルカテゴリ（空なら全カテゴリ）
+    allowed_categories: list[SignalCategory] = Field(default_factory=list)
+
 
 class StrategyCandidate(BaseModel):
     """戦略候補"""
@@ -213,3 +219,9 @@ class OptunaConfig(BaseModel):
 
     # SQLite保存パス（永続化用）
     storage_path: str | None = None
+
+    # Entryフィルターのみ最適化（Exitパラメータは変更しない）
+    entry_filter_only: bool = Field(default=False)
+
+    # 最適化対象として許可するシグナルカテゴリ（空なら全カテゴリ）
+    allowed_categories: list[SignalCategory] = Field(default_factory=list)

--- a/apps/bt/src/agent/signal_filters.py
+++ b/apps/bt/src/agent/signal_filters.py
@@ -1,0 +1,33 @@
+"""Lab用のシグナルフィルター判定ヘルパー。"""
+
+from .models import SignalCategory
+
+SIGNAL_CATEGORY_MAP: dict[str, SignalCategory] = {
+    "period_breakout": "breakout",
+    "ma_breakout": "trend",
+    "crossover": "trend",
+    "mean_reversion": "oscillator",
+    "bollinger_bands": "volatility",
+    "atr_support_break": "volatility",
+    "rsi_threshold": "oscillator",
+    "rsi_spread": "oscillator",
+    "volume": "volume",
+    "trading_value": "volume",
+    "trading_value_range": "volume",
+    "beta": "macro",
+    "margin": "macro",
+    "index_daily_change": "macro",
+    "index_macd_histogram": "macro",
+    "fundamental": "fundamental",
+}
+
+
+def is_signal_allowed(
+    signal_name: str,
+    allowed_categories: set[SignalCategory],
+) -> bool:
+    """カテゴリ制約に基づいてシグナルを許可判定する。"""
+    if not allowed_categories:
+        return True
+    category = SIGNAL_CATEGORY_MAP.get(signal_name)
+    return category in allowed_categories

--- a/apps/bt/src/server/routes/lab.py
+++ b/apps/bt/src/server/routes/lab.py
@@ -136,6 +136,8 @@ async def run_lab_evolve(request: LabEvolveRequest) -> LabJobResponse:
             "generations": request.generations,
             "population": request.population,
             "save": request.save,
+            "entry_filter_only": request.entry_filter_only,
+            "allowed_categories": request.allowed_categories,
         },
         error_label="evolve",
     )
@@ -151,6 +153,8 @@ async def run_lab_optimize(request: LabOptimizeRequest) -> LabJobResponse:
             "trials": request.trials,
             "sampler": request.sampler,
             "save": request.save,
+            "entry_filter_only": request.entry_filter_only,
+            "allowed_categories": request.allowed_categories,
             "scoring_weights": request.scoring_weights,
         },
         error_label="optimize",

--- a/apps/bt/src/server/schemas/lab.py
+++ b/apps/bt/src/server/schemas/lab.py
@@ -56,6 +56,14 @@ class LabEvolveRequest(BaseModel):
     generations: int = Field(default=20, ge=1, le=100, description="世代数")
     population: int = Field(default=50, ge=10, le=500, description="個体数")
     save: bool = Field(default=True, description="結果をYAMLに保存")
+    entry_filter_only: bool = Field(
+        default=False,
+        description="Entryフィルターのみ最適化（Exitパラメータは変更しない）",
+    )
+    allowed_categories: list[LabSignalCategory] | None = Field(
+        default=None,
+        description="最適化対象として許可するカテゴリ（未指定時は全カテゴリ）",
+    )
 
 
 class LabOptimizeRequest(BaseModel):
@@ -65,6 +73,14 @@ class LabOptimizeRequest(BaseModel):
     trials: int = Field(default=100, ge=10, le=1000, description="試行回数")
     sampler: Literal["tpe", "random", "cmaes"] = Field(default="tpe", description="サンプラー")
     save: bool = Field(default=True, description="結果をYAMLに保存")
+    entry_filter_only: bool = Field(
+        default=False,
+        description="Entryフィルターのみ最適化（Exitパラメータは変更しない）",
+    )
+    allowed_categories: list[LabSignalCategory] | None = Field(
+        default=None,
+        description="最適化対象として許可するカテゴリ（未指定時は全カテゴリ）",
+    )
     scoring_weights: dict[str, float] | None = Field(
         default=None, description="スコアリング重み"
     )

--- a/apps/bt/tests/unit/agent/test_models.py
+++ b/apps/bt/tests/unit/agent/test_models.py
@@ -70,6 +70,8 @@ class TestEvolutionConfig:
         assert config.mutation_rate == 0.1
         assert config.crossover_rate == 0.7
         assert config.elite_ratio == 0.1
+        assert config.entry_filter_only is False
+        assert config.allowed_categories == []
 
     def test_mutation_rate_range(self):
         """mutation_rate の範囲バリデーション"""
@@ -91,6 +93,8 @@ class TestOptunaConfig:
         assert config.n_trials == 100
         assert config.sampler == "tpe"
         assert config.pruning is True
+        assert config.entry_filter_only is False
+        assert config.allowed_categories == []
 
     def test_sampler_options(self):
         """サンプラー設定"""

--- a/apps/bt/tests/unit/cli_bt/test_lab_cli.py
+++ b/apps/bt/tests/unit/cli_bt/test_lab_cli.py
@@ -117,10 +117,24 @@ def test_lab_evolve_command_runs() -> None:
 
         result = runner.invoke(
             app,
-            ["lab", "evolve", "experimental/base_strategy_01", "--generations", "2", "--population", "10"],
+            [
+                "lab",
+                "evolve",
+                "experimental/base_strategy_01",
+                "--generations",
+                "2",
+                "--population",
+                "10",
+                "--entry-filter-only",
+                "--allowed-category",
+                "fundamental",
+            ],
         )
 
     assert result.exit_code == 0
+    config = MockEvolver.call_args.kwargs["config"]
+    assert config.entry_filter_only is True
+    assert config.allowed_categories == ["fundamental"]
 
 
 def test_lab_evolve_command_runs_without_save() -> None:
@@ -167,10 +181,58 @@ def test_lab_optimize_command_runs() -> None:
 
         result = runner.invoke(
             app,
-            ["lab", "optimize", "experimental/base_strategy_01", "--trials", "10"],
+            [
+                "lab",
+                "optimize",
+                "experimental/base_strategy_01",
+                "--trials",
+                "10",
+                "--entry-filter-only",
+                "--allowed-category",
+                "fundamental",
+            ],
         )
 
     assert result.exit_code == 0
+    config = MockOptimizer.call_args.kwargs["config"]
+    assert config.entry_filter_only is True
+    assert config.allowed_categories == ["fundamental"]
+
+
+def test_lab_evolve_rejects_invalid_category() -> None:
+    result = runner.invoke(
+        app,
+        ["lab", "evolve", "experimental/base_strategy_01", "--allowed-category", "invalid"],
+    )
+
+    assert result.exit_code == 1
+    assert "無効な --allowed-category" in result.stdout
+
+
+def test_lab_optimize_rejects_invalid_category() -> None:
+    result = runner.invoke(
+        app,
+        ["lab", "optimize", "experimental/base_strategy_01", "--allowed-category", "invalid"],
+    )
+
+    assert result.exit_code == 1
+    assert "無効な --allowed-category" in result.stdout
+
+
+def test_lab_evolve_help_includes_filter_options() -> None:
+    result = runner.invoke(app, ["lab", "evolve", "--help"])
+    assert result.exit_code == 0
+    output = _strip_ansi(result.stdout)
+    assert "--entry-filter-only" in output
+    assert "--allowed-category" in output
+
+
+def test_lab_optimize_help_includes_filter_options() -> None:
+    result = runner.invoke(app, ["lab", "optimize", "--help"])
+    assert result.exit_code == 0
+    output = _strip_ansi(result.stdout)
+    assert "--entry-filter-only" in output
+    assert "--allowed-category" in output
 
 
 def test_lab_optimize_command_runs_without_save() -> None:

--- a/apps/ts/packages/clients-ts/src/backtest/types.ts
+++ b/apps/ts/packages/clients-ts/src/backtest/types.ts
@@ -447,6 +447,8 @@ export interface LabEvolveRequest {
   generations?: number;
   population?: number;
   save?: boolean;
+  entry_filter_only?: boolean;
+  allowed_categories?: LabSignalCategory[];
 }
 
 export interface LabOptimizeRequest {
@@ -454,6 +456,8 @@ export interface LabOptimizeRequest {
   trials?: number;
   sampler?: string;
   save?: boolean;
+  entry_filter_only?: boolean;
+  allowed_categories?: LabSignalCategory[];
   scoring_weights?: Record<string, number>;
 }
 

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -7180,7 +7180,7 @@
                   "additionalProperties": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
+                      "$ref": "#/components/schemas/OHLCVRecord"
                     }
                   },
                   "title": "Response Get Dataset Ohlcv Batch Api Dataset  Name  Stocks Ohlcv Batch Get"
@@ -7300,7 +7300,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
+                    "$ref": "#/components/schemas/OHLCVRecord"
                   },
                   "title": "Response Get Dataset Stock Ohlcv Api Dataset  Name  Stocks  Code  Ohlcv Get"
                 }
@@ -14108,6 +14108,37 @@
             "title": "Save",
             "description": "結果をYAMLに保存",
             "default": true
+          },
+          "entry_filter_only": {
+            "type": "boolean",
+            "title": "Entry Filter Only",
+            "description": "Entryフィルターのみ最適化（Exitパラメータは変更しない）",
+            "default": false
+          },
+          "allowed_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "breakout",
+                    "trend",
+                    "oscillator",
+                    "volatility",
+                    "volume",
+                    "macro",
+                    "fundamental",
+                    "sector"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Categories",
+            "description": "最適化対象として許可するカテゴリ（未指定時は全カテゴリ）"
           }
         },
         "type": "object",
@@ -14616,6 +14647,37 @@
             "title": "Save",
             "description": "結果をYAMLに保存",
             "default": true
+          },
+          "entry_filter_only": {
+            "type": "boolean",
+            "title": "Entry Filter Only",
+            "description": "Entryフィルターのみ最適化（Exitパラメータは変更しない）",
+            "default": false
+          },
+          "allowed_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "breakout",
+                    "trend",
+                    "oscillator",
+                    "volatility",
+                    "volume",
+                    "macro",
+                    "fundamental",
+                    "sector"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Categories",
+            "description": "最適化対象として許可するカテゴリ（未指定時は全カテゴリ）"
           },
           "scoring_weights": {
             "anyOf": [
@@ -15542,33 +15604,27 @@
         "properties": {
           "date": {
             "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
+            "title": "Date"
           },
           "open": {
             "type": "number",
-            "title": "Open",
-            "description": "始値"
+            "title": "Open"
           },
           "high": {
             "type": "number",
-            "title": "High",
-            "description": "高値"
+            "title": "High"
           },
           "low": {
             "type": "number",
-            "title": "Low",
-            "description": "安値"
+            "title": "Low"
           },
           "close": {
             "type": "number",
-            "title": "Close",
-            "description": "終値"
+            "title": "Close"
           },
           "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
+            "type": "integer",
+            "title": "Volume"
           }
         },
         "type": "object",
@@ -15580,8 +15636,7 @@
           "close",
           "volume"
         ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
+        "title": "OHLCVRecord"
       },
       "OHLCVResampleRequest": {
         "properties": {
@@ -15702,7 +15757,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/OHLCVRecord"
+              "$ref": "#/components/schemas/src__server__schemas__indicators__OHLCVRecord"
             },
             "type": "array",
             "title": "Data",
@@ -16293,7 +16348,7 @@
             "title": "Datapoints"
           },
           "dateRange": {
-            "$ref": "#/components/schemas/DateRange"
+            "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__DateRange"
           },
           "excludedStocks": {
             "items": {
@@ -16592,7 +16647,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__portfolio_performance__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -20874,44 +20929,6 @@
         ],
         "title": "DateRange"
       },
-      "src__server__schemas__dataset_data__OHLCVRecord": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "open": {
-            "type": "number",
-            "title": "Open"
-          },
-          "high": {
-            "type": "number",
-            "title": "High"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close"
-          },
-          "volume": {
-            "type": "integer",
-            "title": "Volume"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
-        ],
-        "title": "OHLCVRecord"
-      },
       "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
@@ -20949,6 +20966,69 @@
         "title": "DateRange",
         "description": "分析期間"
       },
+      "src__server__schemas__indicators__OHLCVRecord": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
+          },
+          "open": {
+            "type": "number",
+            "title": "Open",
+            "description": "始値"
+          },
+          "high": {
+            "type": "number",
+            "title": "High",
+            "description": "高値"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low",
+            "description": "安値"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close",
+            "description": "終値"
+          },
+          "volume": {
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
+        ],
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
+      },
+      "src__server__schemas__portfolio_factor_regression__DateRange": {
+        "properties": {
+          "from": {
+            "type": "string",
+            "title": "From"
+          },
+          "to": {
+            "type": "string",
+            "title": "To"
+          }
+        },
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "title": "DateRange"
+      },
       "src__server__schemas__portfolio_factor_regression__IndexMatch": {
         "properties": {
           "code": {
@@ -20971,24 +21051,6 @@
           "rSquared"
         ],
         "title": "IndexMatch"
-      },
-      "src__server__schemas__portfolio_performance__DateRange": {
-        "properties": {
-          "from": {
-            "type": "string",
-            "title": "From"
-          },
-          "to": {
-            "type": "string",
-            "title": "To"
-          }
-        },
-        "type": "object",
-        "required": [
-          "from",
-          "to"
-        ],
-        "title": "DateRange"
       },
       "ErrorDetail": {
         "description": "バリデーションエラー詳細",

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -4001,6 +4001,17 @@ export interface components {
              * @default true
              */
             save: boolean;
+            /**
+             * Entry Filter Only
+             * @description Entryフィルターのみ最適化（Exitパラメータは変更しない）
+             * @default false
+             */
+            entry_filter_only: boolean;
+            /**
+             * Allowed Categories
+             * @description 最適化対象として許可するカテゴリ（未指定時は全カテゴリ）
+             */
+            allowed_categories?: ("breakout" | "trend" | "oscillator" | "volatility" | "volume" | "macro" | "fundamental" | "sector")[] | null;
         };
         /**
          * LabEvolveResult
@@ -4282,6 +4293,17 @@ export interface components {
              * @default true
              */
             save: boolean;
+            /**
+             * Entry Filter Only
+             * @description Entryフィルターのみ最適化（Exitパラメータは変更しない）
+             * @default false
+             */
+            entry_filter_only: boolean;
+            /**
+             * Allowed Categories
+             * @description 最適化対象として許可するカテゴリ（未指定時は全カテゴリ）
+             */
+            allowed_categories?: ("breakout" | "trend" | "oscillator" | "volatility" | "volume" | "macro" | "fundamental" | "sector")[] | null;
             /**
              * Scoring Weights
              * @description スコアリング重み
@@ -4697,40 +4719,19 @@ export interface components {
             /** Close */
             close: number;
         };
-        /**
-         * OHLCVRecord
-         * @description OHLCVレコード
-         */
+        /** OHLCVRecord */
         OHLCVRecord: {
-            /**
-             * Date
-             * @description 日付 (YYYY-MM-DD)
-             */
+            /** Date */
             date: string;
-            /**
-             * Open
-             * @description 始値
-             */
+            /** Open */
             open: number;
-            /**
-             * High
-             * @description 高値
-             */
+            /** High */
             high: number;
-            /**
-             * Low
-             * @description 安値
-             */
+            /** Low */
             low: number;
-            /**
-             * Close
-             * @description 終値
-             */
+            /** Close */
             close: number;
-            /**
-             * Volume
-             * @description 出来高
-             */
+            /** Volume */
             volume: number;
         };
         /**
@@ -4809,7 +4810,7 @@ export interface components {
              * Data
              * @description OHLCVデータ
              */
-            data: components["schemas"]["OHLCVRecord"][];
+            data: components["schemas"]["src__server__schemas__indicators__OHLCVRecord"][];
         };
         /**
          * OptimizationGridConfig
@@ -5141,7 +5142,7 @@ export interface components {
             analysisDate: string;
             /** Datapoints */
             dataPoints: number;
-            dateRange: components["schemas"]["DateRange"];
+            dateRange: components["schemas"]["src__server__schemas__portfolio_factor_regression__DateRange"];
             /** Excludedstocks */
             excludedStocks: components["schemas"]["ExcludedStock"][];
         };
@@ -5221,7 +5222,7 @@ export interface components {
             benchmarkTimeSeries?: components["schemas"]["BenchmarkTimeSeriesPoint"][] | null;
             /** Analysisdate */
             analysisDate: string;
-            dateRange?: components["schemas"]["src__server__schemas__portfolio_performance__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             /** Datapoints */
             dataPoints: number;
             /** Warnings */
@@ -7039,21 +7040,6 @@ export interface components {
             /** Max */
             max: string;
         };
-        /** OHLCVRecord */
-        src__server__schemas__dataset_data__OHLCVRecord: {
-            /** Date */
-            date: string;
-            /** Open */
-            open: number;
-            /** High */
-            high: number;
-            /** Low */
-            low: number;
-            /** Close */
-            close: number;
-            /** Volume */
-            volume: number;
-        };
         /** DateRange */
         src__server__schemas__db__DateRange: {
             /** Min */
@@ -7071,6 +7057,49 @@ export interface components {
             /** To */
             to: string;
         };
+        /**
+         * OHLCVRecord
+         * @description OHLCVレコード
+         */
+        src__server__schemas__indicators__OHLCVRecord: {
+            /**
+             * Date
+             * @description 日付 (YYYY-MM-DD)
+             */
+            date: string;
+            /**
+             * Open
+             * @description 始値
+             */
+            open: number;
+            /**
+             * High
+             * @description 高値
+             */
+            high: number;
+            /**
+             * Low
+             * @description 安値
+             */
+            low: number;
+            /**
+             * Close
+             * @description 終値
+             */
+            close: number;
+            /**
+             * Volume
+             * @description 出来高
+             */
+            volume: number;
+        };
+        /** DateRange */
+        src__server__schemas__portfolio_factor_regression__DateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
+        };
         /** IndexMatch */
         src__server__schemas__portfolio_factor_regression__IndexMatch: {
             /** Code */
@@ -7079,13 +7108,6 @@ export interface components {
             name: string;
             /** Rsquared */
             rSquared: number;
-        };
-        /** DateRange */
-        src__server__schemas__portfolio_performance__DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
         };
         /**
          * ErrorDetail
@@ -12217,7 +12239,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
+                        [key: string]: components["schemas"]["OHLCVRecord"][];
                     };
                 };
             };
@@ -12280,7 +12302,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
+                    "application/json": components["schemas"]["OHLCVRecord"][];
                 };
             };
             /** @description Bad Request */

--- a/apps/ts/packages/web/src/components/Lab/LabEvolveForm.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabEvolveForm.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { LabEvolveForm } from './LabEvolveForm';
+
+describe('LabEvolveForm', () => {
+  it('submits default payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabEvolveForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+    await user.click(screen.getByRole('button', { name: 'Start Evolution' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      generations: 10,
+      population: 20,
+    });
+  });
+
+  it('falls back to defaults when generations/population are invalid', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabEvolveForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+
+    await user.clear(screen.getByLabelText('Generations'));
+    await user.clear(screen.getByLabelText('Population'));
+    await user.click(screen.getByRole('button', { name: 'Start Evolution' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      generations: 10,
+      population: 20,
+    });
+  });
+
+  it('submits fundamental-only constraints', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabEvolveForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('switch', { name: 'Entry Filter Only' }));
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText('Fundamental Only'));
+    await user.click(screen.getByRole('button', { name: 'Start Evolution' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      generations: 10,
+      population: 20,
+      entry_filter_only: true,
+      allowed_categories: ['fundamental'],
+    });
+  });
+
+  it('disables submit when strategy is not selected', () => {
+    const onSubmit = vi.fn();
+    render(<LabEvolveForm strategyName={null} onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('button', { name: 'Start Evolution' })).toBeDisabled();
+  });
+});

--- a/apps/ts/packages/web/src/components/Lab/LabEvolveForm.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabEvolveForm.tsx
@@ -2,7 +2,15 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import type { LabEvolveRequest } from '@/types/backtest';
+
+type CategoryScope = 'all' | 'fundamental';
+
+function resolveCategoryScope(value: string): CategoryScope {
+  return value === 'fundamental' ? 'fundamental' : 'all';
+}
 
 interface LabEvolveFormProps {
   strategyName: string | null;
@@ -13,14 +21,23 @@ interface LabEvolveFormProps {
 export function LabEvolveForm({ strategyName, onSubmit, disabled }: LabEvolveFormProps) {
   const [generations, setGenerations] = useState('10');
   const [population, setPopulation] = useState('20');
+  const [entryFilterOnly, setEntryFilterOnly] = useState(false);
+  const [categoryScope, setCategoryScope] = useState<CategoryScope>('all');
 
   const handleSubmit = () => {
     if (!strategyName) return;
-    onSubmit({
+    const request: LabEvolveRequest = {
       strategy_name: strategyName,
       generations: Number(generations) || 10,
       population: Number(population) || 20,
-    });
+    };
+    if (entryFilterOnly) {
+      request.entry_filter_only = true;
+    }
+    if (categoryScope === 'fundamental') {
+      request.allowed_categories = ['fundamental'];
+    }
+    onSubmit(request);
   };
 
   return (
@@ -54,6 +71,35 @@ export function LabEvolveForm({ strategyName, onSubmit, disabled }: LabEvolveFor
             disabled={disabled}
           />
         </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Label htmlFor="evolve-entry-only" className="text-xs">
+          Entry Filter Only
+        </Label>
+        <Switch
+          id="evolve-entry-only"
+          checked={entryFilterOnly}
+          onCheckedChange={setEntryFilterOnly}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Allowed Categories</Label>
+        <Select
+          value={categoryScope}
+          onValueChange={(value) => setCategoryScope(resolveCategoryScope(value))}
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="fundamental">Fundamental Only</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <Button className="w-full" onClick={handleSubmit} disabled={disabled || !strategyName}>

--- a/apps/ts/packages/web/src/components/Lab/LabOptimizeForm.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabOptimizeForm.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { LabOptimizeForm } from './LabOptimizeForm';
+
+describe('LabOptimizeForm', () => {
+  it('submits default payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabOptimizeForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+    await user.click(screen.getByRole('button', { name: 'Start Optimization' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      trials: 50,
+      sampler: 'tpe',
+    });
+  });
+
+  it('falls back to default trials when input is invalid', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabOptimizeForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+
+    await user.clear(screen.getByLabelText('Trials'));
+    await user.click(screen.getByRole('button', { name: 'Start Optimization' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      trials: 50,
+      sampler: 'tpe',
+    });
+  });
+
+  it('submits fundamental-only constraints', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<LabOptimizeForm strategyName="experimental/base_strategy_01" onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('switch', { name: 'Entry Filter Only' }));
+    const comboboxes = screen.getAllByRole('combobox');
+    const categoryCombobox = comboboxes.at(1);
+    expect(categoryCombobox).toBeDefined();
+    if (!categoryCombobox) {
+      return;
+    }
+    await user.click(categoryCombobox);
+    await user.click(screen.getByText('Fundamental Only'));
+    await user.click(screen.getByRole('button', { name: 'Start Optimization' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      strategy_name: 'experimental/base_strategy_01',
+      trials: 50,
+      sampler: 'tpe',
+      entry_filter_only: true,
+      allowed_categories: ['fundamental'],
+    });
+  });
+
+  it('disables submit when strategy is not selected', () => {
+    const onSubmit = vi.fn();
+    render(<LabOptimizeForm strategyName={null} onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('button', { name: 'Start Optimization' })).toBeDisabled();
+  });
+});

--- a/apps/ts/packages/web/src/components/Lab/LabOptimizeForm.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabOptimizeForm.tsx
@@ -3,7 +3,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import type { LabOptimizeRequest } from '@/types/backtest';
+
+type CategoryScope = 'all' | 'fundamental';
+
+function resolveCategoryScope(value: string): CategoryScope {
+  return value === 'fundamental' ? 'fundamental' : 'all';
+}
 
 interface LabOptimizeFormProps {
   strategyName: string | null;
@@ -14,14 +21,23 @@ interface LabOptimizeFormProps {
 export function LabOptimizeForm({ strategyName, onSubmit, disabled }: LabOptimizeFormProps) {
   const [trials, setTrials] = useState('50');
   const [sampler, setSampler] = useState('tpe');
+  const [entryFilterOnly, setEntryFilterOnly] = useState(false);
+  const [categoryScope, setCategoryScope] = useState<CategoryScope>('all');
 
   const handleSubmit = () => {
     if (!strategyName) return;
-    onSubmit({
+    const request: LabOptimizeRequest = {
       strategy_name: strategyName,
       trials: Number(trials) || 50,
       sampler,
-    });
+    };
+    if (entryFilterOnly) {
+      request.entry_filter_only = true;
+    }
+    if (categoryScope === 'fundamental') {
+      request.allowed_categories = ['fundamental'];
+    }
+    onSubmit(request);
   };
 
   return (
@@ -54,6 +70,35 @@ export function LabOptimizeForm({ strategyName, onSubmit, disabled }: LabOptimiz
             </SelectContent>
           </Select>
         </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Label htmlFor="opt-entry-only" className="text-xs">
+          Entry Filter Only
+        </Label>
+        <Switch
+          id="opt-entry-only"
+          checked={entryFilterOnly}
+          onCheckedChange={setEntryFilterOnly}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Allowed Categories</Label>
+        <Select
+          value={categoryScope}
+          onValueChange={(value) => setCategoryScope(resolveCategoryScope(value))}
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="fundamental">Fundamental Only</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <Button className="w-full" onClick={handleSubmit} disabled={disabled || !strategyName}>


### PR DESCRIPTION
## Summary
- add entry_filter_only and allowed_categories to Lab evolve/optimize backend schemas, routes, service, and CLI
- apply category/entry-only filtering inside ParameterEvolver and OptunaOptimizer via shared signal filter helper
- implement evolve/optimize filter controls in web forms and update TS client types/OpenAPI generated types
- add/expand backend and frontend tests, including deeper branch coverage paths and an Optuna signal-name parsing fix
- update README/AGENTS lab command examples to include evolve/optimize constraints

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check ...
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/cli_bt/test_lab_cli.py apps/bt/tests/server/routes/test_lab.py apps/bt/tests/unit/agent/test_models.py apps/bt/tests/unit/agent/test_optuna_optimizer.py apps/bt/tests/unit/agent/test_parameter_evolver.py --cov=apps/bt/src --cov-branch --cov-report=
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test src/components/Lab/LabEvolveForm.test.tsx src/components/Lab/LabOptimizeForm.test.tsx