### PR TITLE
feat(web-backtest): add sortino metric to runner result summary

### DIFF
--- a/apps/ts/packages/web/src/components/Backtest/JobProgressCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/JobProgressCard.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { BacktestJobResponse } from '@/types/backtest';
+import { JobProgressCard } from './JobProgressCard';
+
+const baseResult = {
+  total_return: 0.12,
+  sharpe_ratio: 1.24,
+  calmar_ratio: 0.8,
+  max_drawdown: -0.1,
+  win_rate: 55,
+  trade_count: 18,
+  html_path: null,
+};
+
+const baseJob: BacktestJobResponse = {
+  job_id: 'job-1',
+  status: 'completed',
+  progress: 100,
+  message: null,
+  created_at: '2026-02-15T09:00:00Z',
+  started_at: '2026-02-15T09:00:01Z',
+  completed_at: '2026-02-15T09:01:00Z',
+  error: null,
+  result: baseResult,
+};
+
+function createJob(overrides: Partial<BacktestJobResponse>): BacktestJobResponse {
+  return {
+    ...baseJob,
+    ...overrides,
+  };
+}
+
+function expectSortinoValue(value: string) {
+  const sortinoRow = screen.getByText('Sortino:').parentElement;
+  expect(sortinoRow).not.toBeNull();
+  if (!sortinoRow) {
+    return;
+  }
+  expect(within(sortinoRow).getByText(value)).toBeInTheDocument();
+}
+
+describe('JobProgressCard', () => {
+  it('renders nothing when no job and not loading', () => {
+    const { container } = render(<JobProgressCard job={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders submitting state when loading without job', () => {
+    render(<JobProgressCard job={null} isLoading={true} />);
+    expect(screen.getByText('Submitting...')).toBeInTheDocument();
+  });
+
+  it('renders running state with progress message and cancel action', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    const job = createJob({
+      status: 'running',
+      result: null,
+      message: 'executing strategy',
+      completed_at: null,
+    });
+
+    render(<JobProgressCard job={job} onCancel={onCancel} />);
+
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText('executing strategy')).toBeInTheDocument();
+    expect(screen.getByText(/⏱/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders failed state with error message', () => {
+    const job = createJob({
+      status: 'failed',
+      result: null,
+      error: 'execution failed',
+      message: null,
+    });
+
+    render(<JobProgressCard job={job} />);
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('execution failed')).toBeInTheDocument();
+  });
+
+  it('renders cancelled state with fallback message', () => {
+    const job = createJob({
+      status: 'cancelled',
+      result: null,
+      message: null,
+    });
+
+    render(<JobProgressCard job={job} />);
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    expect(screen.getByText('Backtest was cancelled')).toBeInTheDocument();
+  });
+
+  it('renders cancelled state with server message', () => {
+    const job = createJob({
+      status: 'cancelled',
+      result: null,
+      message: 'cancelled by user',
+    });
+
+    render(<JobProgressCard job={job} />);
+    expect(screen.getByText('cancelled by user')).toBeInTheDocument();
+  });
+
+  it('renders pending state without cancel button when callback is absent', () => {
+    const job = createJob({
+      status: 'pending',
+      result: null,
+      message: null,
+    });
+
+    render(<JobProgressCard job={job} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('shows sortino ratio when available on result payload', () => {
+    const job = {
+      ...baseJob,
+      result: {
+        ...baseResult,
+        sortino_ratio: 1.86,
+      },
+    } as BacktestJobResponse;
+
+    render(<JobProgressCard job={job} />);
+    expectSortinoValue('1.86');
+  });
+
+  it('shows fallback when sortino ratio is absent', () => {
+    render(<JobProgressCard job={baseJob} />);
+    expectSortinoValue('-');
+  });
+
+  it('shows fallback when sortino ratio is NaN', () => {
+    const job = {
+      ...baseJob,
+      result: {
+        ...baseResult,
+        sortino_ratio: Number.NaN,
+      },
+    } as BacktestJobResponse;
+
+    render(<JobProgressCard job={job} />);
+    expectSortinoValue('-');
+  });
+
+  it('shows fallback when sortino ratio is null', () => {
+    const job = {
+      ...baseJob,
+      result: {
+        ...baseResult,
+        sortino_ratio: null,
+      },
+    } as BacktestJobResponse;
+
+    render(<JobProgressCard job={job} />);
+    expectSortinoValue('-');
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/JobProgressCard.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/JobProgressCard.tsx
@@ -16,6 +16,10 @@ type BacktestResultWithSortino = NonNullable<BacktestJobResponse['result']> & {
   sortino_ratio?: number | null;
 };
 
+function formatRatio(value: number | null | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(2) : '-';
+}
+
 function StatusIcon({ status }: { status: JobStatus }) {
   switch (status) {
     case 'pending':
@@ -41,6 +45,62 @@ function StatusLabel({ status }: { status: JobStatus }) {
     cancelled: 'Cancelled',
   };
   return <span className="font-medium capitalize">{labels[status]}</span>;
+}
+
+function RunningProgress({ isActive, message }: { isActive: boolean; message: string | null }) {
+  if (!isActive) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="h-2 w-full rounded-full bg-secondary overflow-hidden">
+        <div className="h-full rounded-full bg-blue-500 animate-progress-indeterminate" />
+      </div>
+      {message && <p className="text-xs text-muted-foreground">{message}</p>}
+    </div>
+  );
+}
+
+function CompletedSummary({ result }: { result: BacktestResultWithSortino | null }) {
+  if (!result) return null;
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <span className="text-muted-foreground">Return:</span>
+          <span className={`ml-2 font-medium ${result.total_return >= 0 ? 'text-green-500' : 'text-red-500'}`}>
+            {formatPercentage(result.total_return)}
+          </span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Sharpe:</span>
+          <span className="ml-2 font-medium">{formatRatio(result.sharpe_ratio)}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Sortino:</span>
+          <span className="ml-2 font-medium">{formatRatio(result.sortino_ratio)}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Max DD:</span>
+          <span className="ml-2 font-medium text-red-500">{formatPercentage(result.max_drawdown, { showSign: false })}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Trades:</span>
+          <span className="ml-2 font-medium">{result.trade_count}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusAlert({ job }: { job: BacktestJobResponse }) {
+  if (job.status === 'failed' && job.error) {
+    return <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{job.error}</div>;
+  }
+  if (job.status === 'cancelled') {
+    return <div className="rounded-md bg-orange-500/10 p-3 text-sm text-orange-500">{job.message ?? 'Backtest was cancelled'}</div>;
+  }
+  return null;
 }
 
 export function JobProgressCard({ job, isLoading, onCancel, isCancelling }: JobProgressCardProps) {
@@ -75,8 +135,6 @@ export function JobProgressCard({ job, isLoading, onCancel, isCancelling }: JobP
 
   if (!job) return null;
 
-  const formatRatio = (value: number | null | undefined) =>
-    typeof value === 'number' && Number.isFinite(value) ? value.toFixed(2) : '-';
   const completedResult =
     job.status === 'completed' && job.result ? (job.result as BacktestResultWithSortino) : null;
 
@@ -116,61 +174,9 @@ export function JobProgressCard({ job, isLoading, onCancel, isCancelling }: JobP
         </div>
       </CardHeader>
       <CardContent>
-        {/* Progress bar (indeterminate) */}
-        {isActive && (
-          <div className="space-y-2">
-            <div className="h-2 w-full rounded-full bg-secondary overflow-hidden">
-              <div className="h-full rounded-full bg-blue-500 animate-progress-indeterminate" />
-            </div>
-            {job.message && <p className="text-xs text-muted-foreground">{job.message}</p>}
-          </div>
-        )}
-
-        {/* Completed result summary */}
-        {completedResult && (
-          <div className="space-y-2 text-sm">
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <span className="text-muted-foreground">Return:</span>
-                <span
-                  className={`ml-2 font-medium ${completedResult.total_return >= 0 ? 'text-green-500' : 'text-red-500'}`}
-                >
-                  {formatPercentage(completedResult.total_return)}
-                </span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Sharpe:</span>
-                <span className="ml-2 font-medium">{formatRatio(completedResult.sharpe_ratio)}</span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Sortino:</span>
-                <span className="ml-2 font-medium">{formatRatio(completedResult.sortino_ratio)}</span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Max DD:</span>
-                <span className="ml-2 font-medium text-red-500">
-                  {formatPercentage(completedResult.max_drawdown, { showSign: false })}
-                </span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Trades:</span>
-                <span className="ml-2 font-medium">{completedResult.trade_count}</span>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Failed error */}
-        {job.status === 'failed' && job.error && (
-          <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{job.error}</div>
-        )}
-
-        {/* Cancelled */}
-        {job.status === 'cancelled' && (
-          <div className="rounded-md bg-orange-500/10 p-3 text-sm text-orange-500">
-            {job.message ?? 'Backtest was cancelled'}
-          </div>
-        )}
+        <RunningProgress isActive={isActive} message={job.message} />
+        <CompletedSummary result={completedResult} />
+        <StatusAlert job={job} />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary\n- add Sortino metric to Backtest Runner completed job summary card\n- handle missing/null/NaN sortino values with '-' fallback\n- add comprehensive JobProgressCard tests for status states and sortino rendering\n\n## Verification\n- bun run --filter @trading25/web test -- JobProgressCard\n- bun run --filter @trading25/web typecheck\n- bun run --filter @trading25/web test:coverage -- JobProgressCard\n