### PR TITLE
feat: add lab job history browsing

### DIFF
--- a/.codex/skills/ts-api-endpoints/references/openapi-paths.md
+++ b/.codex/skills/ts-api-endpoints/references/openapi-paths.md
@@ -2,7 +2,7 @@
 
 Generated from `apps/ts/packages/shared/openapi/bt-openapi.json`. Do not edit manually.
 
-Total paths: **111**
+Total paths: **112**
 
 ## /api/analytics
 
@@ -131,6 +131,7 @@ Total paths: **111**
 | `/api/lab/evolve` | `POST` |
 | `/api/lab/generate` | `POST` |
 | `/api/lab/improve` | `POST` |
+| `/api/lab/jobs` | `GET` |
 | `/api/lab/jobs/{job_id}` | `GET` |
 | `/api/lab/jobs/{job_id}/cancel` | `POST` |
 | `/api/lab/jobs/{job_id}/stream` | `GET` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ uv run pyright src/              # 型チェック
 
 - Lab `evolve/optimize` の API/Web は `target_scope`（`entry_filter_only` / `exit_trigger_only` / `both`）を受け付ける（`entry_filter_only` は互換フラグとして維持）
 - Lab `evolve/optimize` の frontend `allowed categories` は `all` / `fundamental only` を提供
+- Lab frontend は `Run` / `History` タブを持ち、`/api/lab/jobs` で実行履歴を一覧し、選択したジョブの進捗・結果を再表示できる
 - Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest

--- a/apps/bt/src/server/services/job_manager.py
+++ b/apps/bt/src/server/services/job_manager.py
@@ -87,19 +87,24 @@ class JobManager:
         """
         return self._jobs.get(job_id)
 
-    def list_jobs(self, limit: int = 50) -> list[JobInfo]:
+    def list_jobs(
+        self, limit: int = 50, job_types: set[str] | None = None
+    ) -> list[JobInfo]:
         """
         ジョブ一覧を取得（最新順）
 
         Args:
             limit: 取得件数上限
+            job_types: ジョブタイプのフィルタ（None の場合は全件）
 
         Returns:
             ジョブ情報リスト
         """
-        sorted_jobs = sorted(
-            self._jobs.values(), key=lambda j: j.created_at, reverse=True
-        )
+        jobs = list(self._jobs.values())
+        if job_types is not None:
+            jobs = [job for job in jobs if job.job_type in job_types]
+
+        sorted_jobs = sorted(jobs, key=lambda j: j.created_at, reverse=True)
         return sorted_jobs[:limit]
 
     async def update_job_status(

--- a/apps/bt/tests/server/test_job_manager.py
+++ b/apps/bt/tests/server/test_job_manager.py
@@ -58,6 +58,17 @@ class TestJobManager:
         jobs = mgr.list_jobs(limit=3)
         assert len(jobs) == 3
 
+    def test_list_jobs_filter_by_job_types(self):
+        mgr = JobManager()
+        lab_id = mgr.create_job("lab_strat", job_type="lab_generate")
+        mgr.create_job("bt_strat", job_type="backtest")
+
+        jobs = mgr.list_jobs(job_types={"lab_generate"})
+
+        assert len(jobs) == 1
+        assert jobs[0].job_id == lab_id
+        assert jobs[0].job_type == "lab_generate"
+
     @pytest.mark.asyncio
     async def test_update_job_status_running(self):
         mgr = JobManager()

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -3482,6 +3482,86 @@
         }
       }
     },
+    "/api/lab/jobs": {
+      "get": {
+        "tags": [
+          "Lab"
+        ],
+        "summary": "List Lab Jobs",
+        "description": "Labジョブ一覧を取得（最新順）",
+        "operationId": "list_lab_jobs_api_lab_jobs_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LabJobResponse"
+                  },
+                  "title": "Response List Lab Jobs Api Lab Jobs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/lab/jobs/{job_id}/stream": {
       "get": {
         "tags": [
@@ -7989,6 +8069,67 @@
               "title": "Codes"
             },
             "description": "Comma-separated stock codes (max 100)"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "period_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "all",
+                "FY",
+                "1Q",
+                "2Q",
+                "3Q"
+              ],
+              "type": "string",
+              "default": "all",
+              "title": "Period Type"
+            }
+          },
+          {
+            "name": "actual_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Actual Only"
+            }
           }
         ],
         "responses": {
@@ -8076,6 +8217,67 @@
             "schema": {
               "type": "string",
               "title": "Code"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "period_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "all",
+                "FY",
+                "1Q",
+                "2Q",
+                "3Q"
+              ],
+              "type": "string",
+              "default": "all",
+              "title": "Period Type"
+            }
+          },
+          {
+            "name": "actual_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Actual Only"
             }
           }
         ],
@@ -12072,7 +12274,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__dataset__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -14021,7 +14223,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
               },
               {
                 "type": "null"
@@ -19534,7 +19736,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
               },
               {
                 "type": "null"
@@ -19562,7 +19764,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
               },
               {
                 "type": "null"
@@ -20623,7 +20825,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__db__DateRange"
               },
               {
                 "type": "null"
@@ -20999,7 +21201,7 @@
         "type": "object",
         "title": "WatchlistUpdateRequest"
       },
-      "src__server__schemas__dataset__DateRange": {
+      "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
             "type": "string",

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -968,6 +968,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/lab/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Lab Jobs
+         * @description Labジョブ一覧を取得（最新順）
+         */
+        get: operations["list_lab_jobs_api_lab_jobs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/lab/jobs/{job_id}/stream": {
         parameters: {
             query?: never;
@@ -2943,7 +2963,7 @@ export interface components {
              * @description Stocks with OHLCV data
              */
             stocksWithQuotes: number;
-            dateRange?: components["schemas"]["src__server__schemas__dataset__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             validation: components["schemas"]["DatasetValidation"];
         };
         /** DatasetValidation */
@@ -3947,7 +3967,7 @@ export interface components {
              * @default 0
              */
             dateCount: number;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
             /** Bycategory */
             byCategory?: {
                 [key: string]: number;
@@ -6390,7 +6410,7 @@ export interface components {
              * @default 0
              */
             dateCount: number;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
             /**
              * Averagestocksperday
              * @default 0
@@ -6401,7 +6421,7 @@ export interface components {
         StockDataValidation: {
             /** Count */
             count: number;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
             /** Missingdates */
             missingDates?: string[];
             /**
@@ -6964,7 +6984,7 @@ export interface components {
         TopixStats: {
             /** Count */
             count: number;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__db__DateRange"] | null;
         };
         /** ValidationError */
         ValidationError: {
@@ -7089,7 +7109,7 @@ export interface components {
             description?: string | null;
         };
         /** DateRange */
-        src__server__schemas__dataset__DateRange: {
+        src__server__schemas__db__DateRange: {
             /** Min */
             min: string;
             /** Max */
@@ -9904,6 +9924,64 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LabJobResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    list_lab_jobs_api_lab_jobs_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LabJobResponse"][];
                 };
             };
             /** @description Bad Request */
@@ -12778,6 +12856,10 @@ export interface operations {
             query: {
                 /** @description Comma-separated stock codes (max 100) */
                 codes: string;
+                start_date?: string | null;
+                end_date?: string | null;
+                period_type?: "all" | "FY" | "1Q" | "2Q" | "3Q";
+                actual_only?: boolean;
             };
             header?: never;
             path: {
@@ -12838,7 +12920,12 @@ export interface operations {
     };
     get_dataset_statements_api_dataset__name__statements__code__get: {
         parameters: {
-            query?: never;
+            query?: {
+                start_date?: string | null;
+                end_date?: string | null;
+                period_type?: "all" | "FY" | "1Q" | "2Q" | "3Q";
+                actual_only?: boolean;
+            };
             header?: never;
             path: {
                 name: string;

--- a/apps/ts/packages/web/src/components/Lab/LabJobHistoryTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabJobHistoryTable.test.tsx
@@ -100,7 +100,14 @@ describe('LabJobHistoryTable', () => {
     expect(refreshButton).toBeDisabled();
     expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1);
 
-    await user.click(screen.getAllByRole('button', { name: 'Monitor' })[0]);
+    const monitorButtons = screen.getAllByRole('button', { name: 'Monitor' });
+    const firstMonitorButton = monitorButtons[0];
+    expect(firstMonitorButton).toBeDefined();
+    if (!firstMonitorButton) {
+      throw new Error('Monitor button not found');
+    }
+
+    await user.click(firstMonitorButton);
     expect(onSelectJob).toHaveBeenCalledWith(jobs[0]);
   });
 });

--- a/apps/ts/packages/web/src/components/Lab/LabJobHistoryTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabJobHistoryTable.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { LabJobResponse } from '@/types/backtest';
+import { LabJobHistoryTable } from './LabJobHistoryTable';
+
+function createJob(overrides: Partial<LabJobResponse> = {}): LabJobResponse {
+  return {
+    job_id: 'job-1',
+    status: 'completed',
+    created_at: '2026-02-16T12:00:00Z',
+    lab_type: 'generate',
+    strategy_name: 'experimental/demo',
+    ...overrides,
+  };
+}
+
+describe('LabJobHistoryTable', () => {
+  it('shows loading state', () => {
+    render(
+      <LabJobHistoryTable
+        jobs={undefined}
+        isLoading
+        isRefreshing={false}
+        selectedJobId={null}
+        onSelectJob={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Job History')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    expect(screen.queryByText('No lab jobs found')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when jobs are missing', () => {
+    render(
+      <LabJobHistoryTable
+        jobs={[]}
+        isLoading={false}
+        isRefreshing={false}
+        selectedJobId={null}
+        onSelectJob={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('No lab jobs found')).toBeInTheDocument();
+  });
+
+  it('renders jobs and handles select/refresh actions', async () => {
+    const user = userEvent.setup();
+    const onSelectJob = vi.fn();
+    const onRefresh = vi.fn();
+    const job = createJob();
+
+    render(
+      <LabJobHistoryTable
+        jobs={[job]}
+        isLoading={false}
+        isRefreshing={false}
+        selectedJobId={null}
+        onSelectJob={onSelectJob}
+        onRefresh={onRefresh}
+      />
+    );
+
+    expect(screen.getByText('Job History')).toBeInTheDocument();
+    expect(screen.getByText('experimental/demo')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'View' }));
+    expect(onSelectJob).toHaveBeenCalledWith(job);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders monitor action for active statuses and handles missing fields', async () => {
+    const user = userEvent.setup();
+    const onSelectJob = vi.fn();
+    const jobs: LabJobResponse[] = [
+      createJob({ job_id: 'pending-1', status: 'pending', created_at: undefined }),
+      createJob({ job_id: 'running-1', status: 'running', lab_type: 'optimize' }),
+      createJob({ job_id: 'failed-1', status: 'failed', strategy_name: undefined }),
+      createJob({ job_id: 'cancelled-1', status: 'cancelled' }),
+    ];
+
+    render(
+      <LabJobHistoryTable
+        jobs={jobs}
+        isLoading={false}
+        isRefreshing
+        selectedJobId="running-1"
+        onSelectJob={onSelectJob}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    const refreshButton = screen.getByRole('button', { name: 'Refresh' });
+    expect(refreshButton).toBeDisabled();
+    expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1);
+
+    await user.click(screen.getAllByRole('button', { name: 'Monitor' })[0]);
+    expect(onSelectJob).toHaveBeenCalledWith(jobs[0]);
+  });
+});

--- a/apps/ts/packages/web/src/components/Lab/LabJobHistoryTable.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabJobHistoryTable.tsx
@@ -1,0 +1,107 @@
+import { CheckCircle2, Clock, Loader2, RotateCw, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { JobStatus, LabJobResponse } from '@/types/backtest';
+
+interface LabJobHistoryTableProps {
+  jobs: LabJobResponse[] | undefined;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  selectedJobId?: string | null;
+  onSelectJob: (job: LabJobResponse) => void;
+  onRefresh: () => void;
+}
+
+function StatusIcon({ status }: { status: JobStatus }) {
+  switch (status) {
+    case 'pending':
+      return <Clock className="h-4 w-4 text-yellow-500" />;
+    case 'running':
+      return <Loader2 className="h-4 w-4 animate-spin text-blue-500" />;
+    case 'completed':
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    case 'failed':
+    case 'cancelled':
+      return <XCircle className="h-4 w-4 text-red-500" />;
+    default:
+      return null;
+  }
+}
+
+function formatDate(dateString?: string): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return date.toLocaleString('ja-JP', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function actionLabel(status: JobStatus): string {
+  if (status === 'pending' || status === 'running') return 'Monitor';
+  return 'View';
+}
+
+export function LabJobHistoryTable({
+  jobs,
+  isLoading,
+  isRefreshing,
+  selectedJobId,
+  onSelectJob,
+  onRefresh,
+}: LabJobHistoryTableProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium">Job History</h4>
+        <Button variant="outline" size="sm" onClick={onRefresh} disabled={isRefreshing}>
+          <RotateCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex h-40 items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : !jobs || jobs.length === 0 ? (
+        <div className="flex h-40 items-center justify-center rounded-md border text-sm text-muted-foreground">
+          No lab jobs found
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-12">Status</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Strategy</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead className="w-24">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {jobs.map((job) => (
+                <TableRow key={job.job_id} className={selectedJobId === job.job_id ? 'bg-accent/50' : ''}>
+                  <TableCell>
+                    <StatusIcon status={job.status} />
+                  </TableCell>
+                  <TableCell className="text-xs uppercase">{job.lab_type ?? '-'}</TableCell>
+                  <TableCell className="text-xs font-mono">{job.strategy_name ?? '-'}</TableCell>
+                  <TableCell className="text-sm">{formatDate(job.created_at)}</TableCell>
+                  <TableCell>
+                    <Button variant="outline" size="sm" onClick={() => onSelectJob(job)}>
+                      {actionLabel(job.status)}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ts/packages/web/src/components/Lab/LabPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabPanel.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LabPanel } from './LabPanel';
+
+const mockSetSelectedStrategy = vi.fn();
+const mockSetActiveLabJobId = vi.fn();
+const mockSetActiveLabType = vi.fn();
+const mockGenerateMutateAsync = vi.fn();
+const mockEvolveMutateAsync = vi.fn();
+const mockOptimizeMutateAsync = vi.fn();
+const mockImproveMutateAsync = vi.fn();
+const mockCancelMutate = vi.fn();
+const mockRefetchLabJobs = vi.fn();
+
+const mockStore = {
+  selectedStrategy: 'strategy.yml' as string | null,
+  setSelectedStrategy: mockSetSelectedStrategy,
+  activeLabJobId: null as string | null,
+  setActiveLabJobId: mockSetActiveLabJobId,
+  setActiveLabType: mockSetActiveLabType,
+};
+
+const mockHookState = {
+  strategies: {
+    data: {
+      strategies: [{ name: 'strategy.yml', display_name: 'Strategy', category: 'production' }],
+    },
+    isLoading: false,
+  },
+  labJobs: {
+    data: [] as Array<Record<string, unknown>>,
+    isLoading: false,
+    isFetching: false,
+    refetch: mockRefetchLabJobs,
+  },
+  sse: {
+    status: null as string | null,
+    progress: null as number | null,
+    message: null as string | null,
+    isConnected: false,
+  },
+  jobStatus: {
+    data: null as Record<string, unknown> | null,
+  },
+  generate: {
+    isPending: false,
+    error: null as Error | null,
+  },
+  evolve: {
+    isPending: false,
+    error: null as Error | null,
+  },
+  optimize: {
+    isPending: false,
+    error: null as Error | null,
+  },
+  improve: {
+    isPending: false,
+    error: null as Error | null,
+  },
+  cancel: {
+    isPending: false,
+  },
+};
+
+vi.mock('@/stores/backtestStore', () => ({
+  useBacktestStore: () => mockStore,
+}));
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useStrategies: () => mockHookState.strategies,
+}));
+
+vi.mock('@/hooks/useLabSSE', () => ({
+  useLabSSE: () => mockHookState.sse,
+}));
+
+vi.mock('@/hooks/useLab', () => ({
+  useLabGenerate: () => ({
+    mutateAsync: mockGenerateMutateAsync,
+    isPending: mockHookState.generate.isPending,
+    error: mockHookState.generate.error,
+  }),
+  useLabEvolve: () => ({
+    mutateAsync: mockEvolveMutateAsync,
+    isPending: mockHookState.evolve.isPending,
+    error: mockHookState.evolve.error,
+  }),
+  useLabOptimize: () => ({
+    mutateAsync: mockOptimizeMutateAsync,
+    isPending: mockHookState.optimize.isPending,
+    error: mockHookState.optimize.error,
+  }),
+  useLabImprove: () => ({
+    mutateAsync: mockImproveMutateAsync,
+    isPending: mockHookState.improve.isPending,
+    error: mockHookState.improve.error,
+  }),
+  useCancelLabJob: () => ({
+    mutate: mockCancelMutate,
+    isPending: mockHookState.cancel.isPending,
+  }),
+  useLabJobs: () => mockHookState.labJobs,
+  useLabJobStatus: () => mockHookState.jobStatus,
+}));
+
+vi.mock('@/components/Backtest/StrategySelector', () => ({
+  StrategySelector: ({ value, onChange }: { value: string | null; onChange: (value: string) => void }) => (
+    <button type="button" onClick={() => onChange('strategy-updated')}>
+      Strategy Selector {value ?? 'none'}
+    </button>
+  ),
+}));
+
+vi.mock('./LabOperationSelector', () => ({
+  LabOperationSelector: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <div>
+      <span>Operation:{value}</span>
+      <button type="button" onClick={() => onChange('optimize')}>
+        Switch Operation
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./LabGenerateForm', () => ({
+  LabGenerateForm: ({
+    onSubmit,
+    disabled,
+  }: {
+    onSubmit: (req: { count: number }) => Promise<void>;
+    disabled: boolean;
+  }) => (
+    <button type="button" disabled={disabled} onClick={() => void onSubmit({ count: 1 })}>
+      Run Generate
+    </button>
+  ),
+}));
+
+vi.mock('./LabEvolveForm', () => ({
+  LabEvolveForm: () => <div>Evolve Form</div>,
+}));
+
+vi.mock('./LabOptimizeForm', () => ({
+  LabOptimizeForm: () => <div>Optimize Form</div>,
+}));
+
+vi.mock('./LabImproveForm', () => ({
+  LabImproveForm: () => <div>Improve Form</div>,
+}));
+
+vi.mock('./LabJobHistoryTable', () => ({
+  LabJobHistoryTable: ({
+    jobs,
+    onSelectJob,
+    onRefresh,
+  }: {
+    jobs: Array<Record<string, unknown>> | undefined;
+    onSelectJob: (job: Record<string, unknown>) => void;
+    onRefresh: () => void;
+  }) => (
+    <div>
+      <div>History Table</div>
+      <button type="button" onClick={onRefresh}>
+        History Refresh
+      </button>
+      <button type="button" onClick={() => jobs?.[0] && onSelectJob(jobs[0])}>
+        History Select
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./LabJobProgress', () => ({
+  LabJobProgress: ({ status, onCancel }: { status: string; onCancel?: () => void }) => (
+    <div>
+      <div>Progress:{status}</div>
+      {onCancel ? (
+        <button type="button" onClick={onCancel}>
+          Cancel Job
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+vi.mock('./LabResultSection', () => ({
+  LabResultSection: () => <div>Result Section</div>,
+}));
+
+describe('LabPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore.selectedStrategy = 'strategy.yml';
+    mockStore.activeLabJobId = null;
+
+    mockHookState.labJobs.data = [];
+    mockHookState.labJobs.isLoading = false;
+    mockHookState.labJobs.isFetching = false;
+
+    mockHookState.sse.status = null;
+    mockHookState.sse.progress = null;
+    mockHookState.sse.message = null;
+    mockHookState.sse.isConnected = false;
+
+    mockHookState.jobStatus.data = null;
+
+    mockHookState.generate.isPending = false;
+    mockHookState.generate.error = null;
+    mockHookState.evolve.isPending = false;
+    mockHookState.evolve.error = null;
+    mockHookState.optimize.isPending = false;
+    mockHookState.optimize.error = null;
+    mockHookState.improve.isPending = false;
+    mockHookState.improve.error = null;
+    mockHookState.cancel.isPending = false;
+
+    mockGenerateMutateAsync.mockResolvedValue({ job_id: 'lab-gen-1' });
+  });
+
+  it('starts generate job and updates active lab state', async () => {
+    const user = userEvent.setup();
+
+    render(<LabPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Run Generate' }));
+
+    await waitFor(() => expect(mockGenerateMutateAsync).toHaveBeenCalledWith({ count: 1 }));
+    expect(mockSetActiveLabJobId).toHaveBeenCalledWith('lab-gen-1');
+    expect(mockSetActiveLabType).toHaveBeenCalledWith('generate');
+  });
+
+  it('shows history tab and applies selected history job type', async () => {
+    const user = userEvent.setup();
+    mockHookState.labJobs.data = [
+      {
+        job_id: 'hist-1',
+        status: 'completed',
+        lab_type: 'optimize',
+        strategy_name: 'strategy.yml',
+        created_at: '2026-02-16T10:00:00Z',
+      },
+    ];
+
+    render(<LabPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'History' }));
+    expect(screen.getByText('History Table')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'History Refresh' }));
+    expect(mockRefetchLabJobs).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'History Select' }));
+    expect(mockSetActiveLabJobId).toHaveBeenCalledWith('hist-1');
+    expect(mockSetActiveLabType).toHaveBeenCalledWith('optimize');
+
+    await user.click(screen.getByRole('button', { name: 'Run' }));
+    expect(screen.getByText('Operation:optimize')).toBeInTheDocument();
+    expect(screen.getByText('Optimize Form')).toBeInTheDocument();
+  });
+
+  it('renders running progress and triggers cancel', async () => {
+    const user = userEvent.setup();
+    mockStore.activeLabJobId = 'running-1';
+    mockHookState.sse.status = 'running';
+    mockHookState.sse.progress = 0.4;
+    mockHookState.sse.message = 'running';
+    mockHookState.jobStatus.data = {
+      status: 'running',
+      created_at: '2026-02-16T10:00:00Z',
+      started_at: '2026-02-16T10:00:01Z',
+      error: null,
+      result_data: null,
+    };
+
+    render(<LabPanel />);
+
+    expect(screen.getByText('Progress:running')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel Job' }));
+    expect(mockCancelMutate).toHaveBeenCalledWith('running-1');
+    expect(screen.queryByText('Result Section')).not.toBeInTheDocument();
+  });
+
+  it('renders result section on completed status and shows mutation error', () => {
+    mockStore.activeLabJobId = 'done-1';
+    mockHookState.generate.error = new Error('generate failed');
+    mockHookState.sse.status = 'completed';
+    mockHookState.jobStatus.data = {
+      status: 'completed',
+      created_at: '2026-02-16T10:00:00Z',
+      started_at: '2026-02-16T10:00:01Z',
+      error: null,
+      result_data: {
+        lab_type: 'generate',
+        total_generated: 1,
+        results: [],
+      },
+    };
+
+    render(<LabPanel />);
+
+    expect(screen.getByText('generate failed')).toBeInTheDocument();
+    expect(screen.getByText('Result Section')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add backend /api/lab/jobs endpoint to list lab job history with type filter and limit
- add web Run/History tabs in Lab panel and new LabJobHistoryTable to browse past jobs
- allow selecting history jobs to re-open progress/result views and invalidate history cache on run/cancel
- sync OpenAPI and generated TypeScript types for new endpoint
- add backend/frontend tests for history listing and UI behavior
- update AGENTS.md with Lab history behavior note

## Testing
- NUMBA_DISABLE_JIT=1 /Users/shinjiroaso/dev/trading25/apps/bt/.venv/bin/python -m pytest apps/bt/tests/server/routes/test_lab.py apps/bt/tests/server/test_job_manager.py --cov=apps/bt/src/server/routes/lab.py --cov=apps/bt/src/server/services/job_manager.py --cov-branch
- bun run --filter @trading25/web vitest run src/hooks/useLab.test.tsx src/components/Lab/LabJobHistoryTable.test.tsx src/components/Lab/LabPanel.test.tsx --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/hooks/useLab.ts' --coverage.include='src/components/Lab/LabJobHistoryTable.tsx' --coverage.include='src/components/Lab/LabPanel.tsx'
- bun run --filter @trading25/web typecheck