### PR TITLE
fix(bt): finalize bt-031 direct access cleanup

### DIFF
--- a/apps/bt/src/cli_bt/backtest.py
+++ b/apps/bt/src/cli_bt/backtest.py
@@ -17,6 +17,7 @@ from rich.text import Text
 from loguru import logger
 
 from src.constants import THREAD_TIMEOUT_SECONDS
+from src.data.access.mode import DATA_ACCESS_MODE_ENV
 from src.lib.strategy_runtime.loader import ConfigLoader
 
 console = Console()
@@ -123,6 +124,7 @@ def _execute_with_progress(
                 template_path=template_path,
                 parameters=parameters,
                 strategy_name=strategy_name,
+                extra_env={DATA_ACCESS_MODE_ENV: "direct"},
             )
         except Exception as e:
             result["error"] = e

--- a/apps/bt/src/data/access/clients.py
+++ b/apps/bt/src/data/access/clients.py
@@ -12,6 +12,11 @@ from typing import Any, Literal
 
 import pandas as pd
 
+from src.api.dataset.helpers import (
+    convert_dated_response,
+    convert_index_response,
+    convert_ohlcv_response,
+)
 from src.api.dataset_client import DatasetAPIClient
 from src.api.market_client import MarketAPIClient
 from src.config.settings import get_settings
@@ -25,6 +30,16 @@ _dataset_db_lock = threading.Lock()
 
 _market_reader: MarketDbReader | None = None
 _market_reader_lock = threading.Lock()
+
+
+def _rows_to_records(
+    rows: list[Any],
+    field_map: dict[str, str],
+) -> list[dict[str, Any]]:
+    return [
+        {output_field: getattr(row, source_attr) for output_field, source_attr in field_map.items()}
+        for row in rows
+    ]
 
 
 def _resolve_dataset_db(dataset_name: str) -> DatasetDb:
@@ -57,98 +72,74 @@ def _resolve_market_reader() -> MarketDbReader:
 
 
 def _to_ohlcv_df(rows: list[Any]) -> pd.DataFrame:
-    if not rows:
-        return pd.DataFrame()
-    index = pd.to_datetime([row.date for row in rows])
-    df = pd.DataFrame(
-        [
-            {
-                "Open": row.open,
-                "High": row.high,
-                "Low": row.low,
-                "Close": row.close,
-                "Volume": row.volume,
-            }
-            for row in rows
-        ]
+    records = _rows_to_records(
+        rows,
+        {
+            "date": "date",
+            "open": "open",
+            "high": "high",
+            "low": "low",
+            "close": "close",
+            "volume": "volume",
+        },
     )
-    df.index = index
-    df.index.name = "date"
-    return df
+    return convert_ohlcv_response(records)
 
 
 def _to_ohlc_df(rows: list[Any]) -> pd.DataFrame:
-    if not rows:
-        return pd.DataFrame()
-    index = pd.to_datetime([row.date for row in rows])
-    df = pd.DataFrame(
-        [
-            {
-                "Open": row.open,
-                "High": row.high,
-                "Low": row.low,
-                "Close": row.close,
-            }
-            for row in rows
-        ]
+    records = _rows_to_records(
+        rows,
+        {
+            "date": "date",
+            "open": "open",
+            "high": "high",
+            "low": "low",
+            "close": "close",
+        },
     )
-    df.index = index
-    df.index.name = "date"
-    return df
+    return convert_index_response(records)
 
 
 def _to_margin_df(rows: list[Any]) -> pd.DataFrame:
-    if not rows:
-        return pd.DataFrame()
-    index = pd.to_datetime([row.date for row in rows])
-    df = pd.DataFrame(
-        [
-            {
-                "longMarginVolume": row.long_margin_volume,
-                "shortMarginVolume": row.short_margin_volume,
-            }
-            for row in rows
-        ]
+    records = _rows_to_records(
+        rows,
+        {
+            "date": "date",
+            "longMarginVolume": "long_margin_volume",
+            "shortMarginVolume": "short_margin_volume",
+        },
     )
-    df.index = index
-    df.index.name = "date"
-    return df
+    return convert_dated_response(records)
 
 
 def _to_statements_df(rows: list[Any]) -> pd.DataFrame:
-    if not rows:
-        return pd.DataFrame()
-    index = pd.to_datetime([row.disclosed_date for row in rows])
-    df = pd.DataFrame(
-        [
-            {
-                "code": row.code,
-                "earningsPerShare": row.earnings_per_share,
-                "profit": row.profit,
-                "equity": row.equity,
-                "typeOfCurrentPeriod": row.type_of_current_period,
-                "typeOfDocument": row.type_of_document,
-                "nextYearForecastEarningsPerShare": row.next_year_forecast_earnings_per_share,
-                "bps": row.bps,
-                "sales": row.sales,
-                "operatingProfit": row.operating_profit,
-                "ordinaryProfit": row.ordinary_profit,
-                "operatingCashFlow": row.operating_cash_flow,
-                "dividendFY": row.dividend_fy,
-                "forecastEps": row.forecast_eps,
-                "investingCashFlow": row.investing_cash_flow,
-                "financingCashFlow": row.financing_cash_flow,
-                "cashAndEquivalents": row.cash_and_equivalents,
-                "totalAssets": row.total_assets,
-                "sharesOutstanding": row.shares_outstanding,
-                "treasuryShares": row.treasury_shares,
-            }
-            for row in rows
-        ]
+    records = _rows_to_records(
+        rows,
+        {
+            "code": "code",
+            "disclosedDate": "disclosed_date",
+            "earningsPerShare": "earnings_per_share",
+            "profit": "profit",
+            "equity": "equity",
+            "typeOfCurrentPeriod": "type_of_current_period",
+            "typeOfDocument": "type_of_document",
+            "nextYearForecastEarningsPerShare": "next_year_forecast_earnings_per_share",
+            "bps": "bps",
+            "sales": "sales",
+            "operatingProfit": "operating_profit",
+            "ordinaryProfit": "ordinary_profit",
+            "operatingCashFlow": "operating_cash_flow",
+            "dividendFY": "dividend_fy",
+            "forecastEps": "forecast_eps",
+            "investingCashFlow": "investing_cash_flow",
+            "financingCashFlow": "financing_cash_flow",
+            "cashAndEquivalents": "cash_and_equivalents",
+            "totalAssets": "total_assets",
+            "sharesOutstanding": "shares_outstanding",
+            "treasuryShares": "treasury_shares",
+        },
     )
-    df.index = index
-    df.index.name = "disclosedDate"
-    return df
+    return convert_dated_response(records, date_column="disclosedDate")
 
 
 class DirectDatasetClient:
@@ -403,40 +394,36 @@ class DirectMarketClient:
         sql += " ORDER BY date"
 
         rows = reader.query(sql, tuple(params))
-        if not rows:
-            return pd.DataFrame()
-        index = pd.to_datetime([row["date"] for row in rows])
-
-        df = pd.DataFrame(
-            [
-                {
-                    "Open": row["open"],
-                    "High": row["high"],
-                    "Low": row["low"],
-                    "Close": row["close"],
-                }
-                for row in rows
-            ]
-        )
-        df.index = index
-        df.index.name = "date"
-        return df
+        records = [
+            {
+                "date": row["date"],
+                "open": row["open"],
+                "high": row["high"],
+                "low": row["low"],
+                "close": row["close"],
+            }
+            for row in rows
+        ]
+        return convert_index_response(records)
 
 
-def get_dataset_client(
-    dataset_name: str,
-    http_client_factory: type[DatasetAPIClient] = DatasetAPIClient,
-) -> DatasetAPIClient | DirectDatasetClient:
+def _create_http_dataset_client(dataset_name: str) -> DatasetAPIClient:
+    return DatasetAPIClient(dataset_name)
+
+
+def _create_http_market_client() -> MarketAPIClient:
+    return MarketAPIClient()
+
+
+def get_dataset_client(dataset_name: str) -> DatasetAPIClient | DirectDatasetClient:
     """Return HTTP or direct dataset client based on active data-access mode."""
     if should_use_direct_db():
         return DirectDatasetClient(dataset_name)
-    return http_client_factory(dataset_name)
+    return _create_http_dataset_client(dataset_name)
 
 
-def get_market_client(
-    http_client_factory: type[MarketAPIClient] = MarketAPIClient,
-) -> MarketAPIClient | DirectMarketClient:
+def get_market_client() -> MarketAPIClient | DirectMarketClient:
     """Return HTTP or direct market client based on active data-access mode."""
     if should_use_direct_db():
         return DirectMarketClient()
-    return http_client_factory()
+    return _create_http_market_client()

--- a/apps/bt/src/data/loaders/data_preparation.py
+++ b/apps/bt/src/data/loaders/data_preparation.py
@@ -12,9 +12,6 @@ from loguru import logger
 from src.api.dataset.statements_mixin import APIPeriodType
 from src.api.exceptions import APIError
 from src.data.access.clients import get_dataset_client
-
-# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
-DatasetAPIClient = get_dataset_client
 from src.exceptions import (
     BatchAPIError,
     DataPreparationError,
@@ -32,6 +29,9 @@ from .multi_asset_loaders import (
 from .statements_loaders import load_statements_data, transform_statements_df
 from .stock_loaders import get_available_stocks, load_stock_data
 from .utils import extract_dataset_name
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 
 
 def prepare_all_stocks_data(

--- a/apps/bt/src/data/loaders/data_preparation.py
+++ b/apps/bt/src/data/loaders/data_preparation.py
@@ -9,10 +9,9 @@ from typing import Dict, List, Literal, Optional
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.api.dataset.statements_mixin import APIPeriodType
-from src.data.access.clients import get_dataset_client
 from src.api.exceptions import APIError
+from src.data.access.clients import get_dataset_client
 from src.exceptions import (
     BatchAPIError,
     DataPreparationError,
@@ -243,7 +242,7 @@ def prepare_multi_data(
     ohlcv_batch: Dict[str, pd.DataFrame] = {}
 
     try:
-        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+        with get_dataset_client(dataset_name) as client:
             ohlcv_batch = client.get_stocks_ohlcv_batch(
                 stock_codes, start_date, end_date, timeframe
             )
@@ -270,7 +269,7 @@ def prepare_multi_data(
         logger.debug("信用残高データ読み込み開始（バッチAPI）")
         margin_codes = list(result.keys())
         try:
-            with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+            with get_dataset_client(dataset_name) as client:
                 margin_batch = client.get_margin_batch(
                     margin_codes, start_date, end_date
                 )
@@ -303,7 +302,7 @@ def prepare_multi_data(
         logger.debug("財務諸表データ読み込み開始（バッチAPI）")
         statements_codes = list(result.keys())
         try:
-            with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+            with get_dataset_client(dataset_name) as client:
                 statements_batch = client.get_statements_batch(
                     statements_codes, start_date, end_date,
                     period_type=period_type, actual_only=True,

--- a/apps/bt/src/data/loaders/data_preparation.py
+++ b/apps/bt/src/data/loaders/data_preparation.py
@@ -12,6 +12,9 @@ from loguru import logger
 from src.api.dataset.statements_mixin import APIPeriodType
 from src.api.exceptions import APIError
 from src.data.access.clients import get_dataset_client
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 from src.exceptions import (
     BatchAPIError,
     DataPreparationError,
@@ -242,7 +245,7 @@ def prepare_multi_data(
     ohlcv_batch: Dict[str, pd.DataFrame] = {}
 
     try:
-        with get_dataset_client(dataset_name) as client:
+        with DatasetAPIClient(dataset_name) as client:
             ohlcv_batch = client.get_stocks_ohlcv_batch(
                 stock_codes, start_date, end_date, timeframe
             )
@@ -269,7 +272,7 @@ def prepare_multi_data(
         logger.debug("信用残高データ読み込み開始（バッチAPI）")
         margin_codes = list(result.keys())
         try:
-            with get_dataset_client(dataset_name) as client:
+            with DatasetAPIClient(dataset_name) as client:
                 margin_batch = client.get_margin_batch(
                     margin_codes, start_date, end_date
                 )
@@ -302,7 +305,7 @@ def prepare_multi_data(
         logger.debug("財務諸表データ読み込み開始（バッチAPI）")
         statements_codes = list(result.keys())
         try:
-            with get_dataset_client(dataset_name) as client:
+            with DatasetAPIClient(dataset_name) as client:
                 statements_batch = client.get_statements_batch(
                     statements_codes, start_date, end_date,
                     period_type=period_type, actual_only=True,

--- a/apps/bt/src/data/loaders/index_loaders.py
+++ b/apps/bt/src/data/loaders/index_loaders.py
@@ -1,7 +1,8 @@
 """
 インデックス・ベンチマークデータローダー
 
-localhost:3002 API経由でインデックス・ベンチマークデータを読み込み、VectorBTで使用できる形式に変換します。
+データアクセスクライアント経由でインデックス・ベンチマークデータを読み込み、
+VectorBTで使用できる形式に変換します。
 
 TOPIXデータの二重ロードパス:
     1. load_topix_data() — dataset.db の topix テーブルからロード（バックテスト専用）
@@ -15,8 +16,6 @@ from typing import Optional
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
-from src.api.market_client import MarketAPIClient
 from src.data.access.clients import get_dataset_client, get_market_client
 from src.data.loaders.cache import cached_loader
 from src.data.loaders.utils import extract_dataset_name
@@ -46,7 +45,7 @@ def load_topix_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_topix(start_date, end_date)
 
     if df.empty:
@@ -85,7 +84,7 @@ def load_topix_data_from_market_db(
         - 直近1年間の市場データ（日次更新）
         - バックテスト用のload_topix_data()とはテーブル名・データソースが異なる
     """
-    with get_market_client(http_client_factory=MarketAPIClient) as client:
+    with get_market_client() as client:
         df = client.get_topix(start_date, end_date)
 
     if df.empty:
@@ -123,7 +122,7 @@ def load_index_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_index(index_code, start_date, end_date)
 
     if df.empty:
@@ -149,7 +148,7 @@ def get_index_list(dataset: str, min_records: int = 100) -> list[str]:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_index_list(min_records)
 
     if df.empty:
@@ -171,7 +170,7 @@ def get_available_indices(dataset: str, min_records: int = 100) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_index_list(min_records)
 
     return df

--- a/apps/bt/src/data/loaders/index_loaders.py
+++ b/apps/bt/src/data/loaders/index_loaders.py
@@ -17,12 +17,12 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client, get_market_client
+from src.data.loaders.cache import cached_loader
+from src.data.loaders.utils import extract_dataset_name
 
 # Backward-compatible symbols for tests patching module-local client constructors.
 DatasetAPIClient = get_dataset_client
 MarketAPIClient = get_market_client
-from src.data.loaders.cache import cached_loader
-from src.data.loaders.utils import extract_dataset_name
 
 
 @cached_loader("topix:{dataset}:{start_date}:{end_date}")

--- a/apps/bt/src/data/loaders/index_loaders.py
+++ b/apps/bt/src/data/loaders/index_loaders.py
@@ -17,6 +17,10 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client, get_market_client
+
+# Backward-compatible symbols for tests patching module-local client constructors.
+DatasetAPIClient = get_dataset_client
+MarketAPIClient = get_market_client
 from src.data.loaders.cache import cached_loader
 from src.data.loaders.utils import extract_dataset_name
 
@@ -45,7 +49,7 @@ def load_topix_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_topix(start_date, end_date)
 
     if df.empty:
@@ -84,7 +88,7 @@ def load_topix_data_from_market_db(
         - 直近1年間の市場データ（日次更新）
         - バックテスト用のload_topix_data()とはテーブル名・データソースが異なる
     """
-    with get_market_client() as client:
+    with MarketAPIClient() as client:
         df = client.get_topix(start_date, end_date)
 
     if df.empty:
@@ -122,7 +126,7 @@ def load_index_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_index(index_code, start_date, end_date)
 
     if df.empty:
@@ -148,7 +152,7 @@ def get_index_list(dataset: str, min_records: int = 100) -> list[str]:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_index_list(min_records)
 
     if df.empty:
@@ -170,7 +174,7 @@ def get_available_indices(dataset: str, min_records: int = 100) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_index_list(min_records)
 
     return df

--- a/apps/bt/src/data/loaders/margin_loaders.py
+++ b/apps/bt/src/data/loaders/margin_loaders.py
@@ -11,11 +11,11 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client
+from src.data.loaders.cache import DataCache
+from src.data.loaders.utils import extract_dataset_name
 
 # Backward-compatible symbol for tests patching module-local DatasetAPIClient.
 DatasetAPIClient = get_dataset_client
-from src.data.loaders.cache import DataCache
-from src.data.loaders.utils import extract_dataset_name
 
 
 def transform_margin_df(df: pd.DataFrame) -> pd.DataFrame:

--- a/apps/bt/src/data/loaders/margin_loaders.py
+++ b/apps/bt/src/data/loaders/margin_loaders.py
@@ -1,7 +1,8 @@
 """
 信用残高データローダー
 
-localhost:3001 API経由で信用残高データを読み込み、VectorBTで使用できる形式に変換します。
+データアクセスクライアント経由で信用残高データを読み込み、
+VectorBTで使用できる形式に変換します。
 """
 
 from typing import Optional
@@ -9,7 +10,6 @@ from typing import Optional
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.data.access.clients import get_dataset_client
 from src.data.loaders.cache import DataCache
 from src.data.loaders.utils import extract_dataset_name
@@ -67,7 +67,7 @@ def load_margin_data(
             return cached
 
     # API呼び出し
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_margin(stock_code, start_date, end_date)
 
     if df.empty:
@@ -105,7 +105,7 @@ def get_margin_available_stocks(dataset: str, min_records: int = 10) -> pd.DataF
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_margin_list(min_records)
 
     return df

--- a/apps/bt/src/data/loaders/margin_loaders.py
+++ b/apps/bt/src/data/loaders/margin_loaders.py
@@ -11,6 +11,9 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 from src.data.loaders.cache import DataCache
 from src.data.loaders.utils import extract_dataset_name
 
@@ -67,7 +70,7 @@ def load_margin_data(
             return cached
 
     # API呼び出し
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_margin(stock_code, start_date, end_date)
 
     if df.empty:
@@ -105,7 +108,7 @@ def get_margin_available_stocks(dataset: str, min_records: int = 10) -> pd.DataF
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_margin_list(min_records)
 
     return df

--- a/apps/bt/src/data/loaders/multi_asset_loaders.py
+++ b/apps/bt/src/data/loaders/multi_asset_loaders.py
@@ -9,7 +9,6 @@ from typing import List, Literal, Optional
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.data.access.clients import get_dataset_client
 from src.exceptions import BatchAPIError, NoValidDataError
 
@@ -54,7 +53,7 @@ def load_multiple_stocks(
     if use_batch_api and not cache.is_enabled():
         dataset_name = extract_dataset_name(dataset)
         try:
-            with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+            with get_dataset_client(dataset_name) as client:
                 batch_data = client.get_stocks_ohlcv_batch(
                     stock_codes, start_date, end_date, timeframe
                 )
@@ -162,7 +161,7 @@ def load_multiple_margin_data(
 
     # バッチAPIを試行
     try:
-        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+        with get_dataset_client(dataset_name) as client:
             batch_data = client.get_margin_batch(
                 stock_codes, start_date, end_date
             )
@@ -229,7 +228,7 @@ def load_multiple_statements_data(
 
     # バッチAPIを試行
     try:
-        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+        with get_dataset_client(dataset_name) as client:
             batch_data = client.get_statements_batch(
                 stock_codes, start_date, end_date,
                 period_type=period_type, actual_only=True,

--- a/apps/bt/src/data/loaders/sector_loaders.py
+++ b/apps/bt/src/data/loaders/sector_loaders.py
@@ -9,6 +9,9 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 from src.exceptions import IndexDataLoadError, SectorDataLoadError
 
 from .index_loaders import load_index_data
@@ -35,7 +38,7 @@ def get_sector_mapping(dataset: str) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_sector_mapping()
 
     return df
@@ -169,7 +172,7 @@ def get_stock_sector_mapping(dataset: str) -> dict[str, str]:
     logger.info("銘柄→セクターマッピング取得開始")
 
     try:
-        with get_dataset_client(dataset_name) as client:
+        with DatasetAPIClient(dataset_name) as client:
             mapping = client.get_stock_sector_mapping()
 
         logger.info(f"銘柄→セクターマッピング取得完了: {len(mapping)}銘柄")

--- a/apps/bt/src/data/loaders/sector_loaders.py
+++ b/apps/bt/src/data/loaders/sector_loaders.py
@@ -9,13 +9,13 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client
-
-# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
-DatasetAPIClient = get_dataset_client
 from src.exceptions import IndexDataLoadError, SectorDataLoadError
 
 from .index_loaders import load_index_data
 from .utils import extract_dataset_name
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 
 # セクターデータキャッシュ（同一セッション内での重複APIコール回避）
 _sector_indices_cache: dict[str, dict[str, pd.DataFrame]] = {}

--- a/apps/bt/src/data/loaders/sector_loaders.py
+++ b/apps/bt/src/data/loaders/sector_loaders.py
@@ -1,13 +1,13 @@
 """
 セクター・業種別データローダー
 
-localhost:3001 API経由でセクター・業種別データを読み込み、VectorBTで使用できる形式に変換します。
+データアクセスクライアント経由でセクター・業種別データを読み込み、
+VectorBTで使用できる形式に変換します。
 """
 
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.data.access.clients import get_dataset_client
 from src.exceptions import IndexDataLoadError, SectorDataLoadError
 
@@ -35,7 +35,7 @@ def get_sector_mapping(dataset: str) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_sector_mapping()
 
     return df
@@ -169,7 +169,7 @@ def get_stock_sector_mapping(dataset: str) -> dict[str, str]:
     logger.info("銘柄→セクターマッピング取得開始")
 
     try:
-        with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+        with get_dataset_client(dataset_name) as client:
             mapping = client.get_stock_sector_mapping()
 
         logger.info(f"銘柄→セクターマッピング取得完了: {len(mapping)}銘柄")

--- a/apps/bt/src/data/loaders/statements_loaders.py
+++ b/apps/bt/src/data/loaders/statements_loaders.py
@@ -1,7 +1,8 @@
 """
 財務諸表データローダー
 
-localhost:3001 API経由で財務諸表データを読み込み、VectorBTで使用できる形式に変換します。
+データアクセスクライアント経由で財務諸表データを読み込み、
+VectorBTで使用できる形式に変換します。
 """
 
 from typing import Optional
@@ -10,7 +11,6 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.api.dataset.statements_mixin import APIPeriodType
 from src.data.access.clients import get_dataset_client
 from src.data.loaders.utils import extract_dataset_name
@@ -178,7 +178,7 @@ def load_statements_data(
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_statements(
             stock_code,
             start_date,

--- a/apps/bt/src/data/loaders/statements_loaders.py
+++ b/apps/bt/src/data/loaders/statements_loaders.py
@@ -13,6 +13,9 @@ from loguru import logger
 
 from src.api.dataset.statements_mixin import APIPeriodType
 from src.data.access.clients import get_dataset_client
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 from src.data.loaders.utils import extract_dataset_name
 from src.models.types import normalize_period_type
 
@@ -178,7 +181,7 @@ def load_statements_data(
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_statements(
             stock_code,
             start_date,

--- a/apps/bt/src/data/loaders/statements_loaders.py
+++ b/apps/bt/src/data/loaders/statements_loaders.py
@@ -13,11 +13,11 @@ from loguru import logger
 
 from src.api.dataset.statements_mixin import APIPeriodType
 from src.data.access.clients import get_dataset_client
+from src.data.loaders.utils import extract_dataset_name
+from src.models.types import normalize_period_type
 
 # Backward-compatible symbol for tests patching module-local DatasetAPIClient.
 DatasetAPIClient = get_dataset_client
-from src.data.loaders.utils import extract_dataset_name
-from src.models.types import normalize_period_type
 
 # カラム名マッピング（API -> VectorBT PascalCase）
 _COLUMN_MAPPING = {

--- a/apps/bt/src/data/loaders/stock_loaders.py
+++ b/apps/bt/src/data/loaders/stock_loaders.py
@@ -11,11 +11,11 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client
+from src.data.loaders.cache import DataCache, cached_loader
+from src.data.loaders.utils import extract_dataset_name
 
 # Backward-compatible symbol for tests patching module-local DatasetAPIClient.
 DatasetAPIClient = get_dataset_client
-from src.data.loaders.cache import DataCache, cached_loader
-from src.data.loaders.utils import extract_dataset_name
 
 
 def get_stock_list(dataset: str, min_records: int = 100) -> list[str]:

--- a/apps/bt/src/data/loaders/stock_loaders.py
+++ b/apps/bt/src/data/loaders/stock_loaders.py
@@ -11,6 +11,9 @@ import pandas as pd
 from loguru import logger
 
 from src.data.access.clients import get_dataset_client
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 from src.data.loaders.cache import DataCache, cached_loader
 from src.data.loaders.utils import extract_dataset_name
 
@@ -37,7 +40,7 @@ def get_stock_list(dataset: str, min_records: int = 100) -> list[str]:
             return cached["stockCode"].tolist()
 
     # API呼び出し
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_stock_list(min_records=min_records)
 
     if df.empty:
@@ -76,7 +79,7 @@ def load_stock_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_stock_ohlcv(stock_code, start_date, end_date, timeframe)
 
     if df.empty:
@@ -101,7 +104,7 @@ def get_available_stocks(dataset: str, min_records: int = 1000) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_available_stocks(min_records=min_records)
 
     return df

--- a/apps/bt/src/data/loaders/stock_loaders.py
+++ b/apps/bt/src/data/loaders/stock_loaders.py
@@ -1,7 +1,8 @@
 """
 株価データローダー
 
-localhost:3001 API経由で株価データを読み込み、VectorBTで使用できる形式に変換します。
+データアクセスクライアント経由で株価データを読み込み、
+VectorBTで使用できる形式に変換します。
 """
 
 from typing import Literal, Optional
@@ -9,7 +10,6 @@ from typing import Literal, Optional
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.data.access.clients import get_dataset_client
 from src.data.loaders.cache import DataCache, cached_loader
 from src.data.loaders.utils import extract_dataset_name
@@ -37,7 +37,7 @@ def get_stock_list(dataset: str, min_records: int = 100) -> list[str]:
             return cached["stockCode"].tolist()
 
     # API呼び出し
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_stock_list(min_records=min_records)
 
     if df.empty:
@@ -76,7 +76,7 @@ def load_stock_data(
     dataset_name = extract_dataset_name(dataset)
 
     # API呼び出し
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_stock_ohlcv(stock_code, start_date, end_date, timeframe)
 
     if df.empty:
@@ -101,7 +101,7 @@ def get_available_stocks(dataset: str, min_records: int = 1000) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_available_stocks(min_records=min_records)
 
     return df

--- a/apps/bt/src/server/services/backtest_service.py
+++ b/apps/bt/src/server/services/backtest_service.py
@@ -171,7 +171,6 @@ class BacktestService:
             strategy=strategy_name,
             progress_callback=progress_callback,
             config_override=config_override,
-            data_access_mode="direct",
         )
 
     def _extract_result_summary(self, result: BacktestResult) -> BacktestResultSummary:

--- a/apps/bt/src/strategies/signals/sector.py
+++ b/apps/bt/src/strategies/signals/sector.py
@@ -9,7 +9,6 @@ from typing import Optional
 import pandas as pd
 from loguru import logger
 
-from src.api.dataset_client import DatasetAPIClient
 from src.data import get_sector_mapping, load_index_data
 from src.data.access.clients import get_dataset_client
 from src.data.loaders.utils import extract_dataset_name
@@ -54,7 +53,7 @@ def get_sector_stocks(dataset: str, sector_name: str) -> list[str]:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         stocks = client.get_sector_stocks(sector_name)
 
     if not stocks:
@@ -79,7 +78,7 @@ def get_all_sectors(dataset: str) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name, http_client_factory=DatasetAPIClient) as client:
+    with get_dataset_client(dataset_name) as client:
         df = client.get_all_sectors()
 
     return df

--- a/apps/bt/src/strategies/signals/sector.py
+++ b/apps/bt/src/strategies/signals/sector.py
@@ -11,6 +11,9 @@ from loguru import logger
 
 from src.data import get_sector_mapping, load_index_data
 from src.data.access.clients import get_dataset_client
+
+# Backward-compatible symbol for tests patching module-local DatasetAPIClient.
+DatasetAPIClient = get_dataset_client
 from src.data.loaders.utils import extract_dataset_name
 
 
@@ -53,7 +56,7 @@ def get_sector_stocks(dataset: str, sector_name: str) -> list[str]:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         stocks = client.get_sector_stocks(sector_name)
 
     if not stocks:
@@ -78,7 +81,7 @@ def get_all_sectors(dataset: str) -> pd.DataFrame:
     """
     dataset_name = extract_dataset_name(dataset)
 
-    with get_dataset_client(dataset_name) as client:
+    with DatasetAPIClient(dataset_name) as client:
         df = client.get_all_sectors()
 
     return df

--- a/apps/bt/src/strategies/signals/sector.py
+++ b/apps/bt/src/strategies/signals/sector.py
@@ -11,10 +11,10 @@ from loguru import logger
 
 from src.data import get_sector_mapping, load_index_data
 from src.data.access.clients import get_dataset_client
+from src.data.loaders.utils import extract_dataset_name
 
 # Backward-compatible symbol for tests patching module-local DatasetAPIClient.
 DatasetAPIClient = get_dataset_client
-from src.data.loaders.utils import extract_dataset_name
 
 
 def get_sector_index_code(dataset: str, sector_name: str) -> str:

--- a/apps/bt/tests/unit/backtest/test_backtest_runner.py
+++ b/apps/bt/tests/unit/backtest/test_backtest_runner.py
@@ -2,9 +2,17 @@
 BacktestRunner unit tests
 """
 
+import json
+import subprocess
+import sys
+import types
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
+import pandas as pd
+
+from src.api.client import BaseAPIClient
 from src.lib.backtest_core.runner import BacktestRunner
 
 
@@ -74,9 +82,10 @@ def test_backtest_runner_uses_execution_config(monkeypatch, tmp_path: Path):
     assert result.html_path.exists()
     assert fake_executor.executed_template_path == "custom_template.py"
     assert fake_executor.executed_strategy_name == "test_strategy"
+    assert fake_executor.executed_extra_env == {"BT_DATA_ACCESS_MODE": "direct"}
 
 
-def test_backtest_runner_propagates_direct_access_mode(monkeypatch, tmp_path: Path):
+def test_backtest_runner_allows_http_override(monkeypatch, tmp_path: Path):
     runner = BacktestRunner()
     fake_executor = _FakeExecutor(str(tmp_path))
 
@@ -100,10 +109,362 @@ def test_backtest_runner_propagates_direct_access_mode(monkeypatch, tmp_path: Pa
         lambda _output_dir: fake_executor,
     )
 
-    runner.execute("production/test_strategy", data_access_mode="direct")
+    runner.execute("production/test_strategy", data_access_mode="http")
 
     assert fake_executor.executed_extra_env is not None
-    assert fake_executor.executed_extra_env.get("BT_DATA_ACCESS_MODE") == "direct"
+    assert fake_executor.executed_extra_env.get("BT_DATA_ACCESS_MODE") == "http"
+
+
+def test_backtest_runner_default_direct_mode_bypasses_http_requests(
+    monkeypatch,
+    tmp_path: Path,
+):
+    runner = BacktestRunner()
+
+    class _FakeDatasetDb:
+        def get_stock_ohlcv(self, _code, start=None, end=None):  # noqa: ANN001, ANN202
+            _ = (start, end)
+            return [
+                SimpleNamespace(
+                    date="2024-01-04",
+                    open=100.0,
+                    high=101.0,
+                    low=99.0,
+                    close=100.5,
+                    volume=12345,
+                )
+            ]
+
+    class _FakeExecutorWithLoad(_FakeExecutor):
+        def execute_notebook(
+            self,
+            template_path: str,
+            parameters: dict,
+            strategy_name: str,
+            extra_env: dict[str, str] | None = None,
+        ):
+            self.executed_template_path = template_path
+            self.executed_strategy_name = strategy_name
+            self.executed_extra_env = extra_env
+            from src.data.loaders.stock_loaders import load_stock_data
+
+            df = load_stock_data("sample", "7203")
+            assert not df.empty
+            html_path = Path(self.output_dir) / "result.html"
+            html_path.write_text("<html></html>", encoding="utf-8")
+            return html_path
+
+    monkeypatch.setattr(
+        "src.data.access.clients._resolve_dataset_db",
+        lambda _dataset_name: _FakeDatasetDb(),
+    )
+
+    def _fail_http_request(*args, **kwargs):  # noqa: ANN001, ANN002, ARG001
+        raise AssertionError("HTTP client must not be used during backtest")
+
+    monkeypatch.setattr(BaseAPIClient, "_request", _fail_http_request)
+
+    fake_executor = _FakeExecutorWithLoad(str(tmp_path))
+
+    monkeypatch.setattr(
+        runner.config_loader,
+        "load_strategy_config",
+        lambda _strategy: {"shared_config": {"dataset": "sample"}},
+    )
+    monkeypatch.setattr(
+        runner.config_loader,
+        "get_template_notebook_path",
+        lambda _: Path("template.py"),
+    )
+    monkeypatch.setattr(
+        runner.config_loader,
+        "get_output_directory",
+        lambda _: tmp_path,
+    )
+    monkeypatch.setattr(
+        "src.lib.backtest_core.runner.MarimoExecutor",
+        lambda _output_dir: fake_executor,
+    )
+
+    runner.execute("production/test_strategy")
+
+    assert fake_executor.executed_extra_env == {"BT_DATA_ACCESS_MODE": "direct"}
+
+
+def test_backtest_runner_progress_callback_and_walk_forward_manifest(
+    monkeypatch,
+    tmp_path: Path,
+):
+    runner = BacktestRunner()
+    fake_executor = _FakeExecutor(str(tmp_path))
+    statuses: list[str] = []
+
+    monkeypatch.setattr(
+        runner.config_loader,
+        "load_strategy_config",
+        lambda _strategy: {"shared_config": {"dataset": "sample"}},
+    )
+    monkeypatch.setattr(
+        runner.config_loader,
+        "get_template_notebook_path",
+        lambda _: Path("template.py"),
+    )
+    monkeypatch.setattr(
+        runner.config_loader,
+        "get_output_directory",
+        lambda _: tmp_path,
+    )
+    monkeypatch.setattr(
+        "src.lib.backtest_core.runner.MarimoExecutor",
+        lambda _output_dir: fake_executor,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_run_walk_forward",
+        lambda _parameters: {"count": 1, "splits": [], "aggregate": {}},
+    )
+
+    result = runner.execute(
+        "production/test_strategy",
+        progress_callback=lambda status, _elapsed: statuses.append(status),
+    )
+
+    manifest_path = Path(result.summary["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert statuses == ["設定を読み込み中...", "バックテストを実行中...", "完了！"]
+    assert "walk_forward" in result.summary
+    assert manifest["strategy_name"] == "test_strategy"
+    assert manifest["dataset_name"] == "sample"
+    assert "walk_forward" in manifest
+
+
+def test_backtest_runner_raises_when_html_missing(monkeypatch, tmp_path: Path):
+    runner = BacktestRunner()
+
+    class _MissingHtmlExecutor(_FakeExecutor):
+        def execute_notebook(  # type: ignore[override]
+            self,
+            template_path: str,
+            parameters: dict,
+            strategy_name: str,
+            extra_env: dict[str, str] | None = None,
+        ):
+            _ = (template_path, parameters, strategy_name, extra_env)
+            return Path(self.output_dir) / "missing.html"
+
+    monkeypatch.setattr(
+        runner.config_loader,
+        "load_strategy_config",
+        lambda _strategy: {"shared_config": {"dataset": "sample"}},
+    )
+    monkeypatch.setattr(
+        runner.config_loader,
+        "get_template_notebook_path",
+        lambda _: Path("template.py"),
+    )
+    monkeypatch.setattr(
+        runner.config_loader,
+        "get_output_directory",
+        lambda _: tmp_path,
+    )
+    monkeypatch.setattr(
+        "src.lib.backtest_core.runner.MarimoExecutor",
+        lambda _output_dir: _MissingHtmlExecutor(str(tmp_path)),
+    )
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="HTML file not found"):
+        runner.execute("production/test_strategy")
+
+
+def test_package_version_and_git_commit_helpers(monkeypatch):
+    runner = BacktestRunner()
+
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: "9.9.9")
+    assert runner._get_package_version("dummy") == "9.9.9"
+
+    def _raise_version(_name):  # noqa: ANN001
+        raise RuntimeError("no version")
+
+    monkeypatch.setattr("importlib.metadata.version", _raise_version)
+    assert runner._get_package_version("dummy") is None
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="abc123\n"),  # noqa: ARG005
+    )
+    assert runner._get_git_commit() == "abc123"
+
+    def _raise_subprocess(*args, **kwargs):  # noqa: ANN001, ANN002, ARG001
+        raise subprocess.CalledProcessError(1, args[0])
+
+    monkeypatch.setattr(subprocess, "run", _raise_subprocess)
+    assert runner._get_git_commit() is None
+
+
+def test_collect_and_aggregate_walk_forward_metrics():
+    runner = BacktestRunner()
+
+    class _MetricValue:
+        def __init__(self, value: float) -> None:
+            self._value = value
+
+        def mean(self) -> float:
+            return self._value
+
+    class _Portfolio:
+        def total_return(self):
+            return _MetricValue(10.0)
+
+        def sharpe_ratio(self):
+            return _MetricValue(1.2)
+
+        def calmar_ratio(self):
+            return _MetricValue(0.8)
+
+    metrics = runner._collect_portfolio_metrics(_Portfolio())
+    assert metrics == {
+        "total_return": 10.0,
+        "sharpe_ratio": 1.2,
+        "calmar_ratio": 0.8,
+    }
+    assert runner._collect_portfolio_metrics(None) == {}
+    assert runner._coerce_metric("invalid") is None
+
+    aggregate = runner._aggregate_walk_forward_metrics(
+        [
+            {"metrics": {"total_return": 10.0, "sharpe_ratio": 1.0}},
+            {"metrics": {"total_return": 20.0, "calmar_ratio": 0.5}},
+        ]
+    )
+    assert aggregate == {"total_return": 15.0, "sharpe_ratio": 1.0, "calmar_ratio": 0.5}
+
+
+def test_run_walk_forward_guard_paths(monkeypatch):
+    runner = BacktestRunner()
+
+    assert runner._run_walk_forward({"shared_config": {"walk_forward": {"enabled": False}}}) is None
+    assert runner._run_walk_forward({"shared_config": {"walk_forward": "invalid"}}) is None
+
+    parameters = {
+        "shared_config": {
+            "walk_forward": {"enabled": True},
+            "stock_codes": ["all"],
+            "dataset": "sample",
+        }
+    }
+    monkeypatch.setattr("src.data.get_stock_list", lambda _dataset: (_ for _ in ()).throw(RuntimeError("failed")))
+    assert runner._run_walk_forward(parameters) is None
+
+    monkeypatch.setattr("src.data.get_stock_list", lambda _dataset: [])
+    assert runner._run_walk_forward(parameters) is None
+
+
+def test_run_walk_forward_success_and_max_splits(monkeypatch):
+    runner = BacktestRunner()
+
+    class _Portfolio:
+        def total_return(self):
+            return 10.0
+
+        def sharpe_ratio(self):
+            return 2.0
+
+        def calmar_ratio(self):
+            return 1.0
+
+    split1 = SimpleNamespace(
+        train_start="2024-01-01",
+        train_end="2024-02-01",
+        test_start="2024-02-02",
+        test_end="2024-03-01",
+    )
+    split2 = SimpleNamespace(
+        train_start="2024-03-02",
+        train_end="2024-04-01",
+        test_start="2024-04-02",
+        test_end="2024-05-01",
+    )
+
+    fake_data_module = types.SimpleNamespace(get_stock_list=lambda _dataset: ["7203"])
+    fake_stock_loader_module = types.SimpleNamespace(
+        load_stock_data=lambda **kwargs: pd.DataFrame(  # noqa: ARG005
+            {"Close": [100, 101, 102]},
+            index=pd.date_range("2024-01-01", periods=3, freq="D"),
+        )
+    )
+    fake_walkforward_module = types.SimpleNamespace(
+        generate_walkforward_splits=lambda *args, **kwargs: [split1, split2]  # noqa: ARG005
+    )
+    fake_factory_module = types.SimpleNamespace(
+        StrategyFactory=types.SimpleNamespace(
+            execute_strategy_with_config=lambda *args, **kwargs: {  # noqa: ARG005
+                "kelly_portfolio": _Portfolio()
+            }
+        )
+    )
+
+    monkeypatch.setitem(sys.modules, "src.data", fake_data_module)
+    monkeypatch.setitem(sys.modules, "src.data.loaders.stock_loaders", fake_stock_loader_module)
+    monkeypatch.setitem(sys.modules, "src.lib.backtest_core.walkforward", fake_walkforward_module)
+    monkeypatch.setitem(sys.modules, "src.strategies.core.factory", fake_factory_module)
+
+    result = runner._run_walk_forward(
+        {
+            "shared_config": {
+                "dataset": "sample",
+                "stock_codes": ["all"],
+                "timeframe": "daily",
+                "walk_forward": {
+                    "enabled": True,
+                    "train_window": 10,
+                    "test_window": 5,
+                    "step": 2,
+                    "max_splits": 1,
+                },
+            },
+            "entry_filter_params": {"a": 1},
+            "exit_trigger_params": {"b": 2},
+        }
+    )
+
+    assert result is not None
+    assert result["count"] == 1
+    assert result["aggregate"] == {
+        "total_return": 10.0,
+        "sharpe_ratio": 2.0,
+        "calmar_ratio": 1.0,
+    }
+
+
+def test_get_execution_info_success_and_error(monkeypatch):
+    runner = BacktestRunner()
+
+    monkeypatch.setattr(
+        runner.config_loader,
+        "load_strategy_config",
+        lambda _strategy: {"display_name": "S", "description": "D"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_build_parameters",
+        lambda _config: {
+            "shared_config": {"dataset": "sample", "initial_cash": 1000, "fees": 0.1, "kelly_fraction": 0.8}
+        },
+    )
+    info = runner.get_execution_info("prod/s")
+    assert info["dataset"] == "sample"
+    assert info["kelly_fraction"] == 0.8
+
+    def _raise(_strategy):  # noqa: ANN001
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runner.config_loader, "load_strategy_config", _raise)
+    error_info = runner.get_execution_info("prod/s")
+    assert error_info == {"error": "boom"}
 
 
 class TestBuildParametersConfigOverride:

--- a/apps/bt/tests/unit/cli/test_backtest_command.py
+++ b/apps/bt/tests/unit/cli/test_backtest_command.py
@@ -1,0 +1,284 @@
+"""Unit tests for src.cli_bt.backtest."""
+
+from __future__ import annotations
+
+import sys
+import types
+import time
+from pathlib import Path
+
+import pytest
+
+from src.cli_bt import backtest as backtest_module
+from src.data.access.mode import DATA_ACCESS_MODE_ENV
+
+
+class _NoOpLive:
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002
+        _ = (args, kwargs)
+
+    def __enter__(self) -> _NoOpLive:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001, ANN201
+        _ = (exc_type, exc, tb)
+        return None
+
+    def update(self, _value) -> None:  # noqa: ANN001
+        return None
+
+
+def test_run_backtest_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: dict[str, object] = {}
+
+    class _FakeConfigLoader:
+        def __init__(self) -> None:
+            self.default_config = {"parameters": {}}
+
+        def load_strategy_config(self, _strategy: str) -> dict[str, object]:
+            return {
+                "shared_config": {"dataset": "sample", "stock_codes": ["all"]},
+                "display_name": "test",
+                "description": "desc",
+                "entry_filter_params": {"volume": {"enabled": True}},
+                "exit_trigger_params": {"volume": {"enabled": False}},
+            }
+
+        def merge_shared_config(self, strategy_config: dict[str, object]) -> dict[str, object]:
+            return strategy_config["shared_config"]  # type: ignore[index]
+
+        def get_output_directory(self, _strategy_config: dict[str, object]) -> Path:
+            return tmp_path
+
+    class _FakeMarimoExecutor:
+        def __init__(self, output_dir: str) -> None:
+            self.output_dir = output_dir
+
+        def get_execution_summary(self, _html_path: Path) -> dict[str, object]:
+            return {"html_path": "x", "generated_at": "now"}
+
+    monkeypatch.setattr(backtest_module, "ConfigLoader", _FakeConfigLoader)
+    monkeypatch.setattr(
+        backtest_module,
+        "_execute_with_progress",
+        lambda executor, template_path, parameters, strategy_name: (  # noqa: ARG005
+            tmp_path / "result.html",
+            1.2,
+        ),
+    )
+    monkeypatch.setattr(backtest_module, "_display_execution_info", lambda *_args: None)
+    monkeypatch.setattr(backtest_module, "_display_execution_summary", lambda *_args: None)
+    monkeypatch.setattr(
+        backtest_module.console,
+        "print",
+        lambda *args, **kwargs: calls.setdefault("printed", True),  # noqa: ARG005
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.lib.backtest_core.marimo_executor",
+        types.SimpleNamespace(MarimoExecutor=_FakeMarimoExecutor),
+    )
+
+    backtest_module.run_backtest("production/test_strategy")
+
+    assert calls.get("printed") is True
+
+
+def test_run_backtest_execution_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _FakeConfigLoader:
+        def __init__(self) -> None:
+            self.default_config = {"parameters": {}}
+
+        def load_strategy_config(self, _strategy: str) -> dict[str, object]:
+            return {"shared_config": {"dataset": "sample"}}
+
+        def merge_shared_config(self, strategy_config: dict[str, object]) -> dict[str, object]:
+            return strategy_config["shared_config"]  # type: ignore[index]
+
+        def get_output_directory(self, _strategy_config: dict[str, object]) -> Path:
+            return tmp_path
+
+    class _FakeMarimoExecutor:
+        def __init__(self, output_dir: str) -> None:
+            self.output_dir = output_dir
+
+    monkeypatch.setattr(backtest_module, "ConfigLoader", _FakeConfigLoader)
+    monkeypatch.setattr(
+        backtest_module,
+        "_execute_with_progress",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("exec failed")),  # noqa: ARG005
+    )
+    monkeypatch.setattr(backtest_module, "_display_execution_info", lambda *_args: None)
+    monkeypatch.setattr(backtest_module.console, "print", lambda *args, **kwargs: None)  # noqa: ARG005
+    monkeypatch.setitem(
+        sys.modules,
+        "src.lib.backtest_core.marimo_executor",
+        types.SimpleNamespace(MarimoExecutor=_FakeMarimoExecutor),
+    )
+
+    with pytest.raises(SystemExit, match="1"):
+        backtest_module.run_backtest("production/test_strategy")
+
+
+def test_run_backtest_strategy_name_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeConfigLoader:
+        def load_strategy_config(self, _strategy: str) -> dict[str, object]:
+            raise ValueError("invalid strategy")
+
+    monkeypatch.setattr(backtest_module, "ConfigLoader", _FakeConfigLoader)
+    monkeypatch.setattr(backtest_module.console, "print", lambda *args, **kwargs: None)  # noqa: ARG005
+
+    with pytest.raises(SystemExit, match="1"):
+        backtest_module.run_backtest("bad")
+
+
+def test_execute_with_progress_sets_direct_data_access_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeExecutor:
+        def __init__(self) -> None:
+            self.extra_env: dict[str, str] | None = None
+
+        def execute_notebook(
+            self,
+            template_path: str,
+            parameters: dict,
+            strategy_name: str,
+            extra_env: dict[str, str] | None = None,
+        ) -> Path:
+            _ = (template_path, parameters, strategy_name)
+            self.extra_env = extra_env
+            return tmp_path / "result.html"
+
+    fake_executor = _FakeExecutor()
+    monkeypatch.setattr(backtest_module, "Live", _NoOpLive)
+    monkeypatch.setattr(backtest_module.time, "sleep", lambda _s: None)
+
+    html_path, _elapsed = backtest_module._execute_with_progress(
+        executor=fake_executor,
+        template_path="template.py",
+        parameters={},
+        strategy_name="test",
+    )
+
+    assert html_path == tmp_path / "result.html"
+    assert fake_executor.extra_env == {DATA_ACCESS_MODE_ENV: "direct"}
+
+
+def test_execute_with_progress_updates_live_spinner(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    updates: list[object] = []
+
+    class _RecordingLive(_NoOpLive):
+        def update(self, value) -> None:  # noqa: ANN001
+            updates.append(value)
+
+    class _SlowExecutor:
+        def execute_notebook(self, *args, **kwargs):  # noqa: ANN002
+            _ = (args, kwargs)
+            time.sleep(0.2)
+            return tmp_path / "result.html"
+
+    monkeypatch.setattr(backtest_module, "Live", _RecordingLive)
+    monkeypatch.setattr(backtest_module.time, "time", lambda: 120.0)
+
+    html_path, _elapsed = backtest_module._execute_with_progress(
+        executor=_SlowExecutor(),
+        template_path="template.py",
+        parameters={},
+        strategy_name="test",
+    )
+
+    assert html_path == tmp_path / "result.html"
+    assert updates
+
+
+def test_execute_with_progress_raises_on_executor_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FailExecutor:
+        def execute_notebook(self, *args, **kwargs):  # noqa: ANN002
+            _ = (args, kwargs)
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(backtest_module, "Live", _NoOpLive)
+    monkeypatch.setattr(backtest_module.time, "sleep", lambda _s: None)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        backtest_module._execute_with_progress(
+            executor=_FailExecutor(),
+            template_path="template.py",
+            parameters={},
+            strategy_name="test",
+        )
+
+
+def test_execute_with_progress_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _InterruptLive:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002
+            _ = (args, kwargs)
+
+        def __enter__(self):  # noqa: ANN201
+            raise KeyboardInterrupt()
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001, ANN201
+            _ = (exc_type, exc, tb)
+            return None
+
+    class _SlowExecutor:
+        def execute_notebook(self, *args, **kwargs):  # noqa: ANN002
+            _ = (args, kwargs)
+            time.sleep(0.2)
+            return Path("/tmp/unused.html")
+
+    monkeypatch.setattr(backtest_module, "Live", _InterruptLive)
+    monkeypatch.setattr(backtest_module.console, "print", lambda *args, **kwargs: None)  # noqa: ARG005
+
+    with pytest.raises(KeyboardInterrupt):
+        backtest_module._execute_with_progress(
+            executor=_SlowExecutor(),
+            template_path="template.py",
+            parameters={},
+            strategy_name="test",
+        )
+
+
+def test_display_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    printed: list[object] = []
+    monkeypatch.setattr(
+        backtest_module.console,
+        "print",
+        lambda value, *args, **kwargs: printed.append(value),  # noqa: ARG005
+    )
+
+    backtest_module._display_execution_info(
+        {"display_name": "A", "description": "B"},
+        {"shared_config": {"stock_codes": ["all"], "initial_cash": 1000, "fees": 0.01}},
+    )
+    backtest_module._display_execution_info(
+        {"display_name": "A", "description": "B"},
+        {
+            "shared_config": {
+                "stock_codes": ["1", "2", "3", "4", "5", "6"],
+                "initial_cash": 1000,
+                "fees": 0.01,
+            }
+        },
+    )
+    backtest_module._display_execution_info(
+        {"display_name": "A", "description": "B"},
+        {"shared_config": {"stock_codes": "N/A", "initial_cash": 1000, "fees": 0.01}},
+    )
+    backtest_module._display_execution_summary({"error": "failed"})
+    backtest_module._display_execution_summary(
+        {
+            "execution_time": 1.5,
+            "html_path": "/tmp/a.html",
+            "file_size": 2048,
+            "generated_at": "now",
+        }
+    )
+    backtest_module._display_execution_summary(
+        {
+            "html_path": "/tmp/b.html",
+            "file_size": 0,
+            "generated_at": "now",
+        }
+    )
+
+    assert len(printed) >= 6

--- a/apps/bt/tests/unit/data/test_access_mode_and_clients.py
+++ b/apps/bt/tests/unit/data/test_access_mode_and_clients.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Generator, cast
+from typing import Any, Generator
 
 import pandas as pd
 import pytest
@@ -408,15 +408,25 @@ def test_client_factories_switch_by_mode(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr(clients, "DirectDatasetClient", _DirectDatasetClient)
     monkeypatch.setattr(clients, "DirectMarketClient", _DirectMarketClient)
+    monkeypatch.setattr(
+        clients,
+        "_create_http_dataset_client",
+        lambda dataset_name: _HTTPDatasetClient(dataset_name),
+    )
+    monkeypatch.setattr(
+        clients,
+        "_create_http_market_client",
+        lambda: _HTTPMarketClient(),
+    )
 
     monkeypatch.setattr(clients, "should_use_direct_db", lambda: False)
-    http_dataset = clients.get_dataset_client("sample", cast(Any, _HTTPDatasetClient))
-    http_market = clients.get_market_client(cast(Any, _HTTPMarketClient))
+    http_dataset = clients.get_dataset_client("sample")
+    http_market = clients.get_market_client()
     assert isinstance(http_dataset, _HTTPDatasetClient)
     assert isinstance(http_market, _HTTPMarketClient)
 
     monkeypatch.setattr(clients, "should_use_direct_db", lambda: True)
-    direct_dataset = clients.get_dataset_client("sample", cast(Any, _HTTPDatasetClient))
-    direct_market = clients.get_market_client(cast(Any, _HTTPMarketClient))
+    direct_dataset = clients.get_dataset_client("sample")
+    direct_market = clients.get_market_client()
     assert isinstance(direct_dataset, _DirectDatasetClient)
     assert isinstance(direct_market, _DirectMarketClient)

--- a/issues/done/bt-031-backtest-direct-access-phase2-cleanup.md
+++ b/issues/done/bt-031-backtest-direct-access-phase2-cleanup.md
@@ -1,12 +1,12 @@
 ---
 id: bt-031
 title: Backtest direct access Phase2 cleanup
-status: open
+status: done
 priority: medium
 labels: [backtest, architecture, maintenance]
 project: bt
 created: 2026-02-12
-updated: 2026-02-12
+updated: 2026-02-14
 depends_on: []
 blocks: []
 parent: null
@@ -30,7 +30,13 @@ backtest 実行経路で導入した `http/direct` 二重モードを整理し�
 - テストを `mode依存` から `振る舞い依存` に寄せる。
 
 ## 結果
-未着手
+- `BacktestRunner.execute()` のデフォルトを `direct` に変更し、`BT_DATA_ACCESS_MODE` を常時明示注入する形へ整理した。
+- `BacktestService` は mode を個別指定せず Runner のデフォルトを利用するようにし、`http` 指定は明示オーバーライド時のみの限定利用に縮小した。
+- `src/data/access/clients.py` の DB行→DataFrame 変換を `src/api/dataset/helpers.py` の共通変換関数に寄せ、変換責務を一本化した。
+- `get_dataset_client()` / `get_market_client()` から `http_client_factory` 引数を削除し、loader/strategy 側の呼び出しを最小インターフェースへ統一した。
+- backtest 実行中の HTTP 非利用を担保する回帰テスト（`test_backtest_runner_default_direct_mode_bypasses_http_requests`）を追加した。
+- 旧来の `localhost:3001` など legacy 記述を関連 loader で整理した。
+- 追加テストにより、対象モジュールの line/branch coverage を 80% 以上で担保した（`backtest.py` 96%, `clients.py` 98%, `runner.py` 95%, `backtest_service.py` 98%）。
 
 ## 補足
 - Phase1 実装: backtest 実行時のみ `BT_DATA_ACCESS_MODE=direct` を有効化済み。


### PR DESCRIPTION
## Summary
- defaulted backtest execution path to direct DB access and removed service-level explicit mode wiring
- simplified data access client surface by removing loader-side http client factory usage and centralizing row-to-DataFrame conversion
- cleaned loader/strategy legacy references and aligned CLI backtest execution to inject direct mode
- closed local issue bt-031 by moving it into issues/done with outcome notes

## Tests
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check (modified src/tests)
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pyright (modified src/tests)
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest -q apps/bt/tests/unit/cli/test_backtest_command.py apps/bt/tests/unit/data/test_access_mode_and_clients.py apps/bt/tests/unit/data/test_direct_access_mode.py apps/bt/tests/unit/backtest/test_backtest_runner.py apps/bt/tests/unit/server/services/test_backtest_service.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt coverage report -m apps/bt/src/cli_bt/backtest.py apps/bt/src/data/access/clients.py apps/bt/src/lib/backtest_core/runner.py apps/bt/src/server/services/backtest_service.py