### PR TITLE
fix(bt): restore ROA and margin loader signal columns

### DIFF
--- a/apps/bt/src/data/loaders/margin_loaders.py
+++ b/apps/bt/src/data/loaders/margin_loaders.py
@@ -22,6 +22,7 @@ def transform_margin_df(df: pd.DataFrame) -> pd.DataFrame:
     """Batch/個別共用: APIレスポンスDataFrameをVectorBT形式に変換
 
     カラム名のリネーム、MarginRatio/TotalMargin計算、NaN処理を行う。
+    後方互換として margin_balance (買い残高) も付与する。
     """
     df = df.rename(
         columns={"longMarginVolume": "LongMargin", "shortMarginVolume": "ShortMargin"}
@@ -32,6 +33,8 @@ def transform_margin_df(df: pd.DataFrame) -> pd.DataFrame:
     total = df["LongMargin"] + df["ShortMargin"]
     df["MarginRatio"] = df["ShortMargin"].div(total).fillna(0)
     df["TotalMargin"] = total
+    # Signal registry は margin_balance を参照するため互換カラムを維持
+    df["margin_balance"] = df["LongMargin"]
     return df
 
 

--- a/apps/bt/tests/unit/data/test_statements_loaders.py
+++ b/apps/bt/tests/unit/data/test_statements_loaders.py
@@ -345,5 +345,38 @@ class TestTransformStatementsAdjusted:
         assert result.loc["2024-04-28", "AdjustedForecastEPS"] == 60.0
 
 
+class TestTransformStatementsRoa:
+    def test_transform_calculates_roa_from_total_assets(self):
+        df = pd.DataFrame(
+            {
+                "disclosedDate": [pd.Timestamp("2024-04-28"), pd.Timestamp("2024-07-30")],
+                "profit": [2_000_000, 1_200_000],
+                "equity": [5_000_000, 5_200_000],
+                "totalAssets": [20_000_000, 24_000_000],
+            }
+        ).set_index("disclosedDate")
+
+        result = transform_statements_df(df)
+
+        assert "ROA" in result.columns
+        assert result.loc["2024-04-28", "ROA"] == pytest.approx(10.0)
+        assert result.loc["2024-07-30", "ROA"] == pytest.approx(5.0)
+
+    def test_transform_roa_is_nan_when_total_assets_invalid(self):
+        df = pd.DataFrame(
+            {
+                "disclosedDate": [pd.Timestamp("2024-04-28"), pd.Timestamp("2024-07-30")],
+                "profit": [2_000_000, 1_200_000],
+                "equity": [5_000_000, 5_200_000],
+                "totalAssets": [0, None],
+            }
+        ).set_index("disclosedDate")
+
+        result = transform_statements_df(df)
+
+        assert pd.isna(result.loc["2024-04-28", "ROA"])
+        assert pd.isna(result.loc["2024-07-30", "ROA"])
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary
- add totalAssets -> TotalAssets mapping and ROA calculation in statements loader
- expose backward-compatible margin_balance in margin loader so registry margin signal receives expected column
- add/extend unit tests for ROA transform and margin loader cache/column behavior

## Verification
- uv run --project /Users/shinjiroaso/.codex/worktrees/535d/trading25/apps/bt pytest /Users/shinjiroaso/.codex/worktrees/535d/trading25/apps/bt/tests/unit/data/test_statements_loaders.py /Users/shinjiroaso/.codex/worktrees/535d/trading25/apps/bt/tests/unit/data/test_margin_loaders.py -q
