### PR TITLE
fix(bt-agent): enable nested fundamental random_add mutations

### DIFF
--- a/apps/bt/src/agent/optuna_optimizer.py
+++ b/apps/bt/src/agent/optuna_optimizer.py
@@ -145,6 +145,7 @@ class OptunaOptimizer:
                 add_exit_signals=add_exit_signals,
                 base_entry_signals=base_entry,
                 base_exit_signals=base_exit,
+                allowed_categories=self.allowed_category_set,
             )
             logger.info(
                 "Optuna random-add applied: "

--- a/apps/bt/src/agent/parameter_evolver.py
+++ b/apps/bt/src/agent/parameter_evolver.py
@@ -237,6 +237,7 @@ class ParameterEvolver:
                 add_exit_signals=add_exit_signals,
                 base_entry_signals=self._base_entry_signals,
                 base_exit_signals=self._base_exit_signals,
+                allowed_categories=self.allowed_category_set,
             )
             augmented.strategy_id = "base_augmented"
             population.append(augmented)
@@ -252,6 +253,7 @@ class ParameterEvolver:
                     add_exit_signals=add_exit_signals,
                     base_entry_signals=self._base_entry_signals,
                     base_exit_signals=self._base_exit_signals,
+                    allowed_categories=self.allowed_category_set,
                 )
             mutated.strategy_id = f"init_{i}"
             mutated.metadata["generation"] = 0
@@ -311,6 +313,7 @@ class ParameterEvolver:
                     add_exit_signals=add_exit_signals,
                     base_entry_signals=self._base_entry_signals,
                     base_exit_signals=self._base_exit_signals,
+                    allowed_categories=self.allowed_category_set,
                 )
 
             child.strategy_id = f"gen_{len(next_population)}"
@@ -439,6 +442,7 @@ class ParameterEvolver:
                 add_exit_signals=add_exit_signals,
                 base_entry_signals=self._base_entry_signals,
                 base_exit_signals=self._base_exit_signals,
+                allowed_categories=self.allowed_category_set,
             )
         return mutated
 

--- a/apps/bt/src/agent/signal_catalog.py
+++ b/apps/bt/src/agent/signal_catalog.py
@@ -11,6 +11,7 @@ Lab固有の制約（相互排他・推奨組み合わせ・カテゴリ互換�
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast, get_args, get_origin
 
@@ -306,7 +307,11 @@ def _extract_range(field_info: Any, param_type: ParamType) -> ParamRange | None:
 
         gt = _read_numeric_attr(metadata, "gt")
         if gt is not None:
-            gt_value = float(int(gt) + 1) if param_type == "int" else gt
+            gt_value = (
+                float(int(gt) + 1)
+                if param_type == "int"
+                else math.nextafter(gt, math.inf)
+            )
             lower = gt_value if lower is None else max(lower, gt_value)
 
         le = _read_numeric_attr(metadata, "le")
@@ -315,7 +320,11 @@ def _extract_range(field_info: Any, param_type: ParamType) -> ParamRange | None:
 
         lt = _read_numeric_attr(metadata, "lt")
         if lt is not None:
-            lt_value = float(int(lt) - 1) if param_type == "int" else lt
+            lt_value = (
+                float(int(lt) - 1)
+                if param_type == "int"
+                else math.nextafter(lt, -math.inf)
+            )
             upper = lt_value if upper is None else min(upper, lt_value)
 
     if lower is None or upper is None:
@@ -389,4 +398,3 @@ SIGNAL_CATEGORY_MAP: dict[str, SignalCategory] = {
     signal.name: signal.category for signal in AVAILABLE_SIGNALS
 }
 PARAM_RANGES: dict[str, dict[str, ParamRange]] = _build_param_ranges()
-

--- a/apps/bt/tests/unit/agent/test_optuna_optimizer.py
+++ b/apps/bt/tests/unit/agent/test_optuna_optimizer.py
@@ -174,7 +174,11 @@ class TestOptimizeFlow:
             optimizer.optimize("demo_strategy", progress_callback=None)
 
     def test_optimize_applies_random_add_structure_when_enabled(self):
-        optimizer = _make_optimizer(n_trials=10, target_scope="entry_filter_only")
+        optimizer = _make_optimizer(
+            n_trials=10,
+            target_scope="entry_filter_only",
+            allowed_categories=["fundamental"],
+        )
         optimizer.config.structure_mode = "random_add"
         optimizer.config.random_add_entry_signals = 1
         optimizer.config.random_add_exit_signals = 0
@@ -203,6 +207,7 @@ class TestOptimizeFlow:
             optimizer.optimize("demo_strategy", progress_callback=None)
 
         mock_random_add.assert_called_once()
+        assert mock_random_add.call_args.kwargs["allowed_categories"] == {"fundamental"}
         assert "period_breakout" in optimizer.base_entry_params
 
 

--- a/apps/bt/tests/unit/agent/test_parameter_evolver.py
+++ b/apps/bt/tests/unit/agent/test_parameter_evolver.py
@@ -151,6 +151,31 @@ class TestMutation:
             "fundamental", usage_type="entry"
         ) is True
 
+    def test_random_add_mutation_passes_allowed_categories(self):
+        config = EvolutionConfig(
+            structure_mode="random_add",
+            random_add_entry_signals=1,
+            random_add_exit_signals=0,
+            allowed_categories=["fundamental"],
+        )
+        evolver = ParameterEvolver(
+            config=config,
+            shared_config_dict={"initial_cash": 10000000, "stock_codes": ["7203"]},
+        )
+        evolver._base_entry_signals = {"volume"}
+        evolver._base_exit_signals = set()
+        candidate = _make_candidate()
+
+        with patch(
+            "src.agent.parameter_evolver.apply_random_add_structure",
+            return_value=(candidate, {"entry": [], "exit": []}),
+        ) as mock_random_add:
+            evolver._mutate(candidate, mutation_strength=0.0)
+
+        assert mock_random_add.call_args.kwargs["allowed_categories"] == {
+            "fundamental"
+        }
+
     def test_effective_random_add_counts_by_target_scope(self):
         entry_only = ParameterEvolver(
             config=EvolutionConfig(

--- a/apps/bt/tests/unit/agent/test_signal_catalog.py
+++ b/apps/bt/tests/unit/agent/test_signal_catalog.py
@@ -43,3 +43,9 @@ def test_param_ranges_generated_for_new_signals() -> None:
     assert "retracement_level" in PARAM_RANGES["retracement"]
     assert "momentum_period" in PARAM_RANGES["sector_strength_ranking"]
 
+
+def test_param_ranges_respect_exclusive_minimums() -> None:
+    lower, upper, param_type = PARAM_RANGES["fundamental"]["forward_eps_growth.threshold"]
+    assert param_type == "float"
+    assert lower > 0.0
+    assert upper <= 2.0


### PR DESCRIPTION
## Summary
- Add fundamental-only nested child enablement in random_add augmentation so evolve actually changes signals under fundamental scope.
- Thread allowed category constraints through evolve and optimize random_add paths.
- Fix strict float bound handling for signal parameter ranges and extend unit tests for augmentation/catalog/evolver/optimizer paths.

## Test
- uv run ruff check apps/bt/src/agent/signal_augmentation.py apps/bt/src/agent/parameter_evolver.py apps/bt/src/agent/optuna_optimizer.py apps/bt/src/agent/signal_catalog.py apps/bt/tests/unit/agent/test_signal_augmentation.py apps/bt/tests/unit/agent/test_signal_catalog.py apps/bt/tests/unit/agent/test_parameter_evolver.py apps/bt/tests/unit/agent/test_optuna_optimizer.py
- uv run pytest apps/bt/tests/unit/agent/test_signal_augmentation.py apps/bt/tests/unit/agent/test_signal_catalog.py apps/bt/tests/unit/agent/test_parameter_evolver.py apps/bt/tests/unit/agent/test_optuna_optimizer.py