### PR TITLE
fix(bt): prevent indices fallback FK failures in legacy market.db

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **market.db**: 読み書き（SQLAlchemy Core）
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
-- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新し、`/indices` 取得失敗時は日付指定フォールバックで継続する（`indices-only` は指数再同期専用モード）
+- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新し、`/indices` 取得失敗時は日付指定フォールバックで継続する（`indices-only` は指数再同期専用モード）。フォールバック時は不足 `index_master` をプレースホルダ補完して、FK 制約付きの既存DBでも継続可能にする
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う

--- a/apps/bt/src/server/services/__init__.py
+++ b/apps/bt/src/server/services/__init__.py
@@ -2,9 +2,15 @@
 API Services
 """
 
-from src.server.services.backtest_service import BacktestService
-from src.server.services.backtest_attribution_service import BacktestAttributionService
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from src.server.services.job_manager import JobManager, job_manager
+
+if TYPE_CHECKING:
+    from src.server.services.backtest_attribution_service import BacktestAttributionService
+    from src.server.services.backtest_service import BacktestService
 
 __all__ = [
     "BacktestService",
@@ -12,3 +18,15 @@ __all__ = [
     "JobManager",
     "job_manager",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "BacktestService":
+        from src.server.services.backtest_service import BacktestService
+
+        return BacktestService
+    if name == "BacktestAttributionService":
+        from src.server.services.backtest_attribution_service import BacktestAttributionService
+
+        return BacktestAttributionService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/bt/tests/unit/server/services/test_services_init.py
+++ b/apps/bt/tests/unit/server/services/test_services_init.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import src.server.services as services
+
+
+def test_getattr_resolves_backtest_service_without_eager_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_module = types.ModuleType("src.server.services.backtest_service")
+
+    class FakeBacktestService:
+        pass
+
+    fake_module.BacktestService = FakeBacktestService
+    monkeypatch.setitem(sys.modules, "src.server.services.backtest_service", fake_module)
+
+    resolved = services.__getattr__("BacktestService")
+    assert resolved is FakeBacktestService
+
+
+def test_getattr_resolves_backtest_attribution_service_without_eager_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_module = types.ModuleType("src.server.services.backtest_attribution_service")
+
+    class FakeBacktestAttributionService:
+        pass
+
+    fake_module.BacktestAttributionService = FakeBacktestAttributionService
+    monkeypatch.setitem(
+        sys.modules,
+        "src.server.services.backtest_attribution_service",
+        fake_module,
+    )
+
+    resolved = services.__getattr__("BacktestAttributionService")
+    assert resolved is FakeBacktestAttributionService
+
+
+def test_getattr_raises_for_unknown_name() -> None:
+    with pytest.raises(AttributeError, match="has no attribute"):
+        services.__getattr__("UnknownService")


### PR DESCRIPTION
## Summary
- prevent incremental index fallback from failing on legacy market.db schemas with indices_data(code) -> index_master(code) FK
- insert missing fallback index master rows before writing fallback indices_data rows when /indices is unavailable
- make MarketDb.upsert_index_master use SQLite ON CONFLICT DO UPDATE instead of OR REPLACE for FK-safe parent updates
- lazily import heavy backtest services in src.server.services.__init__ to avoid import side effects during focused test/coverage runs
- add regression tests for fallback FK compatibility, helper behavior, lazy imports, and legacy schema upsert behavior
- update AGENTS.md with the new incremental-sync FK compatibility rule

## Testing
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/db/test_market_db.py apps/bt/tests/unit/server/services/test_services_init.py
- uv run --project apps/bt pytest --noconftest apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/db/test_market_db.py --cov=src.server.services.sync_strategies --cov=src.lib.market_db.market_db --cov-branch --cov-report=term
- uv run --project apps/bt ruff check apps/bt/src/lib/market_db/market_db.py apps/bt/src/server/services/sync_strategies.py apps/bt/src/server/services/__init__.py apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/db/test_market_db.py apps/bt/tests/unit/server/services/test_services_init.py
- uv run --project apps/bt pyright apps/bt/src/lib/market_db/market_db.py apps/bt/src/server/services/sync_strategies.py apps/bt/src/server/services/__init__.py
