### PR TITLE
refactor: remove redundant book-to-market metric/signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ bun run --filter @trading25/shared bt:sync   # bt の OpenAPI → TS型生成
 `contracts/` に bt/ts 間の安定インターフェースを定義。詳細は [`contracts/README.md`](contracts/README.md) 参照。
 - **バージョニング**: additive (minor) / breaking (major) → 新版ファイル作成
 - **命名規則**: `{domain}-{purpose}-v{N}.schema.json`
-- **現行追加契約**: `fundamentals-metrics-v1.schema.json`（fundamentals API 指標拡張）
+- **現行追加契約**: `fundamentals-metrics-v2.schema.json`（fundamentals API 指標拡張、`bookToMarket` を削除）
 - **アーカイブ**: `hono-openapi-baseline.json`（Phase 3 移行 baseline、参照用に保持）
 
 ## エラーレスポンス

--- a/apps/bt/src/models/signals/fundamental.py
+++ b/apps/bt/src/models/signals/fundamental.py
@@ -55,22 +55,6 @@ class FundamentalSignalParams(BaseSignalParams):
             description="負のPBR（債務超過企業）を除外するか",
         )
 
-    class BookToMarketParams(BaseModel):
-        """B/M（簿価時価比率）シグナルパラメータ"""
-
-        enabled: bool = Field(default=False, description="B/Mシグナル有効")
-        threshold: float = Field(
-            default=1.0, gt=0, le=20.0, description="B/M閾値（この値以上で割安判定）"
-        )
-        condition: Literal["above", "below"] = Field(
-            default="above",
-            description="条件（above=閾値以上、below=閾値以下）",
-        )
-        exclude_negative: bool = Field(
-            default=True,
-            description="負のB/Mを除外するか",
-        )
-
     class PEGRatioParams(BaseModel):
         """PEG Ratio シグナルパラメータ"""
 
@@ -384,9 +368,6 @@ class FundamentalSignalParams(BaseSignalParams):
     # バリュエーション系
     per: PERParams = Field(default_factory=PERParams, description="PERシグナル")
     pbr: PBRParams = Field(default_factory=PBRParams, description="PBRシグナル")
-    book_to_market: BookToMarketParams = Field(
-        default_factory=BookToMarketParams, description="B/Mシグナル"
-    )
     peg_ratio: PEGRatioParams = Field(
         default_factory=PEGRatioParams, description="PEG Ratioシグナル"
     )

--- a/apps/bt/src/server/schemas/fundamentals.py
+++ b/apps/bt/src/server/schemas/fundamentals.py
@@ -67,9 +67,6 @@ class FundamentalDataPoint(BaseModel):
     )
     per: float | None = Field(None, description="Price to earnings ratio")
     pbr: float | None = Field(None, description="Price to book ratio")
-    bookToMarket: float | None = Field(
-        None, description="Book-to-Market ratio (BPS / Close)"
-    )
 
     # Profitability metrics
     roa: float | None = Field(None, description="Return on Assets (%)")

--- a/apps/bt/src/server/services/fundamentals_service.py
+++ b/apps/bt/src/server/services/fundamentals_service.py
@@ -302,9 +302,6 @@ class FundamentalsService:
                 "adjustedDividendFy": adjusted_dividend,
                 "per": self._round_or_none(self._calculate_per(display_eps, item.stockPrice)),
                 "pbr": self._round_or_none(self._calculate_pbr(display_bps, item.stockPrice)),
-                "bookToMarket": self._round_or_none(
-                    self._calculate_book_to_market(display_bps, item.stockPrice)
-                ),
             }
         )
 
@@ -503,7 +500,6 @@ class FundamentalsService:
         # Calculate valuation metrics
         per = self._calculate_per(eps, stock_price)
         pbr = self._calculate_pbr(bps, stock_price)
-        book_to_market = self._calculate_book_to_market(bps, stock_price)
 
         # Calculate profitability metrics
         roa = self._calculate_roa(stmt, prefer_consolidated)
@@ -549,7 +545,6 @@ class FundamentalsService:
             adjustedDividendFy=dividend_fy,
             per=self._round_or_none(per),
             pbr=self._round_or_none(pbr),
-            bookToMarket=self._round_or_none(book_to_market),
             roa=self._round_or_none(roa),
             operatingMargin=self._round_or_none(operating_margin),
             netMargin=self._round_or_none(net_margin),
@@ -673,14 +668,6 @@ class FundamentalsService:
         if bps is None or stock_price is None or bps <= 0:
             return None
         return stock_price / bps
-
-    def _calculate_book_to_market(
-        self, bps: float | None, stock_price: float | None
-    ) -> float | None:
-        """Calculate book-to-market ratio (BPS / Close)."""
-        if bps is None or stock_price is None or bps <= 0 or stock_price <= 0:
-            return None
-        return bps / stock_price
 
     def _calculate_simple_fcf(
         self, cfo: float | None, cfi: float | None

--- a/apps/bt/src/strategies/signals/fundamental.py
+++ b/apps/bt/src/strategies/signals/fundamental.py
@@ -29,7 +29,6 @@ from .fundamental_helpers import (
 
 # バリュエーション系シグナル
 from .fundamental_valuation import (
-    is_high_book_to_market,
     is_undervalued_by_pbr,
     is_undervalued_by_per,
     is_undervalued_growth_by_peg,
@@ -72,7 +71,6 @@ __all__ = [
     # バリュエーション系
     "is_undervalued_by_per",
     "is_undervalued_by_pbr",
-    "is_high_book_to_market",
     "is_undervalued_growth_by_peg",
     # 成長率系
     "is_growing_eps",

--- a/apps/bt/src/strategies/signals/fundamental_valuation.py
+++ b/apps/bt/src/strategies/signals/fundamental_valuation.py
@@ -1,7 +1,7 @@
 """
 財務指標シグナル — バリュエーション系
 
-PER・PBR・B/M・PEGに基づく割安判定シグナルを提供
+PER・PBR・PEGに基づく割安判定シグナルを提供
 """
 
 from __future__ import annotations
@@ -84,46 +84,6 @@ def is_undervalued_by_pbr(
 
     result = pd.Series(False, index=close.index)
     result.loc[common_index] = pbr_signal
-    return result.fillna(False)
-
-
-def is_high_book_to_market(
-    close: pd.Series[float],
-    bps: pd.Series[float],
-    threshold: float = 1.0,
-    condition: Literal["above", "below"] = "above",
-    exclude_negative: bool = True,
-) -> pd.Series[bool]:
-    """
-    B/M（Book-to-Market Ratio）シグナル
-
-    B/M = BPS / Close を計算し、指定した条件で閾値と比較してTrueを返すシグナル
-
-    Args:
-        close: 終値データ
-        bps: BPS（1株当たり純資産）データ
-        threshold: B/M閾値（デフォルト1.0）
-        condition: 条件（above=閾値以上、below=閾値以下）
-        exclude_negative: 負のB/Mを除外するか（デフォルトTrue）
-
-    Returns:
-        pd.Series[bool]: 条件を満たす場合にTrue
-
-    Note:
-        - Closeが0以下またはNaNの場合はFalseを返す
-        - BPSが0以下またはNaNの場合はFalseを返す
-    """
-    common_index = close.index.intersection(bps.index)
-    close_common = close.reindex(common_index)
-    bps_common = bps.reindex(common_index)
-
-    valid_bps = bps_common.where(bps_common > 0, np.nan)
-    valid_close = close_common.where(close_common > 0, np.nan)
-    book_to_market = valid_bps / valid_close
-    bm_signal = _calc_ratio_signal(book_to_market, threshold, condition, exclude_negative)
-
-    result = pd.Series(False, index=close.index)
-    result.loc[common_index] = bm_signal
     return result.fillna(False)
 
 

--- a/apps/bt/src/strategies/signals/registry.py
+++ b/apps/bt/src/strategies/signals/registry.py
@@ -22,7 +22,6 @@ from .buy_and_hold import generate_buy_and_hold_signals
 from .crossover import indicator_crossover_signal
 from .fundamental import (
     cfo_yield_threshold,
-    is_high_book_to_market,
     is_expected_growth_eps,
     is_growing_cfo_yield,
     is_growing_dividend_per_share,
@@ -648,28 +647,6 @@ SIGNAL_REGISTRY: list[SignalDefinition] = [
         category="fundamental",
         description="PBR（株価純資産倍率）の閾値判定",
         param_key="fundamental.pbr",
-        data_checker=lambda d: _has_statements_column(d, "BPS"),
-        data_requirements=["statements:BPS"],
-    ),
-    # 21-2. B/Mシグナル（簿価時価比率）
-    SignalDefinition(
-        name="B/M",
-        signal_func=is_high_book_to_market,
-        enabled_checker=lambda p: p.fundamental.enabled and p.fundamental.book_to_market.enabled,
-        param_builder=lambda p, d: {
-            "close": d["execution_close"],
-            "bps": d["statements_data"][
-                _select_fundamental_column(p, "AdjustedBPS", "BPS")
-            ],
-            "threshold": p.fundamental.book_to_market.threshold,
-            "condition": p.fundamental.book_to_market.condition,
-            "exclude_negative": p.fundamental.book_to_market.exclude_negative,
-        },
-        entry_purpose="B/M（簿価時価比率）が閾値以上の割安株を選定",
-        exit_purpose="B/Mが閾値を下回った割安度低下株を除外",
-        category="fundamental",
-        description="B/M（簿価時価比率）の閾値判定",
-        param_key="fundamental.book_to_market",
         data_checker=lambda d: _has_statements_column(d, "BPS"),
         data_requirements=["statements:BPS"],
     ),

--- a/apps/bt/tests/server/services/test_fundamentals_service.py
+++ b/apps/bt/tests/server/services/test_fundamentals_service.py
@@ -216,18 +216,6 @@ class TestMetricCalculations:
         assert service._calculate_pbr(bps=0.0, stock_price=6000.0) is None
         assert service._calculate_pbr(bps=-100.0, stock_price=6000.0) is None
 
-    def test_calculate_book_to_market(self, service: FundamentalsService):
-        """B/M計算"""
-        bm = service._calculate_book_to_market(bps=2250.0, stock_price=6750.0)
-        assert bm == pytest.approx(0.3333333333)
-
-    def test_calculate_book_to_market_invalid(self, service: FundamentalsService):
-        """B/Mの無効値（BPS<=0 or Close<=0）"""
-        assert service._calculate_book_to_market(bps=None, stock_price=6000.0) is None
-        assert service._calculate_book_to_market(bps=2250.0, stock_price=None) is None
-        assert service._calculate_book_to_market(bps=0.0, stock_price=6000.0) is None
-        assert service._calculate_book_to_market(bps=2250.0, stock_price=0.0) is None
-
     def test_calculate_roa(
         self, service: FundamentalsService, sample_statement: JQuantsStatement
     ):
@@ -1077,10 +1065,8 @@ class TestComputeFundamentals:
         assert result.data[0].bps == 2250.0
         assert result.data[0].cfoToNetProfitRatio == 1.5
         assert result.data[0].tradingValueToMarketCapRatio is not None
-        assert result.data[0].bookToMarket is not None
         assert result.latestMetrics is not None
         assert result.latestMetrics.tradingValueToMarketCapRatio is not None
-        assert result.latestMetrics.bookToMarket is not None
 
     def test_share_adjusted_metrics(self, service: FundamentalsService):
         """発行済株式数でEPS/BPS/予想EPSを調整する"""
@@ -1175,9 +1161,6 @@ class TestComputeFundamentals:
         assert latest.adjustedEps == latest.eps
         assert latest.adjustedForecastEps == latest.forecastEps
         assert latest.adjustedBps == latest.bps
-        assert latest.bookToMarket == pytest.approx(
-            round((latest.adjustedBps or latest.bps) / latest.stockPrice, 2)
-        )
 
         assert older.adjustedEps == 50.0
         # FY uses NxFEPS (=110.0), adjusted = 110.0 * (100/200) = 55.0
@@ -2165,7 +2148,6 @@ class TestDividendPerShare:
             adjustedDividendFy=80.0,
             per=None,
             pbr=None,
-            bookToMarket=None,
             roa=None,
             operatingMargin=None,
             netMargin=None,
@@ -2204,4 +2186,3 @@ class TestDividendPerShare:
         )
 
         assert adjusted.adjustedDividendFy == 40.0
-        assert adjusted.bookToMarket == 0.25

--- a/apps/bt/tests/unit/strategies/signals/test_fundamental.py
+++ b/apps/bt/tests/unit/strategies/signals/test_fundamental.py
@@ -11,7 +11,6 @@ import numpy as np
 from src.strategies.signals.fundamental import (
     is_undervalued_by_per,
     is_undervalued_by_pbr,
-    is_high_book_to_market,
     is_growing_eps,
     is_growing_profit,
     is_growing_sales,
@@ -132,45 +131,6 @@ class TestIsUndervaluedByPbr:
         assert isinstance(signal_high, pd.Series)
         # 高い閾値の方がTrue数が多い
         assert signal_high.sum() >= signal_low.sum()
-
-
-class TestIsHighBookToMarket:
-    """is_high_book_to_market()のテスト"""
-
-    def setup_method(self):
-        """テストデータ作成"""
-        self.dates = pd.date_range("2023-01-01", periods=100)
-        self.close = pd.Series(np.ones(100) * 80.0, index=self.dates)
-        self.bps = pd.Series(np.ones(100) * 100.0, index=self.dates)  # B/M = 1.25
-
-    def test_bm_basic(self):
-        """B/Mシグナル基本テスト"""
-        signal = is_high_book_to_market(self.close, self.bps, threshold=1.0)
-        assert isinstance(signal, pd.Series)
-        assert signal.dtype == bool
-        assert signal.all()
-
-    def test_bm_close_zero(self):
-        """Close<=0は無効値としてFalse"""
-        close_with_zero = self.close.copy()
-        close_with_zero.iloc[0:10] = 0.0
-        signal = is_high_book_to_market(close_with_zero, self.bps, threshold=1.0)
-        assert not signal.iloc[0:10].any()
-        assert signal.iloc[10:].all()
-
-    def test_bm_threshold_effect(self):
-        """閾値の効果テスト"""
-        signal_low = is_high_book_to_market(self.close, self.bps, threshold=1.0)
-        signal_high = is_high_book_to_market(self.close, self.bps, threshold=2.0)
-        assert signal_low.sum() >= signal_high.sum()
-
-    def test_bm_non_positive_bps(self):
-        """BPS<=0は無効値としてFalse"""
-        bps_with_zero = self.bps.copy()
-        bps_with_zero.iloc[0:10] = 0.0
-        signal = is_high_book_to_market(self.close, bps_with_zero, threshold=1.0)
-        assert not signal.iloc[0:10].any()
-        assert signal.iloc[10:].all()
 
 
 class TestIsGrowingEps:
@@ -992,27 +952,6 @@ class TestConditionParameterPBR:
         assert signal.all()
 
 
-class TestConditionParameterBookToMarket:
-    """B/Mのconditionパラメータテスト"""
-
-    def setup_method(self):
-        self.dates = pd.date_range("2023-01-01", periods=100)
-        self.close = pd.Series(np.ones(100) * 80.0, index=self.dates)
-        self.bps = pd.Series(np.ones(100) * 100.0, index=self.dates)  # B/M = 1.25
-
-    def test_condition_above_default(self):
-        """above条件（デフォルト）"""
-        signal = is_high_book_to_market(self.close, self.bps, threshold=1.0)
-        assert signal.all()
-
-    def test_condition_below(self):
-        """below条件"""
-        signal = is_high_book_to_market(
-            self.close, self.bps, threshold=2.0, condition="below"
-        )
-        assert signal.all()
-
-
 class TestConditionParameterROE:
     """ROEのconditionパラメータテスト"""
 
@@ -1344,43 +1283,6 @@ class TestExcludeNegativeParameter:
             self.close, self.bps, threshold=1.5, exclude_negative=True
         )
         pd.testing.assert_series_equal(signal_default, signal_explicit)
-
-    def test_bm_exclude_negative_true_default(self):
-        """B/M: exclude_negative=True（デフォルト）で負のB/Mを除外"""
-        close_with_negative = self.close.copy()
-        close_with_negative.iloc[0:20] = -100.0
-
-        signal = is_high_book_to_market(
-            close_with_negative,
-            pd.Series(np.ones(100) * 100.0, index=self.dates),
-            threshold=0.0,
-            condition="below",
-            exclude_negative=True,
-        )
-        assert not signal.iloc[0:20].any()
-
-    def test_bm_exclude_negative_false(self):
-        """B/M: close<=0はexclude_negativeに関係なくFalse"""
-        close_with_negative = self.close.copy()
-        close_with_negative.iloc[0:20] = -100.0
-
-        signal_exclude = is_high_book_to_market(
-            close_with_negative,
-            pd.Series(np.ones(100) * 100.0, index=self.dates),
-            threshold=0.0,
-            condition="below",
-            exclude_negative=True,
-        )
-        signal_include = is_high_book_to_market(
-            close_with_negative,
-            pd.Series(np.ones(100) * 100.0, index=self.dates),
-            threshold=0.0,
-            condition="below",
-            exclude_negative=False,
-        )
-
-        assert not signal_exclude.iloc[0:20].any()
-        assert not signal_include.iloc[0:20].any()
 
 
 # =====================================================================
@@ -2327,17 +2229,6 @@ class TestFundamentalSignalParamsConfig:
         assert params.eps_growth.enabled is True
         assert params.forward_eps_growth.threshold == 0.1
         assert params.eps_growth.threshold == 0.2
-
-    def test_book_to_market_field_exists(self):
-        """book_to_marketフィールドが正しくパースされること"""
-        from src.models.signals.fundamental import FundamentalSignalParams
-
-        params = FundamentalSignalParams(
-            book_to_market={"enabled": True, "threshold": 1.2, "condition": "above"}
-        )
-        assert params.book_to_market.enabled is True
-        assert params.book_to_market.threshold == 1.2
-        assert params.book_to_market.condition == "above"
 
     def test_dividend_per_share_growth_field_exists(self):
         """dividend_per_share_growthフィールドが正しくパースされること"""

--- a/apps/bt/tests/unit/strategies/signals/test_registry.py
+++ b/apps/bt/tests/unit/strategies/signals/test_registry.py
@@ -228,15 +228,6 @@ class TestSignalRegistry:
         assert sig.category == "fundamental"
         assert "statements:SharesOutstanding" in sig.data_requirements
 
-    def test_book_to_market_registered(self) -> None:
-        """book_to_market（B/M）がレジストリに登録されていること"""
-        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.book_to_market"]
-        assert len(matches) == 1
-        sig = matches[0]
-        assert sig.name == "B/M"
-        assert sig.category == "fundamental"
-        assert "statements:BPS" in sig.data_requirements
-
     def test_market_cap_enabled_checker(self) -> None:
         """market_capのenabled_checkerが正しく動作すること"""
         sig = next(s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.market_cap")
@@ -333,36 +324,3 @@ class TestFundamentalAdjustedSelection:
         sig = self._get_signal("fundamental.per")
         built = sig.param_builder(params, {"statements_data": df, "execution_close": close})
         assert built["eps"].equals(df["EPS"])
-
-    def test_book_to_market_uses_adjusted_by_default(self) -> None:
-        params = SignalParams()
-        params.fundamental.book_to_market.enabled = True
-
-        df = pd.DataFrame(
-            {
-                "BPS": [1.0],
-                "AdjustedBPS": [0.5],
-            }
-        )
-        close = pd.Series([100.0])
-
-        sig = self._get_signal("fundamental.book_to_market")
-        built = sig.param_builder(params, {"statements_data": df, "execution_close": close})
-        assert built["bps"].equals(df["AdjustedBPS"])
-
-    def test_book_to_market_adjusted_can_be_disabled(self) -> None:
-        params = SignalParams()
-        params.fundamental.use_adjusted = False
-        params.fundamental.book_to_market.enabled = True
-
-        df = pd.DataFrame(
-            {
-                "BPS": [1.0],
-                "AdjustedBPS": [0.5],
-            }
-        )
-        close = pd.Series([100.0])
-
-        sig = self._get_signal("fundamental.book_to_market")
-        built = sig.param_builder(params, {"statements_data": df, "execution_close": close})
-        assert built["bps"].equals(df["BPS"])

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -12762,18 +12762,6 @@
             "title": "Tradingvaluetomarketcapratio",
             "description": "Market cap / N-day average trading value ratio (x)"
           },
-          "bookToMarket": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Booktomarket",
-            "description": "Book-to-Market ratio (BPS / Close)"
-          },
           "forecastEps": {
             "anyOf": [
               {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -3258,11 +3258,6 @@ export interface components {
              */
             tradingValueToMarketCapRatio?: number | null;
             /**
-             * Booktomarket
-             * @description Book-to-Market ratio (BPS / Close)
-             */
-            bookToMarket?: number | null;
-            /**
              * Forecasteps
              * @description Forecast EPS (JPY)
              */

--- a/apps/ts/packages/shared/src/types/api-types.ts
+++ b/apps/ts/packages/shared/src/types/api-types.ts
@@ -186,8 +186,6 @@ export interface ApiFundamentalDataPoint {
   per: number | null;
   /** Price to Book Ratio (倍) - calculated with disclosure date price */
   pbr: number | null;
-  /** Book-to-Market Ratio = BPS / Close (倍) */
-  bookToMarket?: number | null;
   // Profitability metrics
   /** Return on Assets (%) */
   roa: number | null;

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
@@ -136,7 +136,6 @@ describe('FundamentalsPanel', () => {
           prevCashAndEquivalents: 450,
           cfoToNetProfitRatio: 0.45,
           tradingValueToMarketCapRatio: 33.333333,
-          bookToMarket: 0.56,
         },
         dailyValuation: [{ per: 18, pbr: 1.4, close: 2500, marketCap: 1000000000 }],
         tradingValuePeriod: 20,
@@ -160,7 +159,6 @@ describe('FundamentalsPanel', () => {
     expect(metrics?.stockPrice).toBe(2500);
     expect(metrics?.cfoToNetProfitRatio).toBe(0.45);
     expect(metrics?.tradingValueToMarketCapRatio).toBeCloseTo(33.333333, 5);
-    expect(metrics?.bookToMarket).toBe(0.56);
     expect(mockSummaryCard.mock.calls.at(-1)?.[0]).toMatchObject({ tradingValuePeriod: 20 });
   });
 

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
@@ -51,7 +51,6 @@ export function FundamentalsPanel({
       cfoToNetProfitRatio: data.latestMetrics?.cfoToNetProfitRatio ?? fyData.cfoToNetProfitRatio ?? null,
       tradingValueToMarketCapRatio:
         data.latestMetrics?.tradingValueToMarketCapRatio ?? fyData.tradingValueToMarketCapRatio ?? null,
-      bookToMarket: data.latestMetrics?.bookToMarket ?? fyData.bookToMarket ?? null,
     };
 
     const displayActualEps = result.adjustedEps ?? result.eps ?? null;

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -17,7 +17,6 @@ const baseMetrics: ApiFundamentalDataPoint = {
   bps: 2250,
   per: 20,
   pbr: 2.7,
-  bookToMarket: 0.37,
   roa: 4.4,
   operatingMargin: 11.1,
   netMargin: 8.9,
@@ -57,10 +56,8 @@ describe('FundamentalsSummaryCard', () => {
 
     expect(screen.getByText('営業CF/純利益')).toBeInTheDocument();
     expect(screen.getByText('時価総額/20日売買代金')).toBeInTheDocument();
-    expect(screen.getByText('B/M')).toBeInTheDocument();
     expect(screen.getByText('1.50x')).toBeInTheDocument();
     expect(screen.getByText('8.33x')).toBeInTheDocument();
-    expect(screen.getByText('0.37x')).toBeInTheDocument();
   });
 
   it('uses 15-day label by default', () => {

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -109,7 +109,6 @@ export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: Fu
         <div className="grid grid-cols-8 gap-1.5 p-2">
           <MetricCard label="PER" value={metrics.per} format="times" colorScheme="per" />
           <MetricCard label="PBR" value={metrics.pbr} format="times" colorScheme="pbr" />
-          <MetricCard label="B/M" value={metrics.bookToMarket ?? null} format="times" colorScheme="neutral" />
           <MetricCard label="ROE" value={metrics.roe} format="percent" colorScheme="roe" />
           <MetricCard label="ROA" value={metrics.roa} format="percent" colorScheme="roe" />
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -56,7 +56,8 @@ bun run --filter @trading25/shared bt:sync
 | `dataset-db-schema-v2.json` | **Active** | Dataset DB schema contract aligned with `apps/ts` Drizzle tables (395 lines). Use this for all new development. |
 | `backtest-run-manifest-v1.schema.json` | **Active** | Backtest run manifest emitted by `apps/bt`. |
 | `strategy-config-v1.schema.json` | **Active** | Strategy YAML schema validated by `apps/bt`. |
-| `fundamentals-metrics-v1.schema.json` | **Active** | Fundamentals API response contract (`/api/analytics/fundamentals/{symbol}`), including `cfoToNetProfitRatio`, `tradingValueToMarketCapRatio`, and `tradingValuePeriod`. |
+| `fundamentals-metrics-v1.schema.json` | **Deprecated** | Legacy fundamentals API response contract（`bookToMarket` を含む旧版）。 |
+| `fundamentals-metrics-v2.schema.json` | **Active** | Fundamentals API response contract (`/api/analytics/fundamentals/{symbol}`), including `cfoToNetProfitRatio`, `tradingValueToMarketCapRatio`, and `tradingValuePeriod`. |
 | `portfolio-db-schema-v1.json` | **Active** | Portfolio DB schema contract (portfolios, portfolio_items, watchlists, watchlist_items, portfolio_metadata). |
 | `hono-openapi-baseline.json` | **Archived** | Hono OpenAPI snapshot used as Phase 3 migration baseline. Phase 3F (2026-02-07) で全 90 EP 移行完了・Hono 廃止済み。参照用に保持。 |
 

--- a/contracts/fundamentals-metrics-v2.schema.json
+++ b/contracts/fundamentals-metrics-v2.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Trading25 Fundamentals Metrics Contract v2",
+  "description": "FastAPI fundamentals response contract used by apps/ts frontend and shared types.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["symbol", "data", "tradingValuePeriod", "lastUpdated"],
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "minLength": 1
+    },
+    "companyName": {
+      "type": ["string", "null"]
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/data_point"
+      }
+    },
+    "latestMetrics": {
+      "anyOf": [
+        { "$ref": "#/$defs/data_point" },
+        { "type": "null" }
+      ]
+    },
+    "dailyValuation": {
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/$defs/daily_valuation_point"
+      }
+    },
+    "tradingValuePeriod": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 250
+    },
+    "lastUpdated": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "data_point": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "date",
+        "disclosedDate",
+        "periodType",
+        "isConsolidated",
+        "cfoToNetProfitRatio",
+        "tradingValueToMarketCapRatio"
+      ],
+      "properties": {
+        "date": { "type": "string" },
+        "disclosedDate": { "type": "string" },
+        "periodType": { "type": "string" },
+        "isConsolidated": { "type": "boolean" },
+        "cfoToNetProfitRatio": { "type": ["number", "null"] },
+        "tradingValueToMarketCapRatio": { "type": ["number", "null"] }
+      }
+    },
+    "daily_valuation_point": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["date", "close", "per", "pbr", "marketCap"],
+      "properties": {
+        "date": { "type": "string" },
+        "close": { "type": "number" },
+        "per": { "type": ["number", "null"] },
+        "pbr": { "type": ["number", "null"] },
+        "marketCap": { "type": ["number", "null"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove redundant B/M signal implementation from bt (model, function, registry)
- remove bookToMarket from fundamentals API/schema and ts UI/types
- add contracts/fundamentals-metrics-v2.schema.json and deprecate v1 in contracts docs

## Validation
- uv run --project apps/bt pytest apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/strategies/signals/test_registry.py apps/bt/tests/server/services/test_fundamentals_service.py
- bun run --filter @trading25/web test src/components/Chart/FundamentalsPanel.test.tsx src/components/Chart/FundamentalsSummaryCard.test.tsx
- bun run typecheck:all