### PR TITLE
perf(bt): reuse cached signals and gate optional data loading

### DIFF
--- a/apps/bt/src/strategies/core/mixins/portfolio_analyzer_mixin_kelly.py
+++ b/apps/bt/src/strategies/core/mixins/portfolio_analyzer_mixin_kelly.py
@@ -5,6 +5,7 @@ YamlConfigurableStrategy用のケリー基準を用いたポートフォリオ�
 統合ポートフォリオ全体の統計から最適配分率を計算します。
 """
 
+import math
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import pandas as pd
@@ -249,9 +250,23 @@ class PortfolioAnalyzerKellyMixin:
                 "info",
             )
 
-            kelly_portfolio, _ = self.run_multi_backtest(
-                allocation_pct=optimized_allocation,
-            )
+            if self.group_by and hasattr(self, "run_multi_backtest_from_cached_signals"):
+                try:
+                    kelly_portfolio = self.run_multi_backtest_from_cached_signals(
+                        optimized_allocation
+                    )
+                except Exception as e:
+                    self._log(
+                        f"キャッシュ再利用に失敗したため通常実行にフォールバック: {e}",
+                        "debug",
+                    )
+                    kelly_portfolio, _ = self.run_multi_backtest(
+                        allocation_pct=optimized_allocation,
+                    )
+            else:
+                kelly_portfolio, _ = self.run_multi_backtest(
+                    allocation_pct=optimized_allocation,
+                )
 
             # 結果比較ログ
             self._log("✅ ケリー基準2段階最適化バックテスト完了", "info")
@@ -266,7 +281,7 @@ class PortfolioAnalyzerKellyMixin:
                 ):
                     improvement = kelly_return / initial_return
                     # Inf/-Inf チェック
-                    if not pd.isinf(improvement):
+                    if not math.isinf(improvement):
                         self._log(f"  - 第1段階リターン: {initial_return:.1%}", "info")
                         self._log(f"  - 第2段階リターン: {kelly_return:.1%}", "info")
                         self._log(f"  - 改善倍率: {improvement:.2f}x", "info")

--- a/apps/bt/src/strategies/core/mixins/protocols.py
+++ b/apps/bt/src/strategies/core/mixins/protocols.py
@@ -52,6 +52,9 @@ class StrategyProtocol(Protocol):
     relative_data_dict: dict[str, dict[str, pd.DataFrame]] | None
     execution_data_dict: dict[str, dict[str, pd.DataFrame]] | None
     multi_data_dict: dict[str, dict[str, pd.DataFrame]] | None
+    _grouped_portfolio_inputs_cache: (
+        tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame] | None
+    )
 
     # Logger method
     def _log(self, message: str, level: str = "info") -> None:
@@ -71,6 +74,14 @@ class StrategyProtocol(Protocol):
 
     def load_benchmark_data(self) -> pd.DataFrame:
         """Load benchmark data."""
+        ...
+
+    def _should_load_margin_data(self) -> bool:
+        """Return whether margin data is required."""
+        ...
+
+    def _should_load_statements_data(self) -> bool:
+        """Return whether statements data is required."""
         ...
 
     def generate_multi_signals(
@@ -95,6 +106,13 @@ class StrategyProtocol(Protocol):
         **kwargs: Any,
     ) -> Any:
         """Run multi-stock backtest."""
+        ...
+
+    def run_multi_backtest_from_cached_signals(
+        self,
+        allocation_pct: float,
+    ) -> vbt.Portfolio:
+        """Run grouped backtest by reusing cached close/entry/exit matrices."""
         ...
 
 

--- a/apps/bt/src/strategies/core/yaml_configurable_strategy.py
+++ b/apps/bt/src/strategies/core/yaml_configurable_strategy.py
@@ -99,6 +99,9 @@ class YamlConfigurableStrategy(
         self.multi_data_dict: Optional[Dict[str, Dict[str, pd.DataFrame]]] = None
         self.combined_portfolio: Optional[vbt.Portfolio] = None
         self.portfolio: Optional[vbt.Portfolio] = None
+        self._grouped_portfolio_inputs_cache: Optional[
+            tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
+        ] = None
 
         # Relative Mode用の追加属性
         self.relative_data_dict: Optional[Dict[str, Dict[str, pd.DataFrame]]] = None

--- a/apps/bt/tests/unit/strategies/mixins/test_backtest_executor_mixin.py
+++ b/apps/bt/tests/unit/strategies/mixins/test_backtest_executor_mixin.py
@@ -5,7 +5,12 @@ BacktestExecutorMixin ユニットテスト
 """
 
 from src.strategies.core.mixins.backtest_executor_mixin import BacktestExecutorMixin
-from src.models.signals import SignalParams, BetaSignalParams
+from src.models.signals import (
+    BetaSignalParams,
+    FundamentalSignalParams,
+    MarginSignalParams,
+    SignalParams,
+)
 
 
 class MockStrategy(BacktestExecutorMixin):
@@ -90,3 +95,42 @@ class TestBacktestExecutorMixin:
         )
 
         assert strategy._should_load_benchmark() is True
+
+    def test_should_load_margin_data_when_margin_signal_enabled(self):
+        """信用残高シグナル有効時は信用残高データロードが必要"""
+        strategy = MockStrategy()
+        strategy.entry_filter_params = SignalParams(
+            margin=MarginSignalParams(enabled=True)
+        )
+
+        assert strategy._should_load_margin_data() is True
+
+    def test_should_not_load_margin_data_when_margin_signal_disabled(self):
+        """信用残高シグナル無効時は信用残高データロード不要"""
+        strategy = MockStrategy()
+        strategy.entry_filter_params = SignalParams(
+            margin=MarginSignalParams(enabled=False)
+        )
+
+        assert strategy._should_load_margin_data() is False
+
+    def test_should_load_statements_data_when_fundamental_signal_enabled(self):
+        """財務シグナル有効時は財務諸表データロードが必要"""
+        strategy = MockStrategy()
+        strategy.entry_filter_params = SignalParams(
+            fundamental=FundamentalSignalParams(
+                enabled=True,
+                per={"enabled": True, "threshold": 15.0, "condition": "below"},
+            )
+        )
+
+        assert strategy._should_load_statements_data() is True
+
+    def test_should_not_load_statements_data_when_no_fundamental_subsignal_enabled(self):
+        """fundamental.enabled=True でもサブシグナル無効なら財務諸表データは不要"""
+        strategy = MockStrategy()
+        strategy.entry_filter_params = SignalParams(
+            fundamental=FundamentalSignalParams(enabled=True)
+        )
+
+        assert strategy._should_load_statements_data() is False

--- a/apps/bt/tests/unit/strategies/mixins/test_backtest_executor_mixin_paths.py
+++ b/apps/bt/tests/unit/strategies/mixins/test_backtest_executor_mixin_paths.py
@@ -1,0 +1,342 @@
+"""BacktestExecutorMixin の実行経路テスト."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import vectorbt as vbt
+
+from src.models.allocation import AllocationInfo
+from src.models.signals import SignalParams, Signals
+from src.models.signals.fundamental import FundamentalSignalParams
+from src.models.signals.macro import MarginSignalParams
+from src.models.signals.sector import SectorStrengthRankingParams
+from src.strategies.core.mixins.backtest_executor_mixin import (
+    BacktestExecutorMixin,
+    _any_signal_enabled,
+    _is_signal_enabled,
+)
+
+
+def _ohlcv_df(start: str = "2020-01-01", periods: int = 4) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [10.0, 11.0, 12.0, 13.0],
+            "High": [11.0, 12.0, 13.0, 14.0],
+            "Low": [9.0, 10.0, 11.0, 12.0],
+            "Close": [10.5, 11.5, 12.5, 13.5],
+            "Volume": [100.0, 200.0, 300.0, 400.0],
+        },
+        index=idx,
+    )
+
+
+def _margin_df(index: pd.DatetimeIndex) -> pd.DataFrame:
+    return pd.DataFrame({"margin_balance": [1.0, 2.0, 3.0, 4.0]}, index=index)
+
+
+def _statements_df(index: pd.DatetimeIndex) -> pd.DataFrame:
+    return pd.DataFrame({"EPS": [1.0, 1.1, 1.2, 1.3]}, index=index)
+
+
+def _signals(index: pd.DatetimeIndex) -> Signals:
+    entries = pd.Series([True, True, False, False], index=index, dtype=bool)
+    exits = pd.Series([False, False, False, True], index=index, dtype=bool)
+    return Signals(entries=entries, exits=exits)
+
+
+class _RuntimeStrategy(BacktestExecutorMixin):
+    def __init__(self) -> None:
+        self.stock_codes = ["1111", "2222"]
+        self.stock_code = "1111"
+        self.initial_cash = 1_000_000.0
+        self.fees = 0.001
+        self.spread = 0.0
+        self.borrow_fee = 0.0
+        self.slippage = 0.0
+        self.max_concurrent_positions = None
+        self.max_exposure = None
+        self.cash_sharing = True
+        self.group_by = True
+        self.direction = "longonly"
+        self.printlog = False
+        self.relative_mode = False
+        self.dataset = "primeExTopix500"
+        self.start_date = None
+        self.end_date = None
+        self.timeframe = "daily"
+        self.include_margin_data = False
+        self.include_statements_data = False
+        self.entry_filter_params = None
+        self.exit_trigger_params = None
+        self.benchmark_table = "topix"
+        self.benchmark_data = None
+        self.relative_data_dict = None
+        self.execution_data_dict = None
+        self.multi_data_dict = None
+        self.combined_portfolio = None
+        self.portfolio = None
+        self._grouped_portfolio_inputs_cache = None
+        self.kelly_fraction = 0.5
+        self.min_allocation = 0.01
+        self.max_allocation = 0.5
+        self.logs: list[tuple[str, str]] = []
+        self._mock_multi_data: dict[str, dict[str, pd.DataFrame]] = {}
+        self._mock_relative_data: tuple[
+            dict[str, dict[str, pd.DataFrame]],
+            dict[str, dict[str, pd.DataFrame]],
+        ] = ({}, {})
+        self._next_signals = {}
+
+    def _log(self, message: str, level: str = "info") -> None:
+        self.logs.append((level, message))
+
+    def load_multi_data(self) -> dict[str, dict[str, pd.DataFrame]]:
+        return self._mock_multi_data
+
+    def load_relative_data(
+        self,
+    ) -> tuple[dict[str, dict[str, pd.DataFrame]], dict[str, dict[str, pd.DataFrame]]]:
+        return self._mock_relative_data
+
+    def load_benchmark_data(self) -> pd.DataFrame:
+        self.benchmark_data = _ohlcv_df()[["Open", "High", "Low", "Close"]]
+        return self.benchmark_data
+
+    def generate_multi_signals(self, stock_code: str, data: pd.DataFrame, **kwargs) -> Signals:
+        if stock_code in self._next_signals:
+            return self._next_signals[stock_code]
+        return _signals(data.index)
+
+
+class TestBacktestExecutorMixinPaths:
+    def test_signal_helpers(self) -> None:
+        params = SignalParams(margin=MarginSignalParams(enabled=True))
+        assert _is_signal_enabled(params, "margin") is True
+        assert _is_signal_enabled(params, "fundamental") is False
+        assert _is_signal_enabled(None, "margin") is False
+        assert (
+            _any_signal_enabled(params, None, ("margin",))
+            == "entry_filter_params.margin"
+        )
+        assert _any_signal_enabled(None, None, ("margin",)) is None
+
+    def test_find_data_requirement(self) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.entry_filter_params = SignalParams(
+            fundamental=FundamentalSignalParams(
+                enabled=True,
+                per={"enabled": True, "threshold": 15.0, "condition": "below"},
+            )
+        )
+        strategy.exit_trigger_params = SignalParams(
+            margin=MarginSignalParams(enabled=True)
+        )
+        assert strategy._find_signal_for_data_requirement("statements")
+        assert strategy._find_signal_for_data_requirement("margin")
+        assert strategy._find_signal_for_data_requirement("not_exists") is None
+
+    def test_calculate_cost_params_for_short(self) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.spread = 0.0005
+        strategy.borrow_fee = 0.0007
+        strategy.direction = "both"
+        fees, slippage = strategy._calculate_cost_params()
+        assert fees == pytest.approx(0.0022)
+        assert slippage == 0.0
+
+    def test_cache_helpers(self) -> None:
+        strategy = _RuntimeStrategy()
+        close = pd.DataFrame({"1111": [1.0]})
+        entries = pd.DataFrame({"1111": [True]})
+        exits = pd.DataFrame({"1111": [False]})
+        strategy._set_grouped_portfolio_inputs_cache(close, entries, exits)
+        cached = strategy._get_grouped_portfolio_inputs_cache()
+        assert cached is not None
+        assert cached[0].equals(close)
+        strategy._grouped_portfolio_inputs_cache = ("bad", "bad", "bad")
+        assert strategy._get_grouped_portfolio_inputs_cache() is None
+        strategy._clear_grouped_portfolio_inputs_cache()
+        assert strategy._get_grouped_portfolio_inputs_cache() is None
+
+    def test_create_grouped_portfolio_multi_and_single(self) -> None:
+        strategy = _RuntimeStrategy()
+        close = pd.DataFrame({"1111": [1.0, 2.0], "2222": [3.0, 4.0]})
+        entries = pd.DataFrame({"1111": [True, False], "2222": [True, False]})
+        exits = pd.DataFrame({"1111": [False, True], "2222": [False, True]})
+        strategy.max_exposure = 0.2
+
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf-multi") as mocked:
+            out = strategy._create_grouped_portfolio(close, entries, exits, allocation_pct=0.3)
+            assert out == "pf-multi"
+            kwargs = mocked.call_args.kwargs
+            assert kwargs["size"] == pytest.approx(0.3)
+            assert kwargs["max_size"] == pytest.approx(0.2)
+
+        strategy.stock_codes = ["1111"]
+        strategy.cash_sharing = False
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf-single") as mocked:
+            out = strategy._create_grouped_portfolio(close[["1111"]], entries[["1111"]], exits[["1111"]])
+            assert out == "pf-single"
+            kwargs = mocked.call_args.kwargs
+            assert kwargs["group_by"] is None
+
+    def test_run_multi_backtest_from_cached_signals(self) -> None:
+        strategy = _RuntimeStrategy()
+        with pytest.raises(ValueError):
+            strategy.run_multi_backtest_from_cached_signals(0.2)
+
+        close = pd.DataFrame({"1111": [1.0], "2222": [2.0]})
+        entries = pd.DataFrame({"1111": [True], "2222": [False]})
+        exits = pd.DataFrame({"1111": [False], "2222": [True]})
+        strategy._set_grouped_portfolio_inputs_cache(close, entries, exits)
+        with patch.object(strategy, "_create_grouped_portfolio", return_value="cached-pf") as mocked:
+            out = strategy.run_multi_backtest_from_cached_signals(0.15)
+            assert out == "cached-pf"
+            assert strategy.combined_portfolio == "cached-pf"
+            mocked.assert_called_once()
+
+    def test_run_multi_backtest_grouped_standard_mode(self) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.max_concurrent_positions = 1
+        strategy._mock_multi_data = {
+            "1111": {"daily": _ohlcv_df()},
+            "2222": {"daily": _ohlcv_df()},
+        }
+
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf"):
+            portfolio, all_entries = strategy.run_multi_backtest()
+
+        assert portfolio == "pf"
+        assert all_entries is not None
+        assert isinstance(all_entries, pd.DataFrame)
+        assert strategy._grouped_portfolio_inputs_cache is not None
+
+    def test_run_multi_backtest_grouped_with_sector_and_benchmark(self, monkeypatch) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.entry_filter_params = SignalParams(
+            sector_strength_ranking=SectorStrengthRankingParams(enabled=True)
+        )
+        strategy._mock_multi_data = {
+            "1111": {"daily": _ohlcv_df()},
+            "2222": {"daily": _ohlcv_df()},
+        }
+
+        monkeypatch.setattr(
+            "src.data.loaders.sector_loaders.load_all_sector_indices",
+            lambda *_args, **_kwargs: {"Tech": _ohlcv_df()},
+        )
+        monkeypatch.setattr(
+            "src.data.loaders.sector_loaders.get_stock_sector_mapping",
+            lambda *_args, **_kwargs: {"1111": "Tech", "2222": "Tech"},
+        )
+
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf"):
+            portfolio, _ = strategy.run_multi_backtest()
+        assert portfolio == "pf"
+        assert strategy.benchmark_data is not None
+
+    def test_run_multi_backtest_relative_mode(self) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.stock_codes = ["1111"]
+        strategy.relative_mode = True
+        strategy.include_margin_data = True
+        strategy.include_statements_data = True
+        relative_df = _ohlcv_df()
+        execution_df = _ohlcv_df()
+        strategy._mock_relative_data = (
+            {"1111": {"daily": relative_df}},
+            {
+                "1111": {
+                    "daily": execution_df,
+                    "margin_daily": _margin_df(execution_df.index),
+                    "statements_daily": _statements_df(execution_df.index),
+                }
+            },
+        )
+        strategy._next_signals = {"1111": _signals(relative_df.index)}
+
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf-relative"):
+            portfolio, all_entries = strategy.run_multi_backtest()
+
+        assert portfolio == "pf-relative"
+        assert all_entries is not None
+
+    def test_run_multi_backtest_missing_codes_and_empty_data(self) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.stock_codes = ["1111", "9999"]
+        strategy._mock_multi_data = {"1111": {"daily": _ohlcv_df()}}
+
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf"):
+            portfolio, _ = strategy.run_multi_backtest()
+        assert portfolio == "pf"
+        assert strategy.stock_codes == ["1111"]
+
+        strategy2 = _RuntimeStrategy()
+        strategy2.stock_codes = ["9999"]
+        strategy2._mock_multi_data = {}
+        with pytest.raises(ValueError):
+            strategy2.run_multi_backtest()
+
+    def test_run_multi_backtest_individual_mode(self) -> None:
+        strategy = _RuntimeStrategy()
+        strategy.group_by = False
+        strategy.max_exposure = 0.4
+        strategy._mock_multi_data = {
+            "1111": {"daily": _ohlcv_df()},
+            "2222": {"daily": _ohlcv_df()},
+        }
+        with patch.object(vbt.Portfolio, "from_signals", return_value="pf-individual"):
+            portfolio, all_entries = strategy.run_multi_backtest()
+        assert portfolio == "pf-individual"
+        assert all_entries is None
+
+    def test_limit_entries_per_day(self) -> None:
+        entries = pd.DataFrame(
+            {"1111": [True, True], "2222": [True, False], "3333": [True, True]}
+        )
+        limited = BacktestExecutorMixin._limit_entries_per_day(entries, 2)
+        assert limited.iloc[0].sum() == 2
+        assert limited.iloc[1].sum() <= 2
+        assert BacktestExecutorMixin._limit_entries_per_day(entries, 0).equals(entries)
+
+    def test_run_optimized_backtest_success_and_failure(self) -> None:
+        strategy = _RuntimeStrategy()
+        initial_pf = MagicMock()
+        final_pf = MagicMock()
+        entries = pd.DataFrame({"1111": [True]})
+        with patch.object(
+            strategy,
+            "run_optimized_backtest_kelly",
+            return_value=(
+                initial_pf,
+                final_pf,
+                0.2,
+                {
+                    "win_rate": 0.5,
+                    "avg_win": 1.0,
+                    "avg_loss": 0.5,
+                    "total_trades": 10,
+                    "kelly": 0.4,
+                },
+                entries,
+            ),
+            create=True,
+        ):
+            got_initial, got_final, alloc = strategy.run_optimized_backtest()
+            assert got_initial is initial_pf
+            assert got_final is final_pf
+            assert isinstance(alloc, AllocationInfo)
+            assert strategy.all_entries is entries
+
+        with patch.object(
+            strategy,
+            "run_optimized_backtest_kelly",
+            side_effect=Exception("boom"),
+            create=True,
+        ):
+            with pytest.raises(RuntimeError):
+                strategy.run_optimized_backtest()

--- a/apps/bt/tests/unit/strategies/mixins/test_data_manager_mixin_paths.py
+++ b/apps/bt/tests/unit/strategies/mixins/test_data_manager_mixin_paths.py
@@ -1,0 +1,157 @@
+"""DataManagerMixin の実行経路テスト."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from src.strategies.core.mixins.data_manager_mixin import DataManagerMixin
+
+
+def _ohlcv_df(start: str = "2020-01-01", periods: int = 4) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=periods, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [10.0, 11.0, 12.0, 13.0],
+            "High": [11.0, 12.0, 13.0, 14.0],
+            "Low": [9.0, 10.0, 11.0, 12.0],
+            "Close": [10.5, 11.5, 12.5, 13.5],
+            "Volume": [100.0, 200.0, 300.0, 400.0],
+        },
+        index=idx,
+    )
+
+
+class _DataManagerStrategy(DataManagerMixin):
+    def __init__(self) -> None:
+        self.dataset = "primeExTopix500"
+        self.stock_codes = ["1111"]
+        self.start_date = None
+        self.end_date = None
+        self.timeframe = "daily"
+        self.include_margin_data = True
+        self.include_statements_data = True
+        self.multi_data_dict = None
+        self.relative_data_dict = None
+        self.execution_data_dict = None
+        self.benchmark_data = None
+        self.benchmark_table = "topix"
+        self.entry_filter_params = None
+        self.exit_trigger_params = None
+        self.logs: list[tuple[str, str]] = []
+        self._should_load_margin_data = lambda: False
+        self._should_load_statements_data = lambda: False
+
+    def _log(self, message: str, level: str = "info") -> None:
+        self.logs.append((level, message))
+
+
+class TestDataManagerMixinPaths:
+    def test_load_benchmark_data_success_and_cached(self, monkeypatch) -> None:
+        strategy = _DataManagerStrategy()
+        calls = {"count": 0}
+
+        def fake_load_topix(_dataset, _start, _end):
+            calls["count"] += 1
+            return _ohlcv_df()[["Open", "High", "Low", "Close"]]
+
+        monkeypatch.setattr(
+            "src.strategies.core.mixins.data_manager_mixin.load_topix_data",
+            fake_load_topix,
+        )
+
+        first = strategy.load_benchmark_data()
+        second = strategy.load_benchmark_data()
+        assert not first.empty
+        assert first.equals(second)
+        assert calls["count"] == 1
+
+    def test_load_benchmark_data_error(self, monkeypatch) -> None:
+        strategy = _DataManagerStrategy()
+
+        def raise_error(*_args, **_kwargs):
+            raise RuntimeError("load fail")
+
+        monkeypatch.setattr(
+            "src.strategies.core.mixins.data_manager_mixin.load_topix_data",
+            raise_error,
+        )
+
+        with pytest.raises(ValueError):
+            strategy.load_benchmark_data()
+
+    def test_load_relative_data_success_and_fallback(self, monkeypatch) -> None:
+        strategy = _DataManagerStrategy()
+        strategy.stock_codes = ["1111"]
+        daily = _ohlcv_df()
+        weekly = _ohlcv_df("2020-01-01", 4)
+
+        strategy.load_benchmark_data = MagicMock(
+            return_value=_ohlcv_df()[["Open", "High", "Low", "Close"]]
+        )
+        strategy.load_multi_data = MagicMock(
+            return_value={"1111": {"daily": daily, "weekly": weekly}}
+        )
+
+        call_state = {"count": 0}
+
+        def fake_relative(stock_df, _benchmark):
+            call_state["count"] += 1
+            if call_state["count"] == 2:
+                raise RuntimeError("relative fail")
+            out = stock_df.copy()
+            out["Close"] = out["Close"] / 2
+            return out
+
+        monkeypatch.setattr(
+            "src.strategies.core.mixins.data_manager_mixin.create_relative_ohlc_data",
+            fake_relative,
+        )
+
+        relative_data, execution_data = strategy.load_relative_data()
+        assert "1111" in relative_data
+        assert "1111" in execution_data
+        assert relative_data["1111"]["daily"]["Close"].iloc[0] == pytest.approx(
+            daily["Close"].iloc[0] / 2
+        )
+        assert relative_data["1111"]["weekly"].equals(weekly)
+
+    def test_load_relative_data_uses_cache(self) -> None:
+        strategy = _DataManagerStrategy()
+        cached = {"1111": {"daily": _ohlcv_df()}}
+        strategy.relative_data_dict = cached
+        strategy.execution_data_dict = cached
+
+        strategy.load_benchmark_data = MagicMock(side_effect=AssertionError("should not call"))
+        strategy.load_multi_data = MagicMock(side_effect=AssertionError("should not call"))
+
+        relative_data, execution_data = strategy.load_relative_data()
+        assert relative_data is cached
+        assert execution_data is cached
+
+    def test_load_multi_data_warning_when_required_but_disabled(self, monkeypatch) -> None:
+        strategy = _DataManagerStrategy()
+        strategy.include_margin_data = False
+        strategy.include_statements_data = False
+        strategy._should_load_margin_data = lambda: True
+        strategy._should_load_statements_data = lambda: True
+
+        captured: dict[str, object] = {}
+
+        def fake_prepare_multi_data(**kwargs):
+            captured.update(kwargs)
+            return {"1111": {"daily": _ohlcv_df()}}
+
+        monkeypatch.setattr(
+            "src.strategies.core.mixins.data_manager_mixin.prepare_multi_data",
+            fake_prepare_multi_data,
+        )
+
+        got = strategy.load_multi_data()
+        assert "1111" in got
+        assert captured["include_margin_data"] is False
+        assert captured["include_statements_data"] is False
+        assert any("include_margin_data=false" in msg for _lvl, msg in strategy.logs)
+        assert any("include_statements_data=false" in msg for _lvl, msg in strategy.logs)


### PR DESCRIPTION
## Summary
- reuse grouped backtest inputs to avoid signal recomputation in Kelly stage 2
- dynamically decide margin/statements loading from enabled signal data requirements
- keep default include flags true and apply runtime gating at load time
- add/expand unit tests for backtest executor, data manager, and kelly analyzer paths

## Validation
- uv run pytest tests/unit/strategies/mixins/test_backtest_executor_mixin.py tests/unit/strategies/mixins/test_backtest_executor_mixin_paths.py tests/unit/strategies/mixins/test_data_manager_mixin_paths.py tests/unit/strategies/mixins/test_portfolio_analyzer_mixin_kelly.py tests/unit/models/test_fundamental_period_type.py --cov=src/strategies/core/mixins --cov-branch --cov-report=term-missing
- uv run ruff check src/strategies/core/mixins/portfolio_analyzer_mixin_kelly.py tests/unit/strategies/mixins/test_portfolio_analyzer_mixin_kelly.py
- uv run pyright src/strategies/core/mixins/portfolio_analyzer_mixin_kelly.py