### PR TITLE
feat(bt): reflect quarterly FEPS revisions in forward and PEG signals

### DIFF
--- a/.codex/skills/bt-signal-system/SKILL.md
+++ b/.codex/skills/bt-signal-system/SKILL.md
@@ -21,3 +21,4 @@ description: bt の統一シグナルシステムを扱うスキル。`entry_fil
 1. パラメータモデルと YAML の整合性。
 2. エントリー/エグジット結合ロジックの不変条件。
 3. 追加シグナルの registry 反映漏れ。
+4. `forward_eps_growth` / `peg_ratio` は FY実績EPS固定 + 四半期 FEPS 修正反映（必要時のみ追加取得）を維持。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ uv run pyright src/              # 型チェック
 - Lab `evolve/optimize` の frontend `allowed categories` は `all` / `fundamental only` を提供
 - Lab frontend は `Run` / `History` タブを持ち、`/api/lab/jobs` で実行履歴を一覧し、選択したジョブの進捗・結果を再表示できる
 - Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
+- `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest
 

--- a/apps/bt/src/agent/evaluator/evaluator.py
+++ b/apps/bt/src/agent/evaluator/evaluator.py
@@ -123,7 +123,7 @@ class StrategyEvaluator:
     ) -> list[EvaluationResult]:
         """バッチ評価の内部実装"""
         max_workers = get_max_workers(self.n_jobs)
-        prepared_data = prepare_batch_data(self.shared_config_dict)
+        prepared_data = prepare_batch_data(self.shared_config_dict, candidates)
         results = execute_batch_evaluation(
             candidates,
             max_workers,

--- a/apps/bt/tests/unit/data/test_multi_asset_loaders.py
+++ b/apps/bt/tests/unit/data/test_multi_asset_loaders.py
@@ -1,0 +1,218 @@
+"""multi_asset_loaders.py の財務諸表読み込みテスト"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from src.data.loaders.multi_asset_loaders import load_multiple_statements_data
+
+
+def _mock_context_manager(client: MagicMock) -> MagicMock:
+    manager = MagicMock()
+    manager.__enter__ = MagicMock(return_value=client)
+    manager.__exit__ = MagicMock(return_value=False)
+    return manager
+
+
+class TestLoadMultipleStatementsData:
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_include_forecast_revision_merges_batch_all_period(
+        self,
+        mock_get_client,
+        mock_extract,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+
+        client = MagicMock()
+        client.get_statements_batch.side_effect = [
+            {
+                "7203": pd.DataFrame(
+                    {
+                        "disclosedDate": [pd.Timestamp("2025-01-01")],
+                        "typeOfCurrentPeriod": ["FY"],
+                        "earningsPerShare": [80.0],
+                        "nextYearForecastEarningsPerShare": [100.0],
+                        "profit": [1000.0],
+                        "equity": [5000.0],
+                    }
+                ).set_index("disclosedDate")
+            },
+            {
+                "7203": pd.DataFrame(
+                    {
+                        "disclosedDate": [pd.Timestamp("2025-01-03")],
+                        "typeOfCurrentPeriod": ["1Q"],
+                        "earningsPerShare": [20.0],
+                        "forecastEps": [120.0],
+                        "profit": [300.0],
+                        "equity": [5100.0],
+                    }
+                ).set_index("disclosedDate")
+            },
+        ]
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        result = load_multiple_statements_data(
+            dataset="testds",
+            stock_codes=["7203"],
+            daily_index=daily_index,
+            statements_column="ForwardForecastEPS",
+            period_type="FY",
+            include_forecast_revision=True,
+        )
+
+        assert result.loc["2025-01-02", "7203"] == 100.0
+        assert result.loc["2025-01-05", "7203"] == 120.0
+        assert client.get_statements_batch.call_count == 2
+        assert client.get_statements_batch.call_args_list[0].kwargs["period_type"] == "FY"
+        assert client.get_statements_batch.call_args_list[1].kwargs["period_type"] == "all"
+
+    @patch("src.data.loaders.multi_asset_loaders.logger")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_include_forecast_revision_fallback_on_all_period_error(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_logger,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+
+        client = MagicMock()
+        client.get_statements_batch.side_effect = [
+            {
+                "7203": pd.DataFrame(
+                    {
+                        "disclosedDate": [pd.Timestamp("2025-01-01")],
+                        "typeOfCurrentPeriod": ["FY"],
+                        "earningsPerShare": [80.0],
+                        "nextYearForecastEarningsPerShare": [100.0],
+                        "profit": [1000.0],
+                        "equity": [5000.0],
+                    }
+                ).set_index("disclosedDate")
+            },
+            RuntimeError("boom"),
+        ]
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        result = load_multiple_statements_data(
+            dataset="testds",
+            stock_codes=["7203"],
+            daily_index=daily_index,
+            statements_column="ForwardForecastEPS",
+            period_type="FY",
+            include_forecast_revision=True,
+        )
+
+        assert result.loc["2025-01-05", "7203"] == 100.0
+        mock_logger.warning.assert_called_once()
+
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_revision_fetch_skipped_when_period_type_not_fy(
+        self,
+        mock_get_client,
+        mock_extract,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+
+        client = MagicMock()
+        client.get_statements_batch.return_value = {
+            "7203": pd.DataFrame(
+                {
+                    "disclosedDate": [pd.Timestamp("2025-01-03")],
+                    "typeOfCurrentPeriod": ["1Q"],
+                    "earningsPerShare": [20.0],
+                    "forecastEps": [120.0],
+                    "profit": [300.0],
+                    "equity": [5100.0],
+                }
+            ).set_index("disclosedDate")
+        }
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        load_multiple_statements_data(
+            dataset="testds",
+            stock_codes=["7203"],
+            daily_index=daily_index,
+            statements_column="ForwardForecastEPS",
+            period_type="all",
+            include_forecast_revision=True,
+        )
+
+        assert client.get_statements_batch.call_count == 1
+
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_revision_fetch_skipped_when_non_forward_column_requested(
+        self,
+        mock_get_client,
+        mock_extract,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+
+        client = MagicMock()
+        client.get_statements_batch.return_value = {
+            "7203": pd.DataFrame(
+                {
+                    "disclosedDate": [pd.Timestamp("2025-01-01")],
+                    "typeOfCurrentPeriod": ["FY"],
+                    "earningsPerShare": [80.0],
+                    "nextYearForecastEarningsPerShare": [100.0],
+                    "profit": [1000.0],
+                    "equity": [5000.0],
+                }
+            ).set_index("disclosedDate")
+        }
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        load_multiple_statements_data(
+            dataset="testds",
+            stock_codes=["7203"],
+            daily_index=daily_index,
+            statements_column="eps",
+            period_type="FY",
+            include_forecast_revision=True,
+        )
+
+        assert client.get_statements_batch.call_count == 1
+
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_lowercase_alias_column_is_resolved(
+        self,
+        mock_get_client,
+        mock_extract,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+
+        client = MagicMock()
+        client.get_statements_batch.return_value = {
+            "7203": pd.DataFrame(
+                {
+                    "disclosedDate": [pd.Timestamp("2025-01-01")],
+                    "typeOfCurrentPeriod": ["FY"],
+                    "earningsPerShare": [80.0],
+                    "profit": [1000.0],
+                    "equity": [5000.0],
+                }
+            ).set_index("disclosedDate")
+        }
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        result = load_multiple_statements_data(
+            dataset="testds",
+            stock_codes=["7203"],
+            daily_index=daily_index,
+            statements_column="eps",
+            period_type="FY",
+        )
+
+        assert result.loc["2025-01-05", "7203"] == 80.0


### PR DESCRIPTION
## Summary
- extend forecast-revision handling from forward_eps_growth to peg_ratio
- add forward helper columns (ForwardBaseEPS, ForwardForecastEPS and adjusted variants)
- keep denominator EPS fixed to FY actuals while allowing forecast-side FEPS updates from quarterly disclosures
- fetch/merge period_type=all only when forecast-based signals are enabled, with warning fallback on failures
- propagate include_forecast_revision through data loaders, strategy mixin, optimization prefetch, and agent batch prefetch
- update signal registry to prefer new forward columns and fallback to legacy columns when forward columns are missing or all-NaN
- update AGENTS and skill docs for the new signal behavior

## Tests
- uv run --project /Users/shinjiroaso/.codex/worktrees/7374/trading25/apps/bt pytest apps/bt/tests/unit/data/test_statements_loaders.py apps/bt/tests/unit/data/test_data_preparation.py apps/bt/tests/unit/data/test_multi_asset_loaders.py apps/bt/tests/unit/models/test_fundamental_period_type.py apps/bt/tests/unit/strategies/signals/test_registry.py apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/agent/test_batch_executor.py apps/bt/tests/unit/optimization/test_engine_metrics.py (272 passed)
- uv run --project /Users/shinjiroaso/.codex/worktrees/7374/trading25/apps/bt python -m coverage run --branch -m pytest <same test set> (passed)
