### PR TITLE
fix(backtest): classify risk_adjusted_return as volatility

### DIFF
--- a/apps/bt/src/strategies/signals/registry.py
+++ b/apps/bt/src/strategies/signals/registry.py
@@ -616,7 +616,7 @@ SIGNAL_REGISTRY: list[SignalDefinition] = [
         },
         entry_purpose="高リスク調整リターン銘柄選別",
         exit_purpose="低リスク調整リターン警告",
-        category="fundamental",
+        category="volatility",
         description="シャープレシオ/ソルティノレシオの判定",
         param_key="risk_adjusted_return",
         data_checker=lambda d: "close" in d,

--- a/apps/bt/tests/server/test_signal_reference.py
+++ b/apps/bt/tests/server/test_signal_reference.py
@@ -67,6 +67,15 @@ class TestBuildSignalReference:
         sector_signals = [s for s in result["signals"] if s["category"] == "sector"]
         assert len(sector_signals) == 3
 
+    def test_risk_adjusted_return_is_not_classified_as_fundamental(self):
+        """risk_adjusted_return は fundamental 配下ではなく volatility として返ること"""
+        result = build_signal_reference()
+        signal = next(s for s in result["signals"] if s["key"] == "risk_adjusted_return")
+        assert signal["category"] == "volatility"
+        parsed = yaml.safe_load(signal["yaml_snippet"])
+        assert "risk_adjusted_return" in parsed
+        assert "fundamental" not in parsed
+
 
 class TestYAMLSnippets:
     """YAMLスニペットのテスト"""

--- a/apps/bt/tests/unit/strategies/signals/test_registry.py
+++ b/apps/bt/tests/unit/strategies/signals/test_registry.py
@@ -219,6 +219,15 @@ class TestSignalRegistry:
         params.fundamental.market_cap.enabled = False
         assert not sig.enabled_checker(params)
 
+    def test_risk_adjusted_return_registered_as_volatility(self) -> None:
+        """risk_adjusted_return は独立シグナルとして volatility に分類されること"""
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "risk_adjusted_return"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "リスク調整リターン"
+        assert sig.category == "volatility"
+        assert sig.data_requirements == ["ohlc"]
+
 
 class TestFundamentalAdjustedSelection:
     def _get_signal(self, param_key: str):

--- a/apps/ts/packages/web/src/components/Backtest/strategyValidation.test.ts
+++ b/apps/ts/packages/web/src/components/Backtest/strategyValidation.test.ts
@@ -104,7 +104,7 @@ describe('validateStrategyConfigLocally', () => {
       {
         key: 'risk_adjusted_return',
         name: 'Risk Adjusted Return',
-        category: 'fundamental',
+        category: 'volatility',
         description: '',
         usage_hint: '',
         yaml_snippet: '',


### PR DESCRIPTION
## Summary
- change risk_adjusted_return category from fundamental to volatility in signal registry
- add bt tests to prevent reclassification regressions in registry and signal reference output
- update web strategy validation test fixture to match backend category

## Validation
- uv run --project apps/bt pytest apps/bt/tests/unit/strategies/signals/test_registry.py apps/bt/tests/server/test_signal_reference.py
- bun run --filter @trading25/web test src/components/Backtest/strategyValidation.test.ts
- coverage run --branch for bt registry and signal_reference test targets with confcutdir
