### PR TITLE
fix: unify backtest summary SoT with artifact outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **dataset.db**: 読み書き（SQLAlchemy Core）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新し、`/indices` 取得失敗時は日付指定フォールバックで継続する（`indices-only` は指数再同期専用モード）。フォールバック時は不足 `index_master` をプレースホルダ補完して、FK 制約付きの既存DBでも継続可能にする
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
+- Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う
 - **ts/web** は `/api` パスを FastAPI (:3002) にプロキシ

--- a/apps/bt/src/server/schemas/backtest.py
+++ b/apps/bt/src/server/schemas/backtest.py
@@ -60,6 +60,7 @@ class BacktestResultSummary(BaseModel):
 
     total_return: float = Field(description="トータルリターン (%)")
     sharpe_ratio: float = Field(description="シャープレシオ")
+    sortino_ratio: float | None = Field(default=None, description="ソルティノレシオ")
     calmar_ratio: float = Field(description="カルマーレシオ")
     max_drawdown: float = Field(description="最大ドローダウン (%)")
     win_rate: float = Field(description="勝率 (%)")

--- a/apps/bt/src/server/services/backtest_result_summary.py
+++ b/apps/bt/src/server/services/backtest_result_summary.py
@@ -1,0 +1,138 @@
+"""
+Backtest Result Summary Resolver
+
+バックテスト結果サマリーを HTML 成果物セット（HTML + *.metrics.json）から解決する。
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from src.data.metrics_extractor import extract_metrics_from_html
+from src.server.schemas.backtest import BacktestResultSummary
+
+
+def _to_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _to_required_float(value: Any, *, default: float = 0.0) -> float:
+    parsed = _to_optional_float(value)
+    return default if parsed is None else parsed
+
+
+def _to_required_int(value: Any, *, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _fallback_to_mapping(
+    fallback: Mapping[str, Any] | BacktestResultSummary | None,
+) -> Mapping[str, Any]:
+    if fallback is None:
+        return {}
+    if isinstance(fallback, BacktestResultSummary):
+        return fallback.model_dump()
+    if isinstance(fallback, Mapping):
+        return fallback
+    return {}
+
+
+def _pick_value(
+    artifact_values: Mapping[str, Any],
+    fallback_values: Mapping[str, Any],
+    key: str,
+) -> Any:
+    artifact = artifact_values.get(key)
+    if artifact is not None:
+        return artifact
+    return fallback_values.get(key)
+
+
+def resolve_backtest_result_summary(
+    html_path: str | Path | None,
+    fallback: Mapping[str, Any] | BacktestResultSummary | None = None,
+) -> BacktestResultSummary | None:
+    """
+    BacktestResultSummary を成果物セットから解決する。
+
+    優先順位:
+    1. html_path の *.metrics.json / HTML から抽出された値
+    2. fallback（raw_result または既存 summary）
+    """
+    fallback_values = _fallback_to_mapping(fallback)
+    resolved_html_path: str | None = str(html_path) if html_path else None
+
+    artifact_values: dict[str, Any] = {}
+    if html_path:
+        path = Path(html_path)
+        if path.exists():
+            try:
+                metrics = extract_metrics_from_html(path)
+                artifact_values = {
+                    "total_return": metrics.total_return,
+                    "max_drawdown": metrics.max_drawdown,
+                    "sharpe_ratio": metrics.sharpe_ratio,
+                    "sortino_ratio": metrics.sortino_ratio,
+                    "calmar_ratio": metrics.calmar_ratio,
+                    "win_rate": metrics.win_rate,
+                    "trade_count": metrics.total_trades,
+                }
+            except Exception as e:
+                logger.warning(f"成果物メトリクス抽出失敗: {e}")
+
+    if not artifact_values and not fallback_values:
+        return None
+
+    fallback_trade_count = fallback_values.get("trade_count", fallback_values.get("total_trades"))
+    fallback_html_path = fallback_values.get("html_path")
+    if resolved_html_path is None and isinstance(fallback_html_path, str):
+        resolved_html_path = fallback_html_path
+    trade_count_value = (
+        artifact_values.get("trade_count")
+        if artifact_values.get("trade_count") is not None
+        else fallback_trade_count
+    )
+
+    return BacktestResultSummary(
+        total_return=_to_required_float(
+            _pick_value(artifact_values, fallback_values, "total_return"),
+            default=0.0,
+        ),
+        sharpe_ratio=_to_required_float(
+            _pick_value(artifact_values, fallback_values, "sharpe_ratio"),
+            default=0.0,
+        ),
+        sortino_ratio=_to_optional_float(
+            _pick_value(artifact_values, fallback_values, "sortino_ratio")
+        ),
+        calmar_ratio=_to_required_float(
+            _pick_value(artifact_values, fallback_values, "calmar_ratio"),
+            default=0.0,
+        ),
+        max_drawdown=_to_required_float(
+            _pick_value(artifact_values, fallback_values, "max_drawdown"),
+            default=0.0,
+        ),
+        win_rate=_to_required_float(
+            _pick_value(artifact_values, fallback_values, "win_rate"),
+            default=0.0,
+        ),
+        trade_count=_to_required_int(trade_count_value, default=0),
+        html_path=resolved_html_path,
+    )

--- a/apps/bt/tests/unit/server/services/test_backtest_result_summary.py
+++ b/apps/bt/tests/unit/server/services/test_backtest_result_summary.py
@@ -1,0 +1,135 @@
+"""server/services/backtest_result_summary.py のテスト"""
+
+import json
+from pathlib import Path
+
+from src.server.schemas.backtest import BacktestResultSummary
+from src.server.services.backtest_result_summary import resolve_backtest_result_summary
+
+
+def test_resolve_backtest_result_summary_prefers_artifact_set(tmp_path: Path):
+    html_path = tmp_path / "result.html"
+    html_path.write_text("<html></html>", encoding="utf-8")
+    metrics_path = html_path.with_suffix(".metrics.json")
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "total_return": 12.5,
+                "sharpe_ratio": 1.7,
+                "sortino_ratio": 2.1,
+                "calmar_ratio": 2.9,
+                "max_drawdown": -6.2,
+                "win_rate": 58.0,
+                "total_trades": 42,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fallback = {
+        "total_return": 1.0,
+        "sharpe_ratio": 1.0,
+        "sortino_ratio": 1.0,
+        "calmar_ratio": 1.0,
+        "max_drawdown": -1.0,
+        "win_rate": 50.0,
+        "trade_count": 1,
+    }
+
+    summary = resolve_backtest_result_summary(html_path, fallback)
+
+    assert summary is not None
+    assert summary.total_return == 12.5
+    assert summary.sharpe_ratio == 1.7
+    assert summary.sortino_ratio == 2.1
+    assert summary.calmar_ratio == 2.9
+    assert summary.max_drawdown == -6.2
+    assert summary.win_rate == 58.0
+    assert summary.trade_count == 42
+
+
+def test_resolve_backtest_result_summary_uses_fallback_for_missing_artifact_fields(tmp_path: Path):
+    html_path = tmp_path / "result.html"
+    html_path.write_text("<html></html>", encoding="utf-8")
+    metrics_path = html_path.with_suffix(".metrics.json")
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "total_return": 12.5,
+                # intentionally missing sharpe/calmar/win_rate/trades
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fallback = {
+        "total_return": 1.0,
+        "sharpe_ratio": 1.2,
+        "sortino_ratio": 1.4,
+        "calmar_ratio": 2.0,
+        "max_drawdown": -4.0,
+        "win_rate": 55.0,
+        "trade_count": 11,
+    }
+
+    summary = resolve_backtest_result_summary(html_path, fallback)
+
+    assert summary is not None
+    assert summary.total_return == 12.5
+    assert summary.sharpe_ratio == 1.2
+    assert summary.sortino_ratio == 1.4
+    assert summary.calmar_ratio == 2.0
+    assert summary.max_drawdown == -4.0
+    assert summary.win_rate == 55.0
+    assert summary.trade_count == 11
+
+
+def test_resolve_backtest_result_summary_falls_back_without_artifact():
+    summary = resolve_backtest_result_summary(
+        "/tmp/not-found.html",
+        {
+            "total_return": 7.0,
+            "sharpe_ratio": 1.2,
+            "sortino_ratio": 1.4,
+            "calmar_ratio": 2.0,
+            "max_drawdown": -4.0,
+            "win_rate": 55.0,
+            "trade_count": 11,
+            "html_path": "fallback.html",
+        },
+    )
+
+    assert summary is not None
+    assert summary.total_return == 7.0
+    assert summary.sharpe_ratio == 1.2
+    assert summary.sortino_ratio == 1.4
+    assert summary.calmar_ratio == 2.0
+    assert summary.max_drawdown == -4.0
+    assert summary.win_rate == 55.0
+    assert summary.trade_count == 11
+    assert summary.html_path == "/tmp/not-found.html"
+
+
+def test_resolve_backtest_result_summary_accepts_summary_fallback():
+    fallback_summary = BacktestResultSummary(
+        total_return=3.0,
+        sharpe_ratio=0.8,
+        sortino_ratio=1.0,
+        calmar_ratio=1.2,
+        max_drawdown=-2.0,
+        win_rate=52.0,
+        trade_count=9,
+        html_path=None,
+    )
+
+    summary = resolve_backtest_result_summary(None, fallback_summary)
+
+    assert summary is not None
+    assert summary.total_return == 3.0
+    assert summary.sortino_ratio == 1.0
+    assert summary.trade_count == 9
+
+
+def test_resolve_backtest_result_summary_returns_none_when_no_sources():
+    summary = resolve_backtest_result_summary(None, None)
+    assert summary is None

--- a/apps/ts/packages/clients-ts/src/backtest/types.ts
+++ b/apps/ts/packages/clients-ts/src/backtest/types.ts
@@ -14,6 +14,7 @@ export interface BacktestRequest {
 export interface BacktestResultSummary {
   total_return: number;
   sharpe_ratio: number;
+  sortino_ratio?: number | null;
   calmar_ratio: number;
   max_drawdown: number;
   win_rate: number;

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -11311,6 +11311,18 @@
             "title": "Sharpe Ratio",
             "description": "シャープレシオ"
           },
+          "sortino_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sortino Ratio",
+            "description": "ソルティノレシオ"
+          },
           "calmar_ratio": {
             "type": "number",
             "title": "Calmar Ratio",

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -2632,6 +2632,11 @@ export interface components {
              */
             sharpe_ratio: number;
             /**
+             * Sortino Ratio
+             * @description ソルティノレシオ
+             */
+            sortino_ratio?: number | null;
+            /**
              * Calmar Ratio
              * @description カルマーレシオ
              */

--- a/apps/ts/packages/web/src/components/Backtest/JobProgressCard.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/JobProgressCard.tsx
@@ -12,10 +12,6 @@ interface JobProgressCardProps {
   isCancelling?: boolean;
 }
 
-type BacktestResultWithSortino = NonNullable<BacktestJobResponse['result']> & {
-  sortino_ratio?: number | null;
-};
-
 function formatRatio(value: number | null | undefined) {
   return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(2) : '-';
 }
@@ -60,7 +56,7 @@ function RunningProgress({ isActive, message }: { isActive: boolean; message: st
   );
 }
 
-function CompletedSummary({ result }: { result: BacktestResultWithSortino | null }) {
+function CompletedSummary({ result }: { result: BacktestJobResponse['result'] }) {
   if (!result) return null;
 
   return (
@@ -135,8 +131,7 @@ export function JobProgressCard({ job, isLoading, onCancel, isCancelling }: JobP
 
   if (!job) return null;
 
-  const completedResult =
-    job.status === 'completed' && job.result ? (job.result as BacktestResultWithSortino) : null;
+  const completedResult = job.status === 'completed' ? job.result : null;
 
   const formatElapsed = (s: number) => {
     const m = Math.floor(s / 60);


### PR DESCRIPTION
Summary
- add artifact-based summary resolver for backtest results using HTML and metrics json outputs
- make backtest jobs and backtest result endpoints resolve summary from artifacts with fallback
- include sortino_ratio in BacktestResultSummary and propagate to TS/web runner display
- update AGENTS SoT note and add regression and unit tests

Validation
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_backtest_result_summary.py apps/bt/tests/unit/server/services/test_backtest_service.py apps/bt/tests/unit/server/routes/test_backtest.py
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_backtest_result_summary.py apps/bt/tests/unit/server/services/test_backtest_service.py apps/bt/tests/unit/server/routes/test_backtest.py --cov=src.server.services.backtest_result_summary --cov=src.server.services.backtest_service --cov=src.server.routes.backtest --cov-branch --cov-report=term
- uv run --project apps/bt ruff check apps/bt/src/server/services/backtest_result_summary.py apps/bt/src/server/services/backtest_service.py apps/bt/src/server/routes/backtest.py apps/bt/tests/unit/server/services/test_backtest_result_summary.py apps/bt/tests/unit/server/services/test_backtest_service.py apps/bt/tests/unit/server/routes/test_backtest.py