### PR TITLE
fix(web): prevent password-manager misdetection on chart symbol search

### DIFF
--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -140,6 +140,23 @@ describe('ChartControls', () => {
     expect(screen.getByRole('button', { name: /検索/i })).toBeInTheDocument();
   });
 
+  it('uses non-password-search input attributes for symbol search', () => {
+    render(<ChartControls />, { wrapper: TestWrapper });
+
+    const input = screen.getByPlaceholderText('銘柄コードまたは会社名で検索...');
+    const form = input.closest('form');
+
+    expect(input).toHaveAttribute('type', 'search');
+    expect(input).toHaveAttribute('name', 'symbol-search');
+    expect(input).toHaveAttribute('autocomplete', 'off');
+    expect(input).toHaveAttribute('inputmode', 'search');
+    expect(input).toHaveAttribute('enterkeyhint', 'search');
+    expect(input).toHaveAttribute('data-form-type', 'other');
+    expect(input).toHaveAttribute('data-lpignore', 'true');
+    expect(input).toHaveAttribute('data-1p-ignore', 'true');
+    expect(form).toHaveAttribute('autocomplete', 'off');
+  });
+
   it('submits symbol when form is submitted', async () => {
     const user = userEvent.setup();
     mockChartStore.setSelectedSymbol = vi.fn();

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -257,11 +257,13 @@ export function ChartControls() {
       <div className="glass-panel rounded-lg p-3 space-y-2">
         <SectionHeader icon={Search} title="Symbol Search" />
         <div className="space-y-2">
-          <form onSubmit={handleSymbolSubmit} className="space-y-2">
+          <form onSubmit={handleSymbolSubmit} className="space-y-2" autoComplete="off">
             <div className="relative">
               <Input
                 ref={inputRef}
                 id={symbolSearchId}
+                type="search"
+                name="symbol-search"
                 placeholder="銘柄コードまたは会社名で検索..."
                 value={symbolInput}
                 onChange={(e) => {
@@ -273,6 +275,14 @@ export function ChartControls() {
                 onKeyDown={handleKeyDown}
                 className="w-full glass-panel border-border/30 focus:border-primary/50 transition-all duration-200 pr-10"
                 autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                inputMode="search"
+                enterKeyHint="search"
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
               />
               {isSearching && (
                 <div className="absolute right-3 top-1/2 -translate-y-1/2">
@@ -632,13 +642,7 @@ interface SearchSuggestionsProps {
   onSelect: (stock: StockSearchResultItem) => void;
 }
 
-function SearchSuggestions({
-  containerRef,
-  results,
-  selectedIndex,
-  position,
-  onSelect,
-}: SearchSuggestionsProps) {
+function SearchSuggestions({ containerRef, results, selectedIndex, position, onSelect }: SearchSuggestionsProps) {
   return createPortal(
     <div
       ref={containerRef}


### PR DESCRIPTION
## Summary\n- mark chart symbol input explicitly as search (, )\n- add autofill/assist hints to reduce password-manager false positives\n- add regression test for symbol search input attributes\n\n## Validation\n- bun run --filter @trading25/web test -- src/components/Chart/ChartControls.test.tsx\n- bun run --filter @trading25/web typecheck\n- bun run --filter @trading25/web test:coverage -- src/components/Chart/ChartControls.test.tsx