### PR TITLE
feat: add risk_adjusted_return sub-chart indicator

### DIFF
--- a/apps/bt/src/lib/indicators/__init__.py
+++ b/apps/bt/src/lib/indicators/__init__.py
@@ -3,6 +3,7 @@
 from src.lib.indicators.calculations import (
     compute_atr_support_line,
     compute_nbar_support,
+    compute_risk_adjusted_return,
     compute_trading_value_ma,
     compute_volume_mas,
 )
@@ -10,7 +11,7 @@ from src.lib.indicators.calculations import (
 __all__ = [
     "compute_atr_support_line",
     "compute_nbar_support",
+    "compute_risk_adjusted_return",
     "compute_trading_value_ma",
     "compute_volume_mas",
 ]
-

--- a/apps/bt/src/server/schemas/indicators.py
+++ b/apps/bt/src/server/schemas/indicators.py
@@ -89,6 +89,16 @@ class TradingValueMAParams(BaseModel):
     period: int = Field(default=20, ge=1, le=500, description="MA期間")
 
 
+class RiskAdjustedReturnParams(BaseModel):
+    """リスク調整リターンパラメータ"""
+
+    lookback_period: int = Field(default=60, ge=1, le=500, description="計算期間")
+    ratio_type: Literal["sharpe", "sortino"] = Field(
+        default="sortino",
+        description="レシオ種別",
+    )
+
+
 # ===== Indicator Spec (Discriminated Union) =====
 
 INDICATOR_PARAMS_MAP: dict[str, type[BaseModel]] = {
@@ -103,6 +113,7 @@ INDICATOR_PARAMS_MAP: dict[str, type[BaseModel]] = {
     "nbar_support": NBarSupportParams,
     "volume_comparison": VolumeComparisonParams,
     "trading_value_ma": TradingValueMAParams,
+    "risk_adjusted_return": RiskAdjustedReturnParams,
 }
 
 INDICATOR_TYPES = Literal[
@@ -117,6 +128,7 @@ INDICATOR_TYPES = Literal[
     "nbar_support",
     "volume_comparison",
     "trading_value_ma",
+    "risk_adjusted_return",
 ]
 
 

--- a/apps/bt/tests/unit/server/routes/test_indicators.py
+++ b/apps/bt/tests/unit/server/routes/test_indicators.py
@@ -171,6 +171,31 @@ class TestComputeEndpoint:
         assert len(data["indicators"]) == 3
 
     @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
+    def test_risk_adjusted_return_indicator(self, mock_compute: MagicMock):
+        mock_compute.return_value = {
+            "stock_code": "7203",
+            "timeframe": "daily",
+            "meta": {"bars": 500},
+            "indicators": {
+                "risk_adjusted_return_60_sortino": [{"date": "2024-01-01", "value": 1.23}],
+            },
+        }
+
+        response = client.post(
+            "/api/indicators/compute",
+            json={
+                "stock_code": "7203",
+                "indicators": [
+                    {"type": "risk_adjusted_return", "params": {"lookback_period": 60, "ratio_type": "sortino"}},
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "risk_adjusted_return_60_sortino" in data["indicators"]
+
+    @patch("src.server.routes.indicators.IndicatorService.compute_indicators")
     def test_compute_api_not_found_returns_404(self, mock_compute: MagicMock):
         """APINotFoundError が 404 で返ること"""
         mock_compute.side_effect = APINotFoundError("Resource not found: Stock not found")

--- a/apps/bt/tests/unit/server/services/test_indicator_service.py
+++ b/apps/bt/tests/unit/server/services/test_indicator_service.py
@@ -138,20 +138,20 @@ class TestMakeKey:
         assert _make_key("bollinger", period=20, std=2.0) == "bollinger_20_2.0"
 
 
-# ===== 11 Indicator Compute Function Tests =====
+# ===== 12 Indicator Compute Function Tests =====
 
 
 class TestIndicatorRegistry:
-    """全11インジケーターのレジストリテスト"""
+    """全12インジケーターのレジストリテスト"""
 
-    def test_registry_has_11_entries(self):
-        assert len(INDICATOR_REGISTRY) == 11
+    def test_registry_has_12_entries(self):
+        assert len(INDICATOR_REGISTRY) == 12
 
     def test_all_types_registered(self):
         expected = {
             "sma", "ema", "rsi", "macd", "ppo", "bollinger",
             "atr", "atr_support", "nbar_support", "volume_comparison",
-            "trading_value_ma",
+            "trading_value_ma", "risk_adjusted_return",
         }
         assert set(INDICATOR_REGISTRY.keys()) == expected
 
@@ -291,6 +291,19 @@ class TestComputeTradingValueMA:
         ohlcv = _make_ohlcv()
         key, records = INDICATOR_REGISTRY["trading_value_ma"](ohlcv, {"period": 20}, "include")
         assert key == "trading_value_ma_20"
+
+
+class TestComputeRiskAdjustedReturn:
+    def test_basic(self):
+        ohlcv = _make_ohlcv()
+        key, records = INDICATOR_REGISTRY["risk_adjusted_return"](
+            ohlcv,
+            {"lookback_period": 60, "ratio_type": "sortino"},
+            "include",
+        )
+        assert key == "risk_adjusted_return_60_sortino"
+        assert len(records) == 200
+        assert "value" in records[-1]
 
 
 # ===== Margin Indicators =====

--- a/apps/bt/tests/unit/server/test_indicator_schemas.py
+++ b/apps/bt/tests/unit/server/test_indicator_schemas.py
@@ -18,6 +18,7 @@ from src.server.schemas.indicators import (
     NBarSupportParams,
     PPOParams,
     RSIParams,
+    RiskAdjustedReturnParams,
     SMAParams,
     TradingValueMAParams,
     VolumeComparisonParams,
@@ -104,6 +105,15 @@ class TestParamsModels:
         p = TradingValueMAParams(period=50)
         assert p.period == 50
 
+    def test_risk_adjusted_return_params_default(self):
+        p = RiskAdjustedReturnParams()
+        assert p.lookback_period == 60
+        assert p.ratio_type == "sortino"
+
+    def test_risk_adjusted_return_params_invalid_ratio_type(self):
+        with pytest.raises(ValidationError):
+            RiskAdjustedReturnParams(ratio_type="invalid")
+
 
 class TestIndicatorSpec:
     """IndicatorSpec バリデーションテスト"""
@@ -128,11 +138,11 @@ class TestIndicatorSpec:
         with pytest.raises(ValidationError):
             IndicatorSpec(type="unknown", params={})
 
-    def test_all_11_types(self):
+    def test_all_12_types(self):
         types = [
             "sma", "ema", "rsi", "macd", "ppo", "bollinger",
             "atr", "atr_support", "nbar_support", "volume_comparison",
-            "trading_value_ma",
+            "trading_value_ma", "risk_adjusted_return",
         ]
         for t in types:
             spec = IndicatorSpec(type=t, params={} if t not in ("sma", "ema") else {"period": 20})

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -13958,7 +13958,8 @@
               "atr_support",
               "nbar_support",
               "volume_comparison",
-              "trading_value_ma"
+              "trading_value_ma",
+              "risk_adjusted_return"
             ],
             "title": "Type",
             "description": "インジケータータイプ"

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -3908,7 +3908,7 @@ export interface components {
              * @description インジケータータイプ
              * @enum {string}
              */
-            type: "sma" | "ema" | "rsi" | "macd" | "ppo" | "bollinger" | "atr" | "atr_support" | "nbar_support" | "volume_comparison" | "trading_value_ma";
+            type: "sma" | "ema" | "rsi" | "macd" | "ppo" | "bollinger" | "atr" | "atr_support" | "nbar_support" | "volume_comparison" | "trading_value_ma" | "risk_adjusted_return";
             /**
              * Params
              * @description パラメータ

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -39,6 +39,7 @@ const mockChartStore = {
     showPPOChart: false,
     showVolumeComparison: false,
     showTradingValueMA: false,
+    showRiskAdjustedReturnChart: false,
     showFundamentalsPanel: true,
     showFundamentalsHistoryPanel: true,
     showMarginPressurePanel: true,
@@ -62,6 +63,12 @@ const mockChartStore = {
     },
     tradingValueMA: {
       period: 15,
+    },
+    riskAdjustedReturn: {
+      lookbackPeriod: 60,
+      ratioType: 'sortino' as const,
+      threshold: 1.0,
+      condition: 'above' as const,
     },
     signalOverlay: {
       enabled: false,
@@ -209,6 +216,17 @@ describe('ChartControls', () => {
 
     await user.click(screen.getByRole('switch', { name: /fundamentals/i }));
     expect(mockChartStore.updateSettings).toHaveBeenCalledWith({ showFundamentalsPanel: false });
+  });
+
+  it('updates risk adjusted return settings', async () => {
+    const user = userEvent.setup();
+    mockChartStore.updateSettings = vi.fn();
+
+    render(<ChartControls />, { wrapper: TestWrapper });
+
+    const riskAdjustedSwitches = screen.getAllByRole('switch', { name: /risk adjusted return/i });
+    await user.click(riskAdjustedSwitches[0]!);
+    expect(mockChartStore.updateSettings).toHaveBeenCalledWith({ showRiskAdjustedReturnChart: true });
   });
 
   it('shows signal metadata for panel toggles when reference API is available', () => {

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -28,6 +28,7 @@ const VISIBLE_BAR_OPTIONS = [
 
 type PanelSettingKey =
   | 'showPPOChart'
+  | 'showRiskAdjustedReturnChart'
   | 'showVolumeComparison'
   | 'showTradingValueMA'
   | 'showFundamentalsPanel'
@@ -48,6 +49,12 @@ const PANEL_VISIBILITY_TOGGLES: PanelVisibilityToggle[] = [
     label: 'PPO',
     settingKey: 'showPPOChart',
     linkPanel: 'ppo',
+  },
+  {
+    id: 'show-risk-adjusted-return-panel',
+    label: 'Risk Adjusted Return',
+    settingKey: 'showRiskAdjustedReturnChart',
+    linkPanel: 'riskAdjustedReturn',
   },
   {
     id: 'show-volume-comparison-panel',
@@ -228,6 +235,18 @@ export function ChartControls() {
       updateSettings({ [settingKey]: checked } as Partial<ChartSettings>);
     },
     [updateSettings]
+  );
+
+  const updateRiskAdjustedReturn = useCallback(
+    (newSettings: Partial<ChartSettings['riskAdjustedReturn']>) => {
+      updateSettings({
+        riskAdjustedReturn: {
+          ...settings.riskAdjustedReturn,
+          ...newSettings,
+        },
+      });
+    },
+    [settings.riskAdjustedReturn, updateSettings]
   );
 
   return (
@@ -434,6 +453,74 @@ export function ChartControls() {
       {/* Sub-Chart Indicators */}
       <div className="glass-panel rounded-lg p-3 space-y-2">
         <SectionHeader icon={BarChart3} title="Sub-Chart Indicators" />
+
+        <IndicatorToggle
+          label="Risk Adjusted Return"
+          enabled={settings.showRiskAdjustedReturnChart}
+          onToggle={(checked) => updateSettings({ showRiskAdjustedReturnChart: checked })}
+        >
+          <div className="grid grid-cols-2 gap-1.5">
+            <NumberInput
+              label="Lookback"
+              value={settings.riskAdjustedReturn.lookbackPeriod}
+              onChange={(lookbackPeriod) => updateRiskAdjustedReturn({ lookbackPeriod })}
+              defaultValue={60}
+            />
+            <NumberInput
+              label="Threshold"
+              value={settings.riskAdjustedReturn.threshold}
+              onChange={(threshold) => updateRiskAdjustedReturn({ threshold })}
+              step="0.1"
+              defaultValue={1.0}
+            />
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Ratio Type</Label>
+              <Select
+                value={settings.riskAdjustedReturn.ratioType}
+                onValueChange={(ratioType) =>
+                  updateRiskAdjustedReturn({
+                    ratioType: ratioType as ChartSettings['riskAdjustedReturn']['ratioType'],
+                  })
+                }
+              >
+                <SelectTrigger className="h-7 text-xs glass-panel border-border/30 focus:border-primary/50">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-background/95 backdrop-blur-md border-border shadow-xl">
+                  <SelectItem value="sortino" className="text-xs">
+                    sortino
+                  </SelectItem>
+                  <SelectItem value="sharpe" className="text-xs">
+                    sharpe
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Condition</Label>
+              <Select
+                value={settings.riskAdjustedReturn.condition}
+                onValueChange={(condition) =>
+                  updateRiskAdjustedReturn({
+                    condition: condition as ChartSettings['riskAdjustedReturn']['condition'],
+                  })
+                }
+              >
+                <SelectTrigger className="h-7 text-xs glass-panel border-border/30 focus:border-primary/50">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-background/95 backdrop-blur-md border-border shadow-xl">
+                  <SelectItem value="above" className="text-xs">
+                    above
+                  </SelectItem>
+                  <SelectItem value="below" className="text-xs">
+                    below
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </IndicatorToggle>
 
         <IndicatorToggle
           label="Volume Comparison"

--- a/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CHART_COLORS } from '@/lib/constants';
+import { RiskAdjustedReturnChart } from './RiskAdjustedReturnChart';
+
+const mockChartStore = {
+  settings: {
+    visibleBars: 120,
+  },
+};
+
+vi.mock('@/stores/chartStore', () => ({
+  useChartStore: () => mockChartStore,
+}));
+
+const { mockCreateChart, mockChart, mockRatioSeries, mockThresholdSeries, mockTimeScale, mockLineSeries } =
+  vi.hoisted(() => {
+    const mockRatioSeries = {
+      setData: vi.fn(),
+      applyOptions: vi.fn(),
+    };
+    const mockThresholdSeries = {
+      setData: vi.fn(),
+      applyOptions: vi.fn(),
+    };
+    const mockTimeScale = {
+      setVisibleLogicalRange: vi.fn(),
+    };
+    const mockChart = {
+      addSeries: vi.fn(),
+      timeScale: vi.fn(() => mockTimeScale),
+      applyOptions: vi.fn(),
+      remove: vi.fn(),
+    };
+    const mockCreateChart = vi.fn(() => mockChart);
+    const mockLineSeries = 'LineSeries';
+
+    return {
+      mockCreateChart,
+      mockChart,
+      mockRatioSeries,
+      mockThresholdSeries,
+      mockTimeScale,
+      mockLineSeries,
+    };
+  });
+
+vi.mock('lightweight-charts', () => ({
+  createChart: mockCreateChart,
+  LineSeries: mockLineSeries,
+}));
+
+const sampleData = [
+  { time: '2024-01-01', value: 0.8 },
+  { time: '2024-01-02', value: 1.2 },
+];
+
+describe('RiskAdjustedReturnChart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChart.addSeries.mockReset().mockReturnValueOnce(mockRatioSeries).mockReturnValueOnce(mockThresholdSeries);
+  });
+
+  it('creates chart and renders ratio/threshold metadata', () => {
+    render(
+      <RiskAdjustedReturnChart
+        data={sampleData}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    expect(mockCreateChart).toHaveBeenCalled();
+    expect(mockChart.addSeries).toHaveBeenCalledTimes(2);
+    expect(mockRatioSeries.setData).toHaveBeenCalledWith([
+      { time: '2024-01-01', value: 0.8 },
+      { time: '2024-01-02', value: 1.2 },
+    ]);
+    expect(mockThresholdSeries.setData).toHaveBeenCalledWith([
+      { time: '2024-01-01', value: 1 },
+      { time: '2024-01-02', value: 1 },
+    ]);
+    expect(mockTimeScale.setVisibleLogicalRange).toHaveBeenCalledWith({ from: 0, to: 1.5 });
+    expect(screen.getByText('Risk Adjusted Return')).toBeInTheDocument();
+    expect(screen.getByText('60')).toBeInTheDocument();
+    expect(screen.getByText('sortino')).toBeInTheDocument();
+    expect(screen.getByText('above 1.00')).toBeInTheDocument();
+    expect(screen.getByText('1.20')).toBeInTheDocument();
+  });
+
+  it('updates threshold color based on condition', () => {
+    const { rerender } = render(
+      <RiskAdjustedReturnChart
+        data={sampleData}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    expect(mockThresholdSeries.applyOptions).toHaveBeenCalledWith({ color: CHART_COLORS.UP });
+
+    rerender(
+      <RiskAdjustedReturnChart
+        data={sampleData}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="below"
+      />
+    );
+
+    expect(mockThresholdSeries.applyOptions).toHaveBeenLastCalledWith({ color: CHART_COLORS.DOWN });
+    expect(screen.getByText('below 1.00')).toBeInTheDocument();
+  });
+
+  it('clears chart data when data is empty', () => {
+    render(
+      <RiskAdjustedReturnChart
+        data={[]}
+        lookbackPeriod={30}
+        ratioType="sharpe"
+        threshold={0.5}
+        condition="above"
+      />
+    );
+
+    expect(mockRatioSeries.setData).toHaveBeenCalledWith([]);
+    expect(mockThresholdSeries.setData).toHaveBeenCalledWith([]);
+  });
+
+  it('falls back to empty threshold line when time labels are falsy', () => {
+    render(
+      <RiskAdjustedReturnChart
+        data={[{ time: '', value: 1.0 }]}
+        lookbackPeriod={20}
+        ratioType="sharpe"
+        threshold={0.5}
+        condition="above"
+      />
+    );
+
+    expect(mockThresholdSeries.setData).toHaveBeenCalledWith([]);
+  });
+
+  it('applies resize options when resize observer callback runs', () => {
+    let resizeCallback: (() => void) | undefined;
+
+    class MockResizeObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+
+      constructor(callback: () => void) {
+        resizeCallback = callback;
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', MockResizeObserver as unknown as typeof ResizeObserver);
+
+    const { container } = render(
+      <RiskAdjustedReturnChart
+        data={sampleData}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    const chartContainer = container.querySelector('.flex-1.h-full') as HTMLDivElement;
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 320 });
+    Object.defineProperty(chartContainer, 'clientHeight', { configurable: true, value: 160 });
+
+    if (resizeCallback) {
+      resizeCallback();
+    }
+
+    expect(mockChart.applyOptions).toHaveBeenCalledWith({ width: 320, height: 160 });
+
+    vi.unstubAllGlobals();
+  });
+
+  it('cleans up chart on unmount', () => {
+    const { unmount } = render(
+      <RiskAdjustedReturnChart
+        data={sampleData}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    unmount();
+    expect(mockChart.remove).toHaveBeenCalled();
+  });
+});

--- a/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.tsx
@@ -1,0 +1,169 @@
+import { createChart, type IChartApi, type ISeriesApi, LineSeries } from 'lightweight-charts';
+import { useEffect, useMemo, useRef } from 'react';
+import { CHART_COLORS } from '@/lib/constants';
+import { useChartStore } from '@/stores/chartStore';
+import type { RiskAdjustedReturnCondition, RiskAdjustedReturnRatioType } from '@/stores/chartStore';
+import type { RiskAdjustedReturnData } from '@/types/chart';
+
+function setChartVisibleBars(chart: IChartApi, dataLength: number, barsToShow: number) {
+  if (dataLength === 0) return;
+
+  const from = Math.max(0, dataLength - barsToShow - 0.5);
+  const to = dataLength - 0.5;
+  chart.timeScale().setVisibleLogicalRange({ from, to });
+}
+
+interface RiskAdjustedReturnChartProps {
+  data: RiskAdjustedReturnData[];
+  lookbackPeriod: number;
+  ratioType: RiskAdjustedReturnRatioType;
+  threshold: number;
+  condition: RiskAdjustedReturnCondition;
+  title?: string;
+}
+
+export function RiskAdjustedReturnChart({
+  data,
+  lookbackPeriod,
+  ratioType,
+  threshold,
+  condition,
+  title,
+}: RiskAdjustedReturnChartProps) {
+  const { settings } = useChartStore();
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const ratioSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const thresholdSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const latestValue = useMemo(() => {
+    if (data.length === 0) return null;
+    return data[data.length - 1]?.value ?? null;
+  }, [data]);
+
+  useEffect(() => {
+    if (!chartContainerRef.current) return;
+
+    const chart = createChart(chartContainerRef.current, {
+      layout: {
+        background: { color: 'transparent' },
+        textColor: '#666',
+      },
+      grid: {
+        vertLines: { color: '#e1e1e1' },
+        horzLines: { color: '#e1e1e1' },
+      },
+      width: chartContainerRef.current.clientWidth,
+      height: chartContainerRef.current.clientHeight,
+      timeScale: {
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      crosshair: {
+        mode: 1,
+      },
+      rightPriceScale: {
+        scaleMargins: {
+          top: 0.1,
+          bottom: 0.1,
+        },
+      },
+    });
+    chartRef.current = chart;
+
+    ratioSeriesRef.current = chart.addSeries(LineSeries, {
+      color: '#F59E0B',
+      lineWidth: 2,
+      priceFormat: {
+        type: 'price',
+        precision: 2,
+        minMove: 0.01,
+      },
+    });
+
+    thresholdSeriesRef.current = chart.addSeries(LineSeries, {
+      color: CHART_COLORS.UP,
+      lineWidth: 1,
+      lineStyle: 2,
+      priceFormat: {
+        type: 'price',
+        precision: 2,
+        minMove: 0.01,
+      },
+    });
+
+    return () => {
+      chart.remove();
+      chartRef.current = null;
+      ratioSeriesRef.current = null;
+      thresholdSeriesRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    thresholdSeriesRef.current?.applyOptions({
+      color: condition === 'above' ? CHART_COLORS.UP : CHART_COLORS.DOWN,
+    });
+  }, [condition]);
+
+  useEffect(() => {
+    if (!ratioSeriesRef.current || !thresholdSeriesRef.current) return;
+
+    if (data.length === 0) {
+      ratioSeriesRef.current.setData([]);
+      thresholdSeriesRef.current.setData([]);
+      return;
+    }
+
+    const ratioData = data.map((item) => ({ time: item.time, value: item.value }));
+    ratioSeriesRef.current.setData(ratioData);
+
+    const firstTime = ratioData[0]?.time;
+    const lastTime = ratioData[ratioData.length - 1]?.time;
+    if (firstTime && lastTime) {
+      thresholdSeriesRef.current.setData([
+        { time: firstTime, value: threshold },
+        { time: lastTime, value: threshold },
+      ]);
+    } else {
+      thresholdSeriesRef.current.setData([]);
+    }
+
+    if (chartRef.current) {
+      setChartVisibleBars(chartRef.current, ratioData.length, settings.visibleBars);
+    }
+  }, [condition, data, settings.visibleBars, threshold]);
+
+  useEffect(() => {
+    const container = chartContainerRef.current;
+    if (!container) return;
+
+    const MIN_HEIGHT = 100;
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (!chartRef.current) return;
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      if (width > 0 && height >= MIN_HEIGHT) {
+        chartRef.current.applyOptions({ width, height });
+      }
+    });
+
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return (
+    <div className="h-full">
+      <div className="p-2 text-sm font-medium text-muted-foreground border-b border-border/30 flex items-center gap-2 flex-wrap">
+        <span>{title || 'Risk Adjusted Return'}</span>
+        <span className="text-[#F59E0B]">{lookbackPeriod}</span>
+        <span className="capitalize">{ratioType}</span>
+        <span className={condition === 'above' ? 'text-[#26a69a]' : 'text-[#ef5350]'}>
+          {condition} {threshold.toFixed(2)}
+        </span>
+        {latestValue !== null && <span className="text-[#F59E0B]">{latestValue.toFixed(2)}</span>}
+      </div>
+      <div ref={chartContainerRef} className="flex-1 h-full" />
+    </div>
+  );
+}

--- a/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
@@ -38,6 +38,13 @@ const mockChartStore = {
     tradingValueMA: {
       period: 15,
     },
+    riskAdjustedReturn: {
+      lookbackPeriod: 60,
+      ratioType: 'sortino' as const,
+      threshold: 1.0,
+      condition: 'above' as const,
+    },
+    showRiskAdjustedReturnChart: false,
     signalOverlay: {
       enabled: false,
       signals: [],

--- a/apps/ts/packages/web/src/components/Chart/signalPanelLinks.test.ts
+++ b/apps/ts/packages/web/src/components/Chart/signalPanelLinks.test.ts
@@ -49,6 +49,8 @@ describe('buildSignalPanelLinks', () => {
 
     expect(result.ppo.signalTypes).toEqual(['rsi_threshold']);
     expect(result.ppo.requirements).toEqual(['ohlc']);
+    expect(result.riskAdjustedReturn.signalTypes).toEqual(['rsi_threshold']);
+    expect(result.riskAdjustedReturn.requirements).toEqual(['ohlc']);
 
     expect(result.volumeComparison.signalTypes).toEqual(['volume']);
     expect(result.volumeComparison.requirements).toEqual(['volume']);
@@ -76,6 +78,7 @@ describe('buildSignalPanelLinks', () => {
     });
 
     expect(result.ppo.signalTypes).toEqual([]);
+    expect(result.riskAdjustedReturn.signalTypes).toEqual([]);
     expect(result.volumeComparison.signalTypes).toEqual([]);
     expect(result.tradingValueMA.signalTypes).toEqual([]);
     expect(result.fundamentals.signalTypes).toEqual([]);
@@ -95,6 +98,8 @@ describe('buildSignalPanelLinks', () => {
     });
 
     expect(withNoSignals.ppo.signalTypes).toEqual([]);
+    expect(withNoSignals.riskAdjustedReturn.signalTypes).toEqual([]);
     expect(withNoDefinitions.ppo.signalTypes).toEqual([]);
+    expect(withNoDefinitions.riskAdjustedReturn.signalTypes).toEqual([]);
   });
 });

--- a/apps/ts/packages/web/src/components/Chart/signalPanelLinks.ts
+++ b/apps/ts/packages/web/src/components/Chart/signalPanelLinks.ts
@@ -3,6 +3,7 @@ import type { SignalDefinition } from '@/types/backtest';
 
 export type SignalLinkedPanel =
   | 'ppo'
+  | 'riskAdjustedReturn'
   | 'volumeComparison'
   | 'tradingValueMA'
   | 'fundamentals'
@@ -24,6 +25,7 @@ interface BuildSignalPanelLinksInput {
 
 const PANEL_KEYS: SignalLinkedPanel[] = [
   'ppo',
+  'riskAdjustedReturn',
   'volumeComparison',
   'tradingValueMA',
   'fundamentals',
@@ -35,6 +37,7 @@ const PANEL_KEYS: SignalLinkedPanel[] = [
 function createEmptyLinkMapSets(): Record<SignalLinkedPanel, { signalTypes: Set<string>; requirements: Set<string> }> {
   return {
     ppo: { signalTypes: new Set<string>(), requirements: new Set<string>() },
+    riskAdjustedReturn: { signalTypes: new Set<string>(), requirements: new Set<string>() },
     volumeComparison: { signalTypes: new Set<string>(), requirements: new Set<string>() },
     tradingValueMA: { signalTypes: new Set<string>(), requirements: new Set<string>() },
     fundamentals: { signalTypes: new Set<string>(), requirements: new Set<string>() },
@@ -47,6 +50,7 @@ function createEmptyLinkMapSets(): Record<SignalLinkedPanel, { signalTypes: Set<
 function createEmptyLinkMap(): PanelSignalLinkMap {
   return {
     ppo: { signalTypes: [], requirements: [] },
+    riskAdjustedReturn: { signalTypes: [], requirements: [] },
     volumeComparison: { signalTypes: [], requirements: [] },
     tradingValueMA: { signalTypes: [], requirements: [] },
     fundamentals: { signalTypes: [], requirements: [] },
@@ -90,7 +94,7 @@ function resolvePanelsForRequirement(requirement: string): SignalLinkedPanel[] {
   }
 
   if (requirement === 'ohlc') {
-    return ['ppo'];
+    return ['ppo', 'riskAdjustedReturn'];
   }
 
   return [];

--- a/apps/ts/packages/web/src/hooks/useBtIndicators.ts
+++ b/apps/ts/packages/web/src/hooks/useBtIndicators.ts
@@ -119,6 +119,15 @@ export function buildIndicatorSpecs(settings: ChartSettings): BtIndicatorSpec[] 
   if (settings.showTradingValueMA) {
     specs.push({ type: 'trading_value_ma', params: { period: settings.tradingValueMA.period } });
   }
+  if (settings.showRiskAdjustedReturnChart) {
+    specs.push({
+      type: 'risk_adjusted_return',
+      params: {
+        lookback_period: settings.riskAdjustedReturn.lookbackPeriod,
+        ratio_type: settings.riskAdjustedReturn.ratioType,
+      },
+    });
+  }
 
   return specs;
 }
@@ -226,6 +235,10 @@ const INDICATOR_KEY_TRANSFORMS: Array<{
   {
     prefix: 'trading_value_ma_',
     transform: (r) => ({ target: 'tradingValueMA', data: transformTradingValueMARecords(r) }),
+  },
+  {
+    prefix: 'risk_adjusted_return_',
+    transform: (r) => ({ target: 'indicator', name: 'riskAdjustedReturn', data: transformSingleValueRecords(r) }),
   },
 ];
 

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -47,11 +47,18 @@ const mockSettings = {
   tradingValueMA: {
     period: 15,
   },
+  riskAdjustedReturn: {
+    lookbackPeriod: 60,
+    ratioType: 'sortino' as const,
+    threshold: 1.0,
+    condition: 'above' as const,
+  },
   chartType: 'candlestick' as const,
   showVolume: true,
   showPPOChart: true,
   showVolumeComparison: true,
   showTradingValueMA: true,
+  showRiskAdjustedReturnChart: true,
   showFundamentalsPanel: true,
   showFundamentalsHistoryPanel: true,
   showMarginPressurePanel: true,
@@ -74,6 +81,10 @@ vi.mock('@/components/Chart/StockChart', () => ({
 
 vi.mock('@/components/Chart/PPOChart', () => ({
   PPOChart: () => <div>PPO Chart</div>,
+}));
+
+vi.mock('@/components/Chart/RiskAdjustedReturnChart', () => ({
+  RiskAdjustedReturnChart: () => <div>Risk Adjusted Return Chart</div>,
 }));
 
 vi.mock('@/components/Chart/VolumeComparisonChart', () => ({
@@ -178,6 +189,7 @@ describe('ChartsPage', () => {
     mockSettings.showPPOChart = true;
     mockSettings.showVolumeComparison = true;
     mockSettings.showTradingValueMA = true;
+    mockSettings.showRiskAdjustedReturnChart = true;
     mockSettings.showFundamentalsPanel = true;
     mockSettings.showFundamentalsHistoryPanel = true;
     mockSettings.showMarginPressurePanel = true;
@@ -287,6 +299,7 @@ describe('ChartsPage', () => {
 
     expect(screen.getByText('Stock Chart')).toBeInTheDocument();
     expect(screen.getByText('PPO Chart')).toBeInTheDocument();
+    expect(screen.getByText('Risk Adjusted Return Chart')).toBeInTheDocument();
     expect(screen.getByText('Volume Comparison')).toBeInTheDocument();
     expect(screen.getByText('Trading Value MA')).toBeInTheDocument();
     expect(screen.getByText('Fundamentals Panel')).toBeInTheDocument();

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -7,6 +7,7 @@ import { FundamentalsPanel } from '@/components/Chart/FundamentalsPanel';
 import { useMultiTimeframeChart } from '@/components/Chart/hooks/useMultiTimeframeChart';
 import { MarginPressureChart } from '@/components/Chart/MarginPressureChart';
 import { PPOChart } from '@/components/Chart/PPOChart';
+import { RiskAdjustedReturnChart } from '@/components/Chart/RiskAdjustedReturnChart';
 import { StockChart } from '@/components/Chart/StockChart';
 import { TimeframeSelector } from '@/components/Chart/TimeframeSelector';
 import { TradingValueMAChart } from '@/components/Chart/TradingValueMAChart';
@@ -23,6 +24,7 @@ import type {
   IndicatorValue,
   MarginPressureIndicatorsResponse,
   PPOIndicatorData,
+  RiskAdjustedReturnData,
   TradingValueMAData,
   VolumeComparisonData,
 } from '@/types/chart';
@@ -400,6 +402,37 @@ export function ChartsPage() {
                         <PPOChart
                           data={(chartData[settings.displayTimeframe]?.indicators.ppo as PPOIndicatorData[]) || []}
                           title={`${settings.displayTimeframe.charAt(0).toUpperCase() + settings.displayTimeframe.slice(1)} PPO`}
+                        />
+                      </ErrorBoundary>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Risk Adjusted Return Chart (conditionally displayed) */}
+            {settings.showRiskAdjustedReturnChart && (
+              <div className="h-[200px]">
+                <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+                  <div className="absolute inset-0 gradient-glass opacity-50" />
+                  <div className="relative z-10 h-full">
+                    <div className="p-4 border-b border-border/30">
+                      <h3 className="text-lg font-semibold text-foreground capitalize">
+                        {settings.displayTimeframe} Risk Adjusted Return
+                      </h3>
+                    </div>
+                    <div className="h-[calc(100%-4rem)]">
+                      <ErrorBoundary>
+                        <RiskAdjustedReturnChart
+                          data={
+                            (chartData[settings.displayTimeframe]?.indicators
+                              .riskAdjustedReturn as RiskAdjustedReturnData[]) || []
+                          }
+                          lookbackPeriod={settings.riskAdjustedReturn.lookbackPeriod}
+                          ratioType={settings.riskAdjustedReturn.ratioType}
+                          threshold={settings.riskAdjustedReturn.threshold}
+                          condition={settings.riskAdjustedReturn.condition}
+                          title={`${settings.displayTimeframe.charAt(0).toUpperCase() + settings.displayTimeframe.slice(1)} Risk Adjusted Return`}
                         />
                       </ErrorBoundary>
                     </div>

--- a/apps/ts/packages/web/src/stores/chartStore.test.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.test.ts
@@ -304,4 +304,41 @@ describe('chartStore', () => {
     expect(settings.showMarginPressurePanel).toBe(true);
     expect(settings.showFactorRegressionPanel).toBe(true);
   });
+
+  it('defaults risk adjusted return chart settings', () => {
+    const settings = useChartStore.getState().settings;
+    expect(settings.showRiskAdjustedReturnChart).toBe(false);
+    expect(settings.riskAdjustedReturn).toEqual({
+      lookbackPeriod: 60,
+      ratioType: 'sortino',
+      threshold: 1.0,
+      condition: 'above',
+    });
+  });
+
+  it('sanitizes invalid persisted risk adjusted return settings during rehydrate', async () => {
+    localStorage.setItem(
+      'trading25-chart-store',
+      JSON.stringify({
+        state: {
+          settings: {
+            showRiskAdjustedReturnChart: 'true',
+            riskAdjustedReturn: {
+              lookbackPeriod: 'x',
+              ratioType: 'invalid',
+              threshold: 'invalid',
+              condition: 'invalid',
+            },
+          },
+        },
+        version: 0,
+      })
+    );
+
+    await useChartStore.persist?.rehydrate();
+
+    const settings = useChartStore.getState().settings;
+    expect(settings.showRiskAdjustedReturnChart).toBe(defaultSettings.showRiskAdjustedReturnChart);
+    expect(settings.riskAdjustedReturn).toEqual(defaultSettings.riskAdjustedReturn);
+  });
 });

--- a/apps/ts/packages/web/src/types/chart.ts
+++ b/apps/ts/packages/web/src/types/chart.ts
@@ -20,6 +20,7 @@ export type IndicatorData = ApiIndicatorData;
 export type MACDIndicatorData = ApiMACDIndicatorData;
 export type PPOIndicatorData = ApiPPOIndicatorData;
 export type IndicatorValue = ApiIndicatorValue;
+export type RiskAdjustedReturnData = ApiIndicatorValue;
 export type MarginVolumeRatioData = ApiMarginVolumeRatioData;
 export type MarginVolumeRatioResponse = ApiMarginVolumeRatioResponse;
 export type MarginLongPressureData = ApiMarginLongPressureData;


### PR DESCRIPTION
## Summary
- add backend indicator support for risk_adjusted_return in schema + registry + service
- unify risk-adjusted ratio computation between signal and indicator paths
- add frontend chart controls/store/hook/page integration for Risk Adjusted Return sub-chart
- add panel visibility metadata link and OpenAPI/TS generated type updates
- add/extend backend and frontend tests, including refetch behavior tests

## Testing
- TMPDIR=/tmp bun run --filter @trading25/web typecheck
- TMPDIR=/tmp bun run --filter @trading25/web test
- TMPDIR=/tmp bun run --filter @trading25/web test:coverage
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile apps/bt/src/lib/indicators/calculations.py apps/bt/src/lib/indicators/__init__.py apps/bt/src/server/schemas/indicators.py apps/bt/src/server/services/indicator_service.py apps/bt/src/strategies/signals/risk_adjusted.py

## Notes
- bt pytest execution is blocked in this environment because fastapi is unavailable in the local uv project runtime.