### PR TITLE
perf(bt-lab): force direct mode and use n_jobs=-1

### DIFF
--- a/apps/bt/src/server/services/lab_service.py
+++ b/apps/bt/src/server/services/lab_service.py
@@ -210,7 +210,7 @@ class LabService:
                 "timeframe": timeframe,
                 "dataset": dataset,
             },
-            n_jobs=1,
+            n_jobs=-1,
         )
         results = evaluator.evaluate_batch(candidates, top_k=top)
 
@@ -318,7 +318,7 @@ class LabService:
         config = EvolutionConfig(
             population_size=population,
             generations=generations,
-            n_jobs=1,
+            n_jobs=-1,
             entry_filter_only=resolved_target_scope == "entry_filter_only",
             target_scope=resolved_target_scope,
             allowed_categories=resolved_categories,
@@ -525,7 +525,7 @@ class LabService:
         config = OptunaConfig(
             n_trials=trials,
             sampler=sampler,
-            n_jobs=1,
+            n_jobs=-1,
             entry_filter_only=resolved_target_scope == "entry_filter_only",
             target_scope=resolved_target_scope,
             allowed_categories=allowed_categories,

--- a/apps/bt/tests/server/routes/test_lab.py
+++ b/apps/bt/tests/server/routes/test_lab.py
@@ -1410,6 +1410,7 @@ class TestLabServiceSyncMethods:
         assert result["total_generated"] == 10
         assert result["saved_strategy_path"] == "/tmp/saved.yaml"
         assert len(result["results"]) == 1
+        assert MockEval.call_args.kwargs["n_jobs"] == -1
         service._executor.shutdown(wait=False)
 
     def test_execute_generate_sync_no_save(self) -> None:
@@ -1528,6 +1529,7 @@ class TestLabServiceSyncMethods:
         assert len(result["history"]) == 2
         assert result["saved_strategy_path"] == "/tmp/evo.yaml"
         config = MockEvolver.call_args.kwargs["config"]
+        assert config.n_jobs == -1
         assert config.entry_filter_only is True
         assert config.target_scope == "entry_filter_only"
         assert config.allowed_categories == ["fundamental"]
@@ -1611,6 +1613,7 @@ class TestLabServiceSyncMethods:
         assert result["total_trials"] == 2
         assert result["saved_strategy_path"] == "/tmp/opt.yaml"
         config = MockOpt.call_args.kwargs["config"]
+        assert config.n_jobs == -1
         assert config.entry_filter_only is True
         assert config.target_scope == "entry_filter_only"
         assert config.allowed_categories == ["fundamental"]

--- a/apps/bt/tests/unit/agent/evaluator/test_candidate_processor.py
+++ b/apps/bt/tests/unit/agent/evaluator/test_candidate_processor.py
@@ -1,7 +1,12 @@
-"""candidate_processor.py のテスト (_safe_float)"""
+"""candidate_processor.py のテスト"""
 
+from contextlib import contextmanager
 
-from src.agent.evaluator.candidate_processor import _safe_float
+import pandas as pd
+
+from src.agent.evaluator import candidate_processor
+from src.agent.evaluator.candidate_processor import _safe_float, evaluate_single_candidate
+from src.agent.models import StrategyCandidate
 
 
 class TestSafeFloat:
@@ -28,3 +33,157 @@ class TestSafeFloat:
 
     def test_large_value(self):
         assert _safe_float(1e15) == 1e15
+
+
+def _candidate() -> StrategyCandidate:
+    return StrategyCandidate(
+        strategy_id="c1",
+        entry_filter_params={},
+        exit_trigger_params={},
+        shared_config={},
+    )
+
+
+def test_evaluate_single_candidate_success_with_prefetched_data(monkeypatch) -> None:
+    mode_calls: list[str] = []
+    created: dict[str, object] = {}
+
+    @contextmanager
+    def _fake_mode_context(mode: str):
+        mode_calls.append(mode)
+        yield
+
+    class _FakeSharedConfig:
+        def __init__(self, **kwargs):
+            self.params = kwargs
+            self.kelly_fraction = 0.5
+            self.min_allocation = 0.01
+            self.max_allocation = 0.5
+
+    class _FakePortfolio:
+        def sharpe_ratio(self) -> float:
+            return 1.2
+
+        def calmar_ratio(self) -> float:
+            return 0.8
+
+        def total_return(self) -> float:
+            return 0.2
+
+        def max_drawdown(self) -> float:
+            return -0.1
+
+        class trades:
+            records_readable = pd.DataFrame({"Return": [0.1, -0.2, 0.3]})
+
+    class _FakeStrategy:
+        def __init__(self, shared_config, entry_filter_params, exit_trigger_params):
+            self.shared_config = shared_config
+            self.entry_filter_params = entry_filter_params
+            self.exit_trigger_params = exit_trigger_params
+            self.multi_data_dict = None
+            self.benchmark_data = None
+            created["strategy"] = self
+
+        def run_optimized_backtest_kelly(self, **_kwargs):
+            return None, _FakePortfolio(), None, None, None
+
+    monkeypatch.setattr(candidate_processor, "data_access_mode_context", _fake_mode_context)
+    monkeypatch.setattr(candidate_processor, "SharedConfig", _FakeSharedConfig)
+    monkeypatch.setattr(candidate_processor, "YamlConfigurableStrategy", _FakeStrategy)
+    monkeypatch.setattr(
+        candidate_processor,
+        "convert_dict_to_dataframes",
+        lambda _data: {"7203": {"daily": pd.DataFrame({"Close": [1.0]})}},
+    )
+
+    result = evaluate_single_candidate(
+        candidate=_candidate(),
+        shared_config_dict={"dataset": "demo", "stock_codes": ["all"]},
+        scoring_weights={"sharpe_ratio": 0.5, "calmar_ratio": 0.3, "total_return": 0.2},
+        pre_fetched_stock_codes=["7203", "9984"],
+        pre_fetched_ohlcv_data={"dummy": {}},
+        pre_fetched_benchmark_data={
+            "data": [[100.0], [101.0]],
+            "index": ["2025-01-01", "2025-01-02"],
+            "columns": ["Close"],
+        },
+    )
+
+    assert result.success is True
+    assert result.trade_count == 3
+    assert result.win_rate == 2 / 3
+    assert mode_calls == ["direct"]
+    strategy = created["strategy"]
+    assert getattr(strategy, "multi_data_dict") is not None
+    assert getattr(strategy, "benchmark_data") is not None
+
+
+def test_evaluate_single_candidate_trade_parse_error(monkeypatch) -> None:
+    @contextmanager
+    def _fake_mode_context(_mode: str):
+        yield
+
+    class _FakeSharedConfig:
+        def __init__(self, **_kwargs):
+            self.kelly_fraction = 0.5
+            self.min_allocation = 0.01
+            self.max_allocation = 0.5
+
+    class _BrokenTrades:
+        @property
+        def records_readable(self):
+            raise RuntimeError("broken")
+
+    class _FakePortfolio:
+        def sharpe_ratio(self) -> float:
+            return 1.0
+
+        def calmar_ratio(self) -> float:
+            return 0.5
+
+        def total_return(self) -> float:
+            return 0.1
+
+        def max_drawdown(self) -> float:
+            return -0.2
+
+        trades = _BrokenTrades()
+
+    class _FakeStrategy:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run_optimized_backtest_kelly(self, **_kwargs):
+            return None, _FakePortfolio(), None, None, None
+
+    monkeypatch.setattr(candidate_processor, "SharedConfig", _FakeSharedConfig)
+    monkeypatch.setattr(candidate_processor, "YamlConfigurableStrategy", _FakeStrategy)
+    monkeypatch.setattr(candidate_processor, "data_access_mode_context", _fake_mode_context)
+
+    result = evaluate_single_candidate(
+        candidate=_candidate(),
+        shared_config_dict={"dataset": "demo", "stock_codes": ["7203"]},
+        scoring_weights={"sharpe_ratio": 1.0},
+    )
+
+    assert result.success is True
+    assert result.win_rate == 0.0
+    assert result.trade_count == 0
+
+
+def test_evaluate_single_candidate_failure_returns_failed_result(monkeypatch) -> None:
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(candidate_processor, "SignalParams", _raise)
+
+    result = evaluate_single_candidate(
+        candidate=_candidate(),
+        shared_config_dict={},
+        scoring_weights={},
+    )
+
+    assert result.success is False
+    assert result.score == -999.0
+    assert "boom" in (result.error_message or "")

--- a/apps/bt/tests/unit/agent/evaluator/test_evaluator.py
+++ b/apps/bt/tests/unit/agent/evaluator/test_evaluator.py
@@ -1,0 +1,195 @@
+"""agent/evaluator/evaluator.py のテスト"""
+
+from contextlib import contextmanager
+
+from src.agent.evaluator import evaluator as evaluator_module
+from src.agent.evaluator.evaluator import StrategyEvaluator
+from src.agent.models import EvaluationResult, StrategyCandidate
+
+
+def _candidate() -> StrategyCandidate:
+    return StrategyCandidate(
+        strategy_id="test",
+        entry_filter_params={},
+        exit_trigger_params={},
+    )
+
+
+def test_evaluate_single_forces_direct_mode(monkeypatch) -> None:
+    captured_modes: list[str] = []
+    expected = EvaluationResult(candidate=_candidate(), score=1.0)
+
+    @contextmanager
+    def _fake_mode_context(mode: str):
+        captured_modes.append(mode)
+        yield
+
+    monkeypatch.setattr(
+        "src.agent.evaluator.evaluator.data_access_mode_context",
+        _fake_mode_context,
+    )
+    monkeypatch.setattr(
+        "src.agent.evaluator.evaluator.evaluate_single_candidate",
+        lambda *_args, **_kwargs: expected,
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
+    result = evaluator.evaluate_single(_candidate())
+
+    assert result == expected
+    assert captured_modes == ["direct"]
+
+
+def test_evaluate_batch_forces_direct_mode(monkeypatch) -> None:
+    captured_modes: list[str] = []
+
+    @contextmanager
+    def _fake_mode_context(mode: str):
+        captured_modes.append(mode)
+        yield
+
+    monkeypatch.setattr(
+        "src.agent.evaluator.evaluator.data_access_mode_context",
+        _fake_mode_context,
+    )
+    monkeypatch.setattr(
+        StrategyEvaluator,
+        "_evaluate_batch_internal",
+        lambda self, candidates, top_k=None: [],
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
+    result = evaluator.evaluate_batch([_candidate()], top_k=1, enable_cache=False)
+
+    assert result == []
+    assert captured_modes == ["direct"]
+
+
+def test_evaluate_batch_empty_returns_immediately(monkeypatch) -> None:
+    mode_calls: list[str] = []
+
+    @contextmanager
+    def _fake_mode_context(mode: str):
+        mode_calls.append(mode)
+        yield
+
+    monkeypatch.setattr(
+        "src.agent.evaluator.evaluator.data_access_mode_context",
+        _fake_mode_context,
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
+    assert evaluator.evaluate_batch([], enable_cache=True) == []
+    assert mode_calls == []
+
+
+def test_evaluate_batch_enables_and_disables_cache(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _Cache:
+        def get_stats(self):
+            return {"hits": 3, "misses": 1}
+
+    monkeypatch.setattr(
+        evaluator_module.DataCache,
+        "enable",
+        staticmethod(lambda: calls.append("enable") or _Cache()),
+    )
+    monkeypatch.setattr(
+        evaluator_module.DataCache,
+        "disable",
+        staticmethod(lambda: calls.append("disable")),
+    )
+    monkeypatch.setattr(
+        evaluator_module.DataCache,
+        "get_instance",
+        staticmethod(lambda: _Cache()),
+    )
+    monkeypatch.setattr(
+        StrategyEvaluator,
+        "_evaluate_batch_internal",
+        lambda self, candidates, top_k=None: [],
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
+    result = evaluator.evaluate_batch([_candidate()], enable_cache=True)
+
+    assert result == []
+    assert calls == ["enable", "disable"]
+
+
+def test_evaluate_batch_internal_uses_prepare_and_execute(monkeypatch) -> None:
+    prepared = object()
+    expected = [EvaluationResult(candidate=_candidate(), score=0.5)]
+
+    def _fake_execute_batch_evaluation(
+        candidates,
+        max_workers,
+        prepared_data,
+        shared_config_dict,
+        scoring_weights,
+        timeout_seconds,
+    ):
+        _ = (
+            candidates,
+            max_workers,
+            prepared_data,
+            shared_config_dict,
+            scoring_weights,
+            timeout_seconds,
+        )
+        return expected
+
+    monkeypatch.setattr(evaluator_module, "get_max_workers", lambda n_jobs: 4)
+    monkeypatch.setattr(
+        evaluator_module,
+        "prepare_batch_data",
+        lambda shared_config_dict: prepared,
+    )
+    monkeypatch.setattr(
+        evaluator_module,
+        "execute_batch_evaluation",
+        _fake_execute_batch_evaluation,
+    )
+    monkeypatch.setattr(
+        StrategyEvaluator,
+        "_finalize_batch_results",
+        lambda self, results, top_k: results,
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]}, n_jobs=4)
+    result = evaluator._evaluate_batch_internal([_candidate()], top_k=3)
+
+    assert result == expected
+
+
+def test_finalize_batch_results_sorts_and_applies_topk(monkeypatch) -> None:
+    c1 = _candidate()
+    c2 = StrategyCandidate(
+        strategy_id="c2", entry_filter_params={}, exit_trigger_params={}
+    )
+    c3 = StrategyCandidate(
+        strategy_id="c3", entry_filter_params={}, exit_trigger_params={}
+    )
+    success_low = EvaluationResult(candidate=c1, score=0.1, success=True)
+    success_high = EvaluationResult(candidate=c2, score=0.9, success=True)
+    failed = EvaluationResult(
+        candidate=c3,
+        score=-999.0,
+        success=False,
+        error_message="x",
+    )
+
+    monkeypatch.setattr(
+        evaluator_module,
+        "normalize_scores",
+        lambda successful, scoring_weights: successful,
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
+    result = evaluator._finalize_batch_results(
+        [success_low, failed, success_high],
+        top_k=2,
+    )
+
+    assert [r.candidate.strategy_id for r in result] == ["c2", "test"]

--- a/apps/bt/tests/unit/agent/test_optuna_optimizer.py
+++ b/apps/bt/tests/unit/agent/test_optuna_optimizer.py
@@ -127,7 +127,7 @@ class TestOptimizeFlow:
 
         def fake_optimize(_objective, n_trials, n_jobs, show_progress_bar, callbacks):
             assert n_trials == 10
-            assert n_jobs == 1
+            assert n_jobs == -1
             assert show_progress_bar is True
             for cb in callbacks:
                 cb(study, trial)


### PR DESCRIPTION
## Summary\n- force lab evaluation/optimization execution paths to run under direct data access mode\n- set lab service defaults to n_jobs=-1 for generate/evolve/optimize\n- honor OptunaConfig.n_jobs in study.optimize\n- add and update unit tests for evaluator/candidate processor/optuna/lab service\n\n## Testing\n- unable to re-run pytest in this finish step due offline dependency resolution limits in sandbox\n- changes were validated earlier in-session with targeted unit tests and deep coverage run