### PR TITLE
fix(bt): harden incremental indices sync fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **market.db**: 読み書き（SQLAlchemy Core）
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
-- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する（`indices-only` は指数再同期専用モード）
+- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新し、`/indices` 取得失敗時は日付指定フォールバックで継続する（`indices-only` は指数再同期専用モード）
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う


### PR DESCRIPTION
## Summary
- make incremental index sync resilient when index master fetch fails
- add date-based fallback sync path with anchor-date recheck
- normalize index code parsing (40 to 0040) and add regression tests
- update AGENTS sync note with fallback behavior

## Testing
- uv run --project /Users/shinjiroaso/.codex/worktrees/8408/trading25/apps/bt pytest tests/unit/server/services/test_sync_strategies.py
- uv run --project /Users/shinjiroaso/.codex/worktrees/8408/trading25/apps/bt ruff check src/server/services/sync_strategies.py tests/unit/server/services/test_sync_strategies.py
- uv run --project /Users/shinjiroaso/.codex/worktrees/8408/trading25/apps/bt pyright src/server/services/sync_strategies.py
- coverage: sync_strategies.py branch 82.5%, line 92.66%