### PR TITLE
feat(bt): add trade count to optimization html results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ uv run pyright src/              # 型チェック
 
 - Lab `evolve/optimize` の API/Web は `target_scope`（`entry_filter_only` / `exit_trigger_only` / `both`）を受け付ける（`entry_filter_only` は互換フラグとして維持）
 - Lab `evolve/optimize` の frontend `allowed categories` は `all` / `fundamental only` を提供
+- Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest
 

--- a/apps/bt/notebooks/templates/marimo/optimization_analysis.py
+++ b/apps/bt/notebooks/templates/marimo/optimization_analysis.py
@@ -144,6 +144,10 @@ def ranking_top20(mo, pd, optimization_results):
             _row["Sharpe"] = _r["metric_values"].get("sharpe_ratio", 0)
             _row["Calmar"] = _r["metric_values"].get("calmar_ratio", 0)
             _row["Return"] = _r["metric_values"].get("total_return", 0)
+            try:
+                _row["Trades"] = int(float(_r["metric_values"].get("trade_count", 0)))
+            except (TypeError, ValueError):
+                _row["Trades"] = 0
 
             _ranking_data.append(_row)
 
@@ -178,6 +182,10 @@ def ranking_bottom10(mo, pd, optimization_results):
             _row["Sharpe"] = _r["metric_values"].get("sharpe_ratio", 0)
             _row["Calmar"] = _r["metric_values"].get("calmar_ratio", 0)
             _row["Return"] = _r["metric_values"].get("total_return", 0)
+            try:
+                _row["Trades"] = int(float(_r["metric_values"].get("trade_count", 0)))
+            except (TypeError, ValueError):
+                _row["Trades"] = 0
 
             _bottom_ranking_data.append(_row)
 
@@ -200,10 +208,16 @@ def best_parameters(mo, optimization_results):
         ])
 
         _metrics = _best_result["metric_values"]
+        try:
+            _trade_count = int(float(_metrics.get("trade_count", 0)))
+        except (TypeError, ValueError):
+            _trade_count = 0
+
         _metrics_table = f"""
 | Sharpe Ratio | {_metrics.get('sharpe_ratio', 0):.4f} |
 | Calmar Ratio | {_metrics.get('calmar_ratio', 0):.4f} |
 | Total Return | {_metrics.get('total_return', 0):.2%} |
+| Trade Count | {_trade_count} |
 """
 
         _norm_metrics = _best_result.get("normalized_metrics", {})

--- a/apps/bt/src/optimization/metrics.py
+++ b/apps/bt/src/optimization/metrics.py
@@ -1,0 +1,74 @@
+"""
+最適化用メトリクス収集ユーティリティ
+"""
+
+from typing import Any, Mapping
+
+from .scoring import is_valid_metric
+
+
+def extract_trade_count(portfolio: Any) -> int:
+    """
+    ポートフォリオからclosed trades件数を取得
+
+    Args:
+        portfolio: VectorBTポートフォリオオブジェクト
+
+    Returns:
+        int: トレード件数（取得不能時は0）
+    """
+    try:
+        trades = portfolio.trades
+    except Exception:
+        return 0
+
+    # 優先: VectorBTのcount()（Seriesの可能性があるためsumで集約）
+    try:
+        count = trades.count()
+        count_value = count.sum() if hasattr(count, "sum") else count
+        if is_valid_metric(count_value):
+            return max(0, int(float(count_value)))
+    except Exception:
+        pass
+
+    # フォールバック: records_readableの行数
+    try:
+        if hasattr(trades, "records_readable"):
+            return max(0, int(len(trades.records_readable)))
+    except Exception:
+        pass
+
+    return 0
+
+
+def collect_metrics(
+    portfolio: Any, scoring_weights: Mapping[str, float]
+) -> dict[str, float | int]:
+    """
+    ポートフォリオから最適化メトリクスを収集
+
+    Args:
+        portfolio: VectorBTポートフォリオオブジェクト
+        scoring_weights: スコア計算対象メトリクスの重み
+
+    Returns:
+        dict[str, float | int]: メトリクス名と値のマッピング
+    """
+    metric_values: dict[str, float | int] = {}
+
+    for metric in scoring_weights.keys():
+        if metric == "sharpe_ratio":
+            value = portfolio.sharpe_ratio()
+        elif metric == "calmar_ratio":
+            value = portfolio.calmar_ratio()
+        elif metric == "total_return":
+            value = portfolio.total_return()
+        else:
+            continue
+
+        metric_values[metric] = float(value) if is_valid_metric(value) else 0.0
+
+    # 表示用途: closed trades件数（スコア計算には使用しない）
+    metric_values["trade_count"] = extract_trade_count(portfolio)
+
+    return metric_values

--- a/apps/bt/tests/unit/optimization/test_engine_metrics.py
+++ b/apps/bt/tests/unit/optimization/test_engine_metrics.py
@@ -1,0 +1,85 @@
+"""optimization/metrics.py のメトリクス収集テスト"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from src.optimization.engine import ParameterOptimizationEngine
+from src.optimization.metrics import collect_metrics
+
+
+def _make_scoring_weights() -> dict[str, float]:
+    return {
+        "sharpe_ratio": 0.4,
+        "calmar_ratio": 0.3,
+        "total_return": 0.3,
+    }
+
+
+def _make_portfolio() -> MagicMock:
+    portfolio = MagicMock()
+    portfolio.sharpe_ratio.return_value = 1.5
+    portfolio.calmar_ratio.return_value = 1.2
+    portfolio.total_return.return_value = 0.25
+    return portfolio
+
+
+def test_collect_metrics_includes_trade_count_from_trades_count():
+    portfolio = _make_portfolio()
+    portfolio.trades.count.return_value = pd.Series([3, 4, 5])
+
+    metrics = collect_metrics(portfolio, _make_scoring_weights())
+
+    assert metrics["sharpe_ratio"] == 1.5
+    assert metrics["calmar_ratio"] == 1.2
+    assert metrics["total_return"] == 0.25
+    assert metrics["trade_count"] == 12
+
+
+def test_collect_metrics_fallbacks_to_records_readable_when_count_fails():
+    portfolio = _make_portfolio()
+    portfolio.trades.count.side_effect = RuntimeError("count unavailable")
+    portfolio.trades.records_readable = pd.DataFrame({"PnL": [1.0, -0.5, 0.2]})
+
+    metrics = collect_metrics(portfolio, _make_scoring_weights())
+
+    assert metrics["trade_count"] == 3
+
+
+def test_collect_metrics_sets_trade_count_zero_when_trades_access_fails():
+    portfolio = _make_portfolio()
+
+    class _BrokenTrades:
+        def count(self):
+            raise RuntimeError("count failed")
+
+        @property
+        def records_readable(self):
+            raise RuntimeError("records failed")
+
+    portfolio.trades = _BrokenTrades()
+
+    metrics = collect_metrics(portfolio, _make_scoring_weights())
+
+    assert metrics["trade_count"] == 0
+
+
+def test_collect_metrics_ignores_unsupported_metric_key():
+    portfolio = _make_portfolio()
+    portfolio.trades.count.return_value = 1
+
+    metrics = collect_metrics(portfolio, {"unsupported": 1.0})
+
+    assert "unsupported" not in metrics
+    assert metrics["trade_count"] == 1
+
+
+def test_engine_collect_metrics_delegates_to_metrics_module():
+    engine = object.__new__(ParameterOptimizationEngine)
+    engine.optimization_config = {"scoring_weights": _make_scoring_weights()}
+    portfolio = _make_portfolio()
+    portfolio.trades.count.return_value = 2
+
+    metrics = engine._collect_metrics(portfolio)
+
+    assert metrics["trade_count"] == 2

--- a/apps/bt/tests/unit/optimization/test_notebook_generator.py
+++ b/apps/bt/tests/unit/optimization/test_notebook_generator.py
@@ -28,6 +28,7 @@ def sample_optimization_results():
                 "sharpe_ratio": 1.5,
                 "calmar_ratio": 1.2,
                 "total_return": 0.45,
+                "trade_count": 42,
             },
             "normalized_metrics": {
                 "sharpe_ratio": 0.9,
@@ -45,6 +46,7 @@ def sample_optimization_results():
                 "sharpe_ratio": 1.3,
                 "calmar_ratio": 1.0,
                 "total_return": 0.38,
+                "trade_count": 35,
             },
             "normalized_metrics": {
                 "sharpe_ratio": 0.8,
@@ -62,6 +64,7 @@ def sample_optimization_results():
                 "sharpe_ratio": 1.1,
                 "calmar_ratio": 0.9,
                 "total_return": 0.32,
+                "trade_count": 28,
             },
             "normalized_metrics": {
                 "sharpe_ratio": 0.7,
@@ -111,6 +114,7 @@ class TestSaveResultsAsJson:
         assert (
             loaded_data[0]["params"]["entry_filter_params.period_breakout.period"] == 50
         )
+        assert loaded_data[0]["metric_values"]["trade_count"] == 42
 
     def test_json_serializable_format(self, sample_optimization_results, tmp_path):
         """JSONシリアライズ可能形式の確認"""
@@ -136,6 +140,31 @@ class TestSaveResultsAsJson:
             loaded_data = json.load(f)
 
         assert loaded_data == []
+
+    def test_save_results_without_trade_count_keeps_compatibility(self, tmp_path):
+        """trade_countがない旧データ形式も保存できることを確認"""
+        old_format_results = [
+            {
+                "params": {"entry_filter_params.period_breakout.period": 50},
+                "score": 0.5,
+                "metric_values": {
+                    "sharpe_ratio": 1.0,
+                    "calmar_ratio": 0.8,
+                    "total_return": 0.2,
+                },
+                "normalized_metrics": {
+                    "sharpe_ratio": 0.5,
+                    "calmar_ratio": 0.5,
+                    "total_return": 0.5,
+                },
+            }
+        ]
+
+        json_path = _save_results_as_json(old_format_results, str(tmp_path))
+        with open(json_path, encoding="utf-8") as f:
+            loaded_data = json.load(f)
+
+        assert "trade_count" not in loaded_data[0]["metric_values"]
 
 
 class TestNotebookGeneratorMarimo:


### PR DESCRIPTION
## Summary
- add closed trade count extraction for optimization results
- show Trades column in optimization Top/Bottom rankings and Trade Count in best detail
- refactor metric collection into src/optimization/metrics.py and keep engine delegated
- add unit tests for metric extraction and notebook JSON compatibility
- update AGENTS.md with the new optimization HTML behavior

## Testing
- uv run --project apps/bt pytest apps/bt/tests/unit/optimization/test_engine_metrics.py apps/bt/tests/unit/optimization/test_notebook_generator.py -q
- uv run --project apps/bt ruff check apps/bt/src/optimization/engine.py apps/bt/src/optimization/metrics.py apps/bt/notebooks/templates/marimo/optimization_analysis.py apps/bt/tests/unit/optimization/test_notebook_generator.py apps/bt/tests/unit/optimization/test_engine_metrics.py
- uv run --project apps/bt pyright apps/bt/src/optimization/engine.py apps/bt/src/optimization/metrics.py apps/bt/tests/unit/optimization/test_engine_metrics.py
- uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/optimization/test_engine_metrics.py
- uv run --project apps/bt coverage report -m --include='*/src/optimization/metrics.py'