### PR TITLE
fix(web): unify sub-chart indicator controls

### DIFF
--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -223,9 +223,10 @@ describe('ChartControls', () => {
     render(<ChartControls />, { wrapper: TestWrapper });
 
     expect(screen.getByText('Panel Visibility')).toBeInTheDocument();
-    expect(screen.getAllByRole('switch', { name: /ppo/i }).length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Volume Comparison').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Trading Value MA').length).toBeGreaterThan(0);
+    expect(screen.getByRole('switch', { name: /show ppo chart/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('switch', { name: /risk adjusted return/i })).toHaveLength(1);
+    expect(screen.getAllByRole('switch', { name: /volume comparison/i })).toHaveLength(1);
+    expect(screen.getAllByRole('switch', { name: /trading value ma/i })).toHaveLength(1);
     expect(screen.getByRole('switch', { name: /fundamentals/i })).toBeInTheDocument();
     expect(screen.getByRole('switch', { name: /fy history/i })).toBeInTheDocument();
     expect(screen.getByRole('switch', { name: /margin pressure/i })).toBeInTheDocument();

--- a/apps/ts/packages/web/src/components/Chart/IndicatorToggle.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/IndicatorToggle.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { IndicatorToggle, NumberInput } from './IndicatorToggle';
+
+describe('IndicatorToggle', () => {
+  it('renders label and toggles switch state', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+
+    render(<IndicatorToggle label="Risk Adjusted Return" enabled={false} onToggle={onToggle} />);
+
+    const toggle = screen.getByRole('switch', { name: /risk adjusted return/i });
+    await user.click(toggle);
+
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('renders meta text when provided', () => {
+    render(
+      <IndicatorToggle
+        label="Volume Comparison"
+        enabled={false}
+        onToggle={vi.fn()}
+        meta="Signal req: volume | Signals: volume"
+      />
+    );
+
+    expect(screen.getByText('Signal req: volume | Signals: volume')).toBeInTheDocument();
+  });
+
+  it('renders children only when enabled', () => {
+    const Child = <div>settings</div>;
+
+    const { rerender } = render(
+      <IndicatorToggle label="Trading Value MA" enabled={false} onToggle={vi.fn()}>
+        {Child}
+      </IndicatorToggle>
+    );
+
+    expect(screen.queryByText('settings')).not.toBeInTheDocument();
+
+    rerender(
+      <IndicatorToggle label="Trading Value MA" enabled onToggle={vi.fn()}>
+        {Child}
+      </IndicatorToggle>
+    );
+
+    expect(screen.getByText('settings')).toBeInTheDocument();
+  });
+});
+
+describe('NumberInput', () => {
+  it('parses integer values when step is omitted', () => {
+    const onChange = vi.fn();
+
+    render(<NumberInput label="Period" value={20} onChange={onChange} defaultValue={0} />);
+
+    const input = screen.getByRole('spinbutton', { name: /period/i });
+    fireEvent.change(input, { target: { value: '30' } });
+
+    expect(onChange).toHaveBeenCalledWith(30);
+  });
+
+  it('parses float values when step is provided', () => {
+    const onChange = vi.fn();
+
+    render(<NumberInput label="Multiplier" value={3.0} onChange={onChange} step="0.1" defaultValue={1.0} />);
+
+    const input = screen.getByRole('spinbutton', { name: /multiplier/i });
+    fireEvent.change(input, { target: { value: '2.5' } });
+
+    expect(onChange).toHaveBeenCalledWith(2.5);
+  });
+
+  it('falls back to defaultValue when parsing fails', () => {
+    const onChange = vi.fn();
+
+    render(<NumberInput label="Lookback" value={60} onChange={onChange} defaultValue={42} />);
+
+    const input = screen.getByRole('spinbutton', { name: /lookback/i });
+    fireEvent.change(input, { target: { value: 'not-number' } });
+
+    expect(onChange).toHaveBeenCalledWith(42);
+  });
+});

--- a/apps/ts/packages/web/src/components/Chart/IndicatorToggle.tsx
+++ b/apps/ts/packages/web/src/components/Chart/IndicatorToggle.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useId } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -9,17 +9,25 @@ interface IndicatorToggleProps {
   onToggle: (enabled: boolean) => void;
   children?: ReactNode;
   disabled?: boolean;
+  meta?: string;
 }
 
 /**
  * Reusable indicator toggle component with collapsible settings
  */
-export function IndicatorToggle({ label, enabled, onToggle, children, disabled }: IndicatorToggleProps) {
+export function IndicatorToggle({ label, enabled, onToggle, children, disabled, meta }: IndicatorToggleProps) {
+  const switchId = useId();
+
   return (
     <div className="space-y-1.5 p-2 rounded glass-panel">
-      <div className="flex items-center justify-between">
-        <Label className="text-xs font-medium cursor-pointer">{label}</Label>
-        <Switch checked={enabled} onCheckedChange={onToggle} disabled={disabled} />
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <Label htmlFor={switchId} className="text-xs font-medium cursor-pointer">
+            {label}
+          </Label>
+          {meta && <p className="text-[10px] text-muted-foreground leading-tight">{meta}</p>}
+        </div>
+        <Switch id={switchId} checked={enabled} onCheckedChange={onToggle} disabled={disabled} />
       </div>
       {enabled && children}
     </div>
@@ -39,6 +47,8 @@ interface NumberInputProps {
  * Compact number input for indicator settings
  */
 export function NumberInput({ label, value, onChange, step, defaultValue = 0, disabled }: NumberInputProps) {
+  const inputId = useId();
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const parsed = step ? Number.parseFloat(e.target.value) : Number.parseInt(e.target.value, 10);
     onChange(Number.isNaN(parsed) ? defaultValue : parsed);
@@ -46,8 +56,10 @@ export function NumberInput({ label, value, onChange, step, defaultValue = 0, di
 
   return (
     <div>
-      <Label className="text-xs text-muted-foreground">{label}</Label>
-      <Input type="number" step={step} value={value} onChange={handleChange} className="h-7 text-xs" disabled={disabled} />
+      <Label htmlFor={inputId} className="text-xs text-muted-foreground">
+        {label}
+      </Label>
+      <Input id={inputId} type="number" step={step} value={value} onChange={handleChange} className="h-7 text-xs" disabled={disabled} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove duplicated sub-chart toggles from Panel Visibility and keep those controls next to their parameter settings
- show signal metadata for sub-chart controls where applicable
- improve accessibility by linking IndicatorToggle/NumberInput labels with their switches/inputs
- add focused tests for IndicatorToggle and NumberInput behavior

## Testing
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test src/components/Chart/ChartControls.test.tsx src/components/Chart/IndicatorToggle.test.tsx
- bun run --filter @trading25/web test src/components/Chart/ChartControls.test.tsx src/components/Chart/IndicatorToggle.test.tsx --coverage --coverage.include="src/components/Chart/ChartControls.tsx" --coverage.include="src/components/Chart/IndicatorToggle.tsx"