### PR TITLE
feat(bt): add fundamental dividend and yield growth signals

### DIFF
--- a/apps/bt/src/agent/signal_param_factory.py
+++ b/apps/bt/src/agent/signal_param_factory.py
@@ -240,6 +240,26 @@ def _get_default_fundamental_params(
             "threshold": 2.0,
             "condition": "above",
         },
+        "dividend_per_share_growth": {
+            "enabled": False,
+            "threshold": 0.1,
+            "periods": 1,
+            "condition": "above",
+        },
+        "cfo_yield_growth": {
+            "enabled": False,
+            "threshold": 0.1,
+            "periods": 1,
+            "condition": "above",
+            "use_floating_shares": True,
+        },
+        "simple_fcf_yield_growth": {
+            "enabled": False,
+            "threshold": 0.1,
+            "periods": 1,
+            "condition": "above",
+            "use_floating_shares": True,
+        },
         "market_cap": {
             "enabled": False,
             "threshold": 300.0,
@@ -275,6 +295,15 @@ def _randomize_fundamental_params(
         "roa": {"threshold": (2.0, 15.0, "float")},
         "operating_margin": {"threshold": (3.0, 30.0, "float")},
         "dividend_yield": {"threshold": (0.5, 8.0, "float")},
+        "dividend_per_share_growth": {
+            "threshold": (0.02, 0.5, "float"),
+            "periods": (1, 8, "int"),
+        },
+        "cfo_yield_growth": {"threshold": (0.02, 0.5, "float"), "periods": (1, 8, "int")},
+        "simple_fcf_yield_growth": {
+            "threshold": (0.02, 0.5, "float"),
+            "periods": (1, 8, "int"),
+        },
         "market_cap": {"threshold": (50.0, 5000.0, "float")},
     }
 
@@ -293,4 +322,3 @@ def _randomize_fundamental_params(
                 field_value[param_name] = rng.uniform(min_val, max_val)
 
     return randomized
-

--- a/apps/bt/src/agent/strategy_generator.py
+++ b/apps/bt/src/agent/strategy_generator.py
@@ -397,6 +397,18 @@ class StrategyGenerator:
             "roa": {"threshold": (2.0, 15.0, "float")},
             "operating_margin": {"threshold": (3.0, 30.0, "float")},
             "dividend_yield": {"threshold": (0.5, 8.0, "float")},
+            "dividend_per_share_growth": {
+                "threshold": (0.02, 0.5, "float"),
+                "periods": (1, 8, "int"),
+            },
+            "cfo_yield_growth": {
+                "threshold": (0.02, 0.5, "float"),
+                "periods": (1, 8, "int"),
+            },
+            "simple_fcf_yield_growth": {
+                "threshold": (0.02, 0.5, "float"),
+                "periods": (1, 8, "int"),
+            },
             "market_cap": {"threshold": (50.0, 5000.0, "float")},
         }
 
@@ -581,6 +593,26 @@ class StrategyGenerator:
                 "enabled": False,
                 "threshold": 2.0,
                 "condition": "above",
+            },
+            "dividend_per_share_growth": {
+                "enabled": False,
+                "threshold": 0.1,
+                "periods": 1,
+                "condition": "above",
+            },
+            "cfo_yield_growth": {
+                "enabled": False,
+                "threshold": 0.1,
+                "periods": 1,
+                "condition": "above",
+                "use_floating_shares": True,
+            },
+            "simple_fcf_yield_growth": {
+                "enabled": False,
+                "threshold": 0.1,
+                "periods": 1,
+                "condition": "above",
+                "use_floating_shares": True,
             },
             "market_cap": {
                 "enabled": False,

--- a/apps/bt/src/models/signals/fundamental.py
+++ b/apps/bt/src/models/signals/fundamental.py
@@ -133,6 +133,21 @@ class FundamentalSignalParams(BaseSignalParams):
             description="条件（above=閾値以上、below=閾値以下）",
         )
 
+    class DividendPerShareGrowthParams(BaseModel):
+        """1株配当成長率シグナルパラメータ"""
+
+        enabled: bool = Field(default=False, description="1株配当成長率シグナル有効")
+        threshold: float = Field(
+            default=0.1, gt=0, le=2.0, description="成長率閾値（10%=0.1）"
+        )
+        periods: int = Field(
+            default=1, ge=1, le=20, description="比較期間（決算発表回数、1=前期比）"
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値以下）",
+        )
+
     # =========================================================================
     # 収益性・キャッシュフロー系パラメータ
     # =========================================================================
@@ -299,6 +314,44 @@ class FundamentalSignalParams(BaseSignalParams):
             description="流通株式を使用（発行済み-自己株式）、Falseなら発行済み全体",
         )
 
+    class CFOYieldGrowthParams(BaseModel):
+        """CFO利回り成長率シグナルパラメータ"""
+
+        enabled: bool = Field(default=False, description="CFO利回り成長率シグナル有効")
+        threshold: float = Field(
+            default=0.1, gt=0, le=2.0, description="成長率閾値（10%=0.1）"
+        )
+        periods: int = Field(
+            default=1, ge=1, le=20, description="比較期間（決算発表回数、1=前期比）"
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値以下）",
+        )
+        use_floating_shares: bool = Field(
+            default=True,
+            description="流通株式を使用（発行済み-自己株式）、Falseなら発行済み全体",
+        )
+
+    class SimpleFCFYieldGrowthParams(BaseModel):
+        """簡易FCF利回り成長率シグナルパラメータ"""
+
+        enabled: bool = Field(default=False, description="簡易FCF利回り成長率シグナル有効")
+        threshold: float = Field(
+            default=0.1, gt=0, le=2.0, description="成長率閾値（10%=0.1）"
+        )
+        periods: int = Field(
+            default=1, ge=1, le=20, description="比較期間（決算発表回数、1=前期比）"
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値以下）",
+        )
+        use_floating_shares: bool = Field(
+            default=True,
+            description="流通株式を使用（発行済み-自己株式）、Falseなら発行済み全体",
+        )
+
     # =========================================================================
     # 親レベルパラメータ
     # =========================================================================
@@ -332,6 +385,10 @@ class FundamentalSignalParams(BaseSignalParams):
     sales_growth: SalesGrowthParams = Field(
         default_factory=SalesGrowthParams, description="Sales成長率シグナル"
     )
+    dividend_per_share_growth: DividendPerShareGrowthParams = Field(
+        default_factory=DividendPerShareGrowthParams,
+        description="1株配当成長率シグナル",
+    )
 
     # 収益性・キャッシュフロー系
     roe: ROEParams = Field(default_factory=ROEParams, description="ROEシグナル")
@@ -355,6 +412,13 @@ class FundamentalSignalParams(BaseSignalParams):
     )
     simple_fcf_yield: SimpleFCFYieldParams = Field(
         default_factory=SimpleFCFYieldParams, description="簡易FCF利回りシグナル"
+    )
+    cfo_yield_growth: CFOYieldGrowthParams = Field(
+        default_factory=CFOYieldGrowthParams, description="CFO利回り成長率シグナル"
+    )
+    simple_fcf_yield_growth: SimpleFCFYieldGrowthParams = Field(
+        default_factory=SimpleFCFYieldGrowthParams,
+        description="簡易FCF利回り成長率シグナル",
     )
 
     # 時価総額系

--- a/apps/bt/src/strategies/signals/fundamental.py
+++ b/apps/bt/src/strategies/signals/fundamental.py
@@ -37,6 +37,7 @@ from .fundamental_valuation import (
 # 成長率系シグナル
 from .fundamental_growth import (
     is_expected_growth_eps,
+    is_growing_dividend_per_share,
     is_growing_eps,
     is_growing_profit,
     is_growing_sales,
@@ -53,6 +54,8 @@ from .fundamental_quality import (
 # キャッシュフロー系・時価総額系シグナル
 from .fundamental_cashflow import (
     cfo_yield_threshold,
+    is_growing_cfo_yield,
+    is_growing_simple_fcf_yield,
     market_cap_threshold,
     operating_cash_flow_threshold,
     simple_fcf_threshold,
@@ -74,6 +77,7 @@ __all__ = [
     "is_expected_growth_eps",
     "is_growing_profit",
     "is_growing_sales",
+    "is_growing_dividend_per_share",
     # 収益性・品質系
     "is_high_roe",
     "is_high_roa",
@@ -84,5 +88,7 @@ __all__ = [
     "simple_fcf_threshold",
     "cfo_yield_threshold",
     "simple_fcf_yield_threshold",
+    "is_growing_cfo_yield",
+    "is_growing_simple_fcf_yield",
     "market_cap_threshold",
 ]

--- a/apps/bt/src/strategies/signals/fundamental_growth.py
+++ b/apps/bt/src/strategies/signals/fundamental_growth.py
@@ -1,7 +1,7 @@
 """
 財務指標シグナル — 成長率系
 
-EPS・利益・売上高の成長率およびForward EPS成長率シグナルを提供
+EPS・利益・売上高・1株配当の成長率およびForward EPS成長率シグナルを提供
 """
 
 from __future__ import annotations
@@ -146,3 +146,33 @@ def is_growing_sales(
         - "all"使用時はperiods=4で前年同期比較
     """
     return _calc_growth_signal(sales, periods, growth_threshold, condition)
+
+
+def is_growing_dividend_per_share(
+    dividend_fy: pd.Series[float],
+    growth_threshold: float = 0.1,
+    periods: int = 1,
+    condition: Literal["above", "below"] = "above",
+) -> pd.Series[bool]:
+    """
+    1株配当成長率シグナル
+
+    1株配当（DividendFY）の成長率を計算し、
+    指定した条件で閾値と比較してTrueを返すシグナル
+
+    Args:
+        dividend_fy: 1株配当データ（日次インデックスに補完済み想定）
+        growth_threshold: 成長率閾値（デフォルト0.1 = 10%）
+        periods: 成長率計算期間（決算期数、デフォルト1 = 前期比）
+        condition: 条件（above=閾値以上、below=閾値以下）
+
+    Returns:
+        pd.Series[bool]: 条件を満たす場合にTrue
+
+    Note:
+        - ffill済みデータから決算発表日を検出し、N期間前の発表値と比較
+        - 過去の配当が0以下またはNaNの場合はFalseを返す
+        - 成長率が極端に高い値（10倍以上）の場合はFalseを返す（異常値処理）
+        - 推奨period_type: "FY"（通期配当の比較）
+    """
+    return _calc_growth_signal(dividend_fy, periods, growth_threshold, condition)

--- a/apps/bt/tests/server/test_signal_reference.py
+++ b/apps/bt/tests/server/test_signal_reference.py
@@ -76,6 +76,13 @@ class TestBuildSignalReference:
         assert "risk_adjusted_return" in parsed
         assert "fundamental" not in parsed
 
+    def test_new_fundamental_growth_signals_are_included(self):
+        result = build_signal_reference()
+        keys = {s["key"] for s in result["signals"]}
+        assert "fundamental_dividend_per_share_growth" in keys
+        assert "fundamental_cfo_yield_growth" in keys
+        assert "fundamental_simple_fcf_yield_growth" in keys
+
 
 class TestYAMLSnippets:
     """YAMLスニペットのテスト"""

--- a/apps/bt/tests/unit/agent/test_signal_augmentation.py
+++ b/apps/bt/tests/unit/agent/test_signal_augmentation.py
@@ -23,6 +23,15 @@ class DeterministicRng:
         return seq[0]
 
 
+class PreferDividendGrowthRng(DeterministicRng):
+    """fundamental選択時に dividend_per_share_growth を優先する乱数"""
+
+    def choice(self, seq):  # type: ignore[no-untyped-def]
+        if "dividend_per_share_growth" in seq:
+            return "dividend_per_share_growth"
+        return seq[0]
+
+
 def _make_candidate(entry: dict, exit: dict | None = None) -> StrategyCandidate:
     return StrategyCandidate(
         strategy_id="base",
@@ -129,3 +138,11 @@ def test_build_fundamental_params_has_child_enabled() -> None:
     # DeterministicRng.choice() で "per" が選ばれる
     assert params["per"]["enabled"] is True
 
+
+def test_build_fundamental_params_can_select_new_growth_signal() -> None:
+    rng = PreferDividendGrowthRng()
+    params = build_signal_params("fundamental", "entry", rng)
+
+    assert params["enabled"] is True
+    assert params["dividend_per_share_growth"]["enabled"] is True
+    assert "periods" in params["dividend_per_share_growth"]

--- a/apps/bt/tests/unit/strategies/signals/test_fundamental.py
+++ b/apps/bt/tests/unit/strategies/signals/test_fundamental.py
@@ -14,6 +14,7 @@ from src.strategies.signals.fundamental import (
     is_growing_eps,
     is_growing_profit,
     is_growing_sales,
+    is_growing_dividend_per_share,
     is_high_roe,
     is_high_roa,
     is_high_dividend_yield,
@@ -23,7 +24,9 @@ from src.strategies.signals.fundamental import (
     is_undervalued_growth_by_peg,
     is_expected_growth_eps,
     cfo_yield_threshold,
+    is_growing_cfo_yield,
     simple_fcf_yield_threshold,
+    is_growing_simple_fcf_yield,
     market_cap_threshold,
 )
 
@@ -648,6 +651,51 @@ class TestIsHighDividendYield:
         assert signal.dtype == bool
         # Close=0の部分はFalse
         assert not signal.iloc[0:10].any()
+
+
+class TestDividendPerShareGrowth:
+    """is_growing_dividend_per_share()のテスト"""
+
+    def setup_method(self):
+        self.dates = pd.date_range("2023-01-01", periods=120)
+        # 開示ごとに 10 -> 12 -> 18 へ成長
+        self.dividend_fy = pd.Series([10.0] * 40 + [12.0] * 40 + [18.0] * 40, index=self.dates)
+
+    def test_growth_basic(self):
+        signal = is_growing_dividend_per_share(
+            self.dividend_fy, growth_threshold=0.15, periods=1, condition="above"
+        )
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
+        # 比較対象がない最初のブロックはFalse
+        assert not signal.iloc[:40].any()
+        # 12/10=+20%, 18/12=+50% のため後半はTrue
+        assert signal.iloc[45:].all()
+
+    def test_growth_condition_below(self):
+        signal = is_growing_dividend_per_share(
+            self.dividend_fy, growth_threshold=0.3, periods=1, condition="below"
+        )
+
+        # 2回目開示(+20%)はTrue、3回目開示(+50%)はFalse
+        assert signal.iloc[45]
+        assert not signal.iloc[90]
+
+    def test_growth_insufficient_periods(self):
+        signal = is_growing_dividend_per_share(
+            self.dividend_fy, growth_threshold=0.1, periods=5, condition="above"
+        )
+        assert not signal.any()
+
+    def test_growth_nan_handling(self):
+        dividend_with_nan = self.dividend_fy.copy()
+        dividend_with_nan.iloc[10:20] = np.nan
+
+        signal = is_growing_dividend_per_share(dividend_with_nan, growth_threshold=0.1)
+
+        assert isinstance(signal, pd.Series)
+        assert not signal.iloc[10:20].any()
 
 
 # =====================================================================
@@ -1853,6 +1901,202 @@ class TestSimpleFcfYieldThreshold:
         assert signal.all()
 
 
+class TestCfoYieldGrowth:
+    """is_growing_cfo_yield()のテスト"""
+
+    def setup_method(self):
+        self.dates = pd.date_range("2023-01-01", periods=100)
+        self.close = pd.Series(np.ones(100) * 1000.0, index=self.dates)
+        # 開示間の価格ノイズ（成長率判定に影響しないことを確認）
+        self.close.iloc[60:80] = 6000.0
+        self.operating_cash_flow = pd.Series([45_000_000.0] * 50 + [67_500_000.0] * 50, index=self.dates)
+        self.shares_outstanding = pd.Series(np.ones(100) * 1_000_000.0, index=self.dates)
+        self.treasury_shares = pd.Series(np.zeros(100), index=self.dates)
+
+    def test_growth_release_based(self):
+        signal = is_growing_cfo_yield(
+            self.close,
+            self.operating_cash_flow,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=0.1,
+            periods=1,
+            condition="above",
+        )
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
+        assert not signal.iloc[:50].any()
+        assert signal.iloc[50:].all()
+        # False -> True の1回だけ遷移
+        transitions = signal.astype(int).diff().fillna(0).ne(0).sum()
+        assert transitions == 1
+
+    def test_growth_condition_below_with_floating_share_effect(self):
+        treasury = pd.Series([200_000.0] * 50 + [0.0] * 50, index=self.dates)
+        operating = pd.Series(np.ones(100) * 50_000_000.0, index=self.dates)
+
+        signal_floating = is_growing_cfo_yield(
+            self.close,
+            operating,
+            self.shares_outstanding,
+            treasury,
+            growth_threshold=0.0,
+            periods=1,
+            condition="below",
+            use_floating_shares=True,
+        )
+        signal_total = is_growing_cfo_yield(
+            self.close,
+            operating,
+            self.shares_outstanding,
+            treasury,
+            growth_threshold=0.0,
+            periods=1,
+            condition="below",
+            use_floating_shares=False,
+        )
+
+        assert signal_floating.iloc[50:].all()
+        assert not signal_total.any()
+
+    def test_growth_insufficient_periods(self):
+        signal = is_growing_cfo_yield(
+            self.close,
+            self.operating_cash_flow,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=0.1,
+            periods=5,
+        )
+        assert not signal.any()
+
+    def test_growth_nan_handling(self):
+        operating_with_nan = self.operating_cash_flow.copy()
+        operating_with_nan.iloc[0:10] = np.nan
+
+        signal = is_growing_cfo_yield(
+            self.close,
+            operating_with_nan,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=0.1,
+            periods=1,
+        )
+        assert not signal.iloc[0:10].any()
+
+    def test_growth_treasury_all_nan_keeps_release_based_behavior(self):
+        close_with_noise = self.close.copy()
+        close_with_noise.iloc[20:30] = 4500.0
+        close_with_noise.iloc[70:80] = 7000.0
+        treasury_all_nan = pd.Series(np.nan, index=self.dates)
+
+        signal = is_growing_cfo_yield(
+            close_with_noise,
+            self.operating_cash_flow,
+            self.shares_outstanding,
+            treasury_all_nan,
+            growth_threshold=0.1,
+            periods=1,
+            condition="above",
+            use_floating_shares=True,
+        )
+
+        assert not signal.iloc[:50].any()
+        assert signal.iloc[50:].all()
+        transitions = signal.astype(int).diff().fillna(0).ne(0).sum()
+        assert transitions == 1
+
+    def test_growth_ignores_treasury_change_when_not_using_floating_shares(self):
+        treasury_changes = pd.Series([300_000.0] * 50 + [0.0] * 50, index=self.dates)
+        operating_constant = pd.Series(np.ones(100) * 50_000_000.0, index=self.dates)
+
+        signal = is_growing_cfo_yield(
+            self.close,
+            operating_constant,
+            self.shares_outstanding,
+            treasury_changes,
+            growth_threshold=0.0,
+            periods=1,
+            condition="above",
+            use_floating_shares=False,
+        )
+
+        assert not signal.any()
+
+
+class TestSimpleFcfYieldGrowth:
+    """is_growing_simple_fcf_yield()のテスト"""
+
+    def setup_method(self):
+        self.dates = pd.date_range("2023-01-01", periods=100)
+        self.close = pd.Series(np.ones(100) * 1000.0, index=self.dates)
+        self.close.iloc[60:80] = 5000.0
+        self.operating_cash_flow = pd.Series([60_000_000.0] * 50 + [90_000_000.0] * 50, index=self.dates)
+        self.investing_cash_flow = pd.Series([-24_000_000.0] * 50 + [-30_000_000.0] * 50, index=self.dates)
+        self.shares_outstanding = pd.Series(np.ones(100) * 1_000_000.0, index=self.dates)
+        self.treasury_shares = pd.Series(np.zeros(100), index=self.dates)
+
+    def test_growth_release_based(self):
+        signal = is_growing_simple_fcf_yield(
+            self.close,
+            self.operating_cash_flow,
+            self.investing_cash_flow,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=0.2,
+            periods=1,
+            condition="above",
+        )
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
+        assert not signal.iloc[:50].any()
+        assert signal.iloc[50:].all()
+
+    def test_growth_condition_below(self):
+        signal = is_growing_simple_fcf_yield(
+            self.close,
+            self.operating_cash_flow,
+            self.investing_cash_flow,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=1.0,
+            periods=1,
+            condition="below",
+        )
+
+        assert signal.iloc[50:].all()
+
+    def test_growth_insufficient_periods(self):
+        signal = is_growing_simple_fcf_yield(
+            self.close,
+            self.operating_cash_flow,
+            self.investing_cash_flow,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=0.2,
+            periods=5,
+        )
+        assert not signal.any()
+
+    def test_growth_nan_handling(self):
+        investing_with_nan = self.investing_cash_flow.copy()
+        investing_with_nan.iloc[0:10] = np.nan
+
+        signal = is_growing_simple_fcf_yield(
+            self.close,
+            self.operating_cash_flow,
+            investing_with_nan,
+            self.shares_outstanding,
+            self.treasury_shares,
+            growth_threshold=0.2,
+            periods=1,
+        )
+
+        assert not signal.iloc[0:10].any()
+
+
 class TestYieldSignalsEdgeCases:
     """利回りシグナルのエッジケーステスト"""
 
@@ -1985,6 +2229,33 @@ class TestFundamentalSignalParamsConfig:
         assert params.eps_growth.enabled is True
         assert params.forward_eps_growth.threshold == 0.1
         assert params.eps_growth.threshold == 0.2
+
+    def test_dividend_per_share_growth_field_exists(self):
+        """dividend_per_share_growthフィールドが正しくパースされること"""
+        from src.models.signals.fundamental import FundamentalSignalParams
+
+        params = FundamentalSignalParams(
+            dividend_per_share_growth={
+                "enabled": True,
+                "threshold": 0.15,
+                "periods": 2,
+                "condition": "above",
+            }
+        )
+        assert params.dividend_per_share_growth.enabled is True
+        assert params.dividend_per_share_growth.threshold == 0.15
+        assert params.dividend_per_share_growth.periods == 2
+        assert params.dividend_per_share_growth.condition == "above"
+
+    def test_yield_growth_fields_default(self):
+        """yield成長率フィールドのデフォルト値が正しいこと"""
+        from src.models.signals.fundamental import FundamentalSignalParams
+
+        params = FundamentalSignalParams()
+        assert params.cfo_yield_growth.periods == 1
+        assert params.simple_fcf_yield_growth.periods == 1
+        assert params.cfo_yield_growth.use_floating_shares is True
+        assert params.simple_fcf_yield_growth.use_floating_shares is True
 
 
 # =====================================================================

--- a/apps/bt/tests/unit/strategies/signals/test_registry.py
+++ b/apps/bt/tests/unit/strategies/signals/test_registry.py
@@ -183,6 +183,33 @@ class TestSignalRegistry:
         assert "statements:EPS" in sig.data_requirements
         assert "statements:NextYearForecastEPS" not in sig.data_requirements
 
+    def test_dividend_per_share_growth_registered(self) -> None:
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.dividend_per_share_growth"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "1株配当成長率"
+        assert sig.category == "fundamental"
+        assert sig.data_requirements == ["statements:DividendFY"]
+
+    def test_cfo_yield_growth_registered(self) -> None:
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.cfo_yield_growth"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "CFO利回り成長率"
+        assert sig.category == "fundamental"
+        assert "statements:OperatingCashFlow" in sig.data_requirements
+        assert "statements:SharesOutstanding" in sig.data_requirements
+
+    def test_simple_fcf_yield_growth_registered(self) -> None:
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.simple_fcf_yield_growth"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "簡易FCF利回り成長率"
+        assert sig.category == "fundamental"
+        assert "statements:OperatingCashFlow" in sig.data_requirements
+        assert "statements:InvestingCashFlow" in sig.data_requirements
+        assert "statements:SharesOutstanding" in sig.data_requirements
+
     def test_roa_registered(self) -> None:
         """roa（総資産利益率）がレジストリに登録されていること"""
         matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.roa"]
@@ -217,6 +244,20 @@ class TestSignalRegistry:
 
         # fundamental.enabled=True, market_cap.enabled=False → disabled
         params.fundamental.market_cap.enabled = False
+        assert not sig.enabled_checker(params)
+
+    def test_cfo_yield_growth_enabled_checker(self) -> None:
+        sig = next(s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.cfo_yield_growth")
+
+        params = SignalParams()
+        params.fundamental.enabled = False
+        params.fundamental.cfo_yield_growth.enabled = True
+        assert not sig.enabled_checker(params)
+
+        params.fundamental.enabled = True
+        assert sig.enabled_checker(params)
+
+        params.fundamental.cfo_yield_growth.enabled = False
         assert not sig.enabled_checker(params)
 
     def test_risk_adjusted_return_registered_as_volatility(self) -> None:


### PR DESCRIPTION
## Summary
- add three new fundamental growth signals:
  - `fundamental.dividend_per_share_growth`
  - `fundamental.cfo_yield_growth`
  - `fundamental.simple_fcf_yield_growth`
- implement release-based growth evaluation for CFO/FCF yield growth and forward-fill between disclosure updates
- register new signals in signal registry and export list
- extend Lab fundamental defaults/randomization to include the new signals
- add unit/server tests for signal behavior, registry entries, signal reference exposure, and agent parameter generation
- harden release-point detection for `TreasuryShares` NaN cases and when `use_floating_shares=false`

## Testing
- `uv run --project apps/bt pytest apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/strategies/signals/test_registry.py apps/bt/tests/server/test_signal_reference.py`
- `uv run --project apps/bt pytest apps/bt/tests/unit/agent/test_signal_augmentation.py apps/bt/tests/unit/agent/test_strategy_generator.py`
- `uv run --project apps/bt ruff check apps/bt/src`
- coverage check (manual runner, branch+line): all target modules >= 80%
