### PR TITLE
feat: show optimization params and best/worst results in runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ uv run pyright src/              # 型チェック
 - Lab `evolve/optimize` の frontend `allowed categories` は `all` / `fundamental only` を提供
 - Lab frontend は `Run` / `History` タブを持ち、`/api/lab/jobs` で実行履歴を一覧し、選択したジョブの進捗・結果を再表示できる
 - Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
+- `/api/optimize/jobs/{id}` は `best_score` / `total_combinations` に加えて `best_params` / `worst_score` / `worst_params` を返し、最適化ジョブ結果カードで best/worst 条件を比較表示できる
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest
@@ -126,6 +127,7 @@ bun run cli backtest attribution run <strategy> --wait
 ```
 
 - Backtest UI は `Attribution` サブタブ内に `Run` / `History` を持ち、進捗取得は 2 秒ポーリング
+- Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/apps/bt/src/server/routes/optimize.py
+++ b/apps/bt/src/server/routes/optimize.py
@@ -60,6 +60,9 @@ def _build_optimization_job_response(job_id: str) -> OptimizationJobResponse:
         completed_at=job.completed_at,
         error=job.error,
         best_score=job.best_score,
+        best_params=job.best_params,
+        worst_score=job.worst_score,
+        worst_params=job.worst_params,
         total_combinations=job.total_combinations,
         notebook_path=job.notebook_path,
     )

--- a/apps/bt/src/server/schemas/optimize.py
+++ b/apps/bt/src/server/schemas/optimize.py
@@ -3,6 +3,7 @@ Optimization API Schemas
 """
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -23,6 +24,9 @@ class OptimizationJobResponse(BaseJobResponse):
     """最適化ジョブレスポンス"""
 
     best_score: float | None = Field(default=None, description="最良スコア")
+    best_params: dict[str, Any] | None = Field(default=None, description="最良スコア時のパラメータ")
+    worst_score: float | None = Field(default=None, description="最悪スコア")
+    worst_params: dict[str, Any] | None = Field(default=None, description="最悪スコア時のパラメータ")
     total_combinations: int | None = Field(default=None, description="パラメータ組み合わせ総数")
     notebook_path: str | None = Field(default=None, description="結果Notebookパス")
 

--- a/apps/bt/src/server/services/job_manager.py
+++ b/apps/bt/src/server/services/job_manager.py
@@ -39,6 +39,9 @@ class JobInfo:
         self.task: asyncio.Task[None] | None = None
         # Optimization-specific fields
         self.best_score: float | None = None
+        self.best_params: dict[str, Any] | None = None
+        self.worst_score: float | None = None
+        self.worst_params: dict[str, Any] | None = None
         self.total_combinations: int | None = None
         self.notebook_path: str | None = None
 

--- a/apps/bt/src/server/services/optimization_service.py
+++ b/apps/bt/src/server/services/optimization_service.py
@@ -71,6 +71,9 @@ class OptimizationService:
             job = self._manager.get_job(job_id)
             if job is not None:
                 job.best_score = result.get("best_score")
+                job.best_params = result.get("best_params")
+                job.worst_score = result.get("worst_score")
+                job.worst_params = result.get("worst_params")
                 job.total_combinations = result.get("total_combinations")
                 job.notebook_path = result.get("notebook_path")
 
@@ -108,7 +111,7 @@ class OptimizationService:
         同期的にグリッドサーチ最適化を実行
 
         Returns:
-            結果辞書 (best_score, total_combinations, notebook_path)
+            結果辞書
         """
         from src.optimization.engine import ParameterOptimizationEngine
 
@@ -116,11 +119,18 @@ class OptimizationService:
         opt_result = engine.optimize()
 
         best_score = opt_result.best_score
+        best_params = opt_result.best_params
         total_combinations = len(opt_result.all_results) if opt_result.all_results else 0
+        worst_result = opt_result.all_results[-1] if opt_result.all_results else None
+        worst_score = worst_result.get("score") if worst_result else None
+        worst_params = worst_result.get("params") if worst_result else None
         notebook_path = opt_result.notebook_path if opt_result.notebook_path else None
 
         return {
             "best_score": best_score,
+            "best_params": best_params,
+            "worst_score": worst_score,
+            "worst_params": worst_params,
             "total_combinations": total_combinations,
             "notebook_path": notebook_path,
         }

--- a/apps/bt/tests/unit/server/routes/test_optimize.py
+++ b/apps/bt/tests/unit/server/routes/test_optimize.py
@@ -29,6 +29,9 @@ class TestBuildOptimizationJobResponse:
         mock_job.completed_at = datetime(2025, 1, 1)
         mock_job.error = None
         mock_job.best_score = 0.85
+        mock_job.best_params = {"period": 20, "threshold": 0.3}
+        mock_job.worst_score = 0.12
+        mock_job.worst_params = {"period": 5, "threshold": 0.9}
         mock_job.total_combinations = 100
         mock_job.notebook_path = "/path/to/notebook"
         mock_job_manager.get_job.return_value = mock_job
@@ -36,6 +39,9 @@ class TestBuildOptimizationJobResponse:
         response = _build_optimization_job_response("test-123")
         assert response.job_id == "test-123"
         assert response.best_score == 0.85
+        assert response.best_params == {"period": 20, "threshold": 0.3}
+        assert response.worst_score == 0.12
+        assert response.worst_params == {"period": 5, "threshold": 0.9}
 
     def test_not_found(self, mock_job_manager):
         mock_job_manager.get_job.return_value = None

--- a/apps/bt/tests/unit/server/services/test_optimization_service.py
+++ b/apps/bt/tests/unit/server/services/test_optimization_service.py
@@ -1,0 +1,259 @@
+"""OptimizationService unit tests."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.server.services.optimization_service import OptimizationService
+
+
+def _success_payload() -> dict[str, object]:
+    return {
+        "best_score": 0.9,
+        "best_params": {"period": 20},
+        "worst_score": 0.1,
+        "worst_params": {"period": 5},
+        "total_combinations": 9,
+        "notebook_path": "/tmp/result.ipynb",
+    }
+
+
+def test_execute_optimization_sync_extracts_best_and_worst(monkeypatch):
+    service = OptimizationService()
+
+    class _FakeEngine:
+        def __init__(self, strategy_name: str):
+            assert strategy_name == "demo"
+
+        def optimize(self):
+            return SimpleNamespace(
+                best_score=1.0,
+                best_params={"period": 20},
+                all_results=[
+                    {"score": 1.0, "params": {"period": 20}},
+                    {"score": 0.2, "params": {"period": 5}},
+                ],
+                notebook_path="/tmp/result.ipynb",
+            )
+
+    monkeypatch.setattr("src.optimization.engine.ParameterOptimizationEngine", _FakeEngine)
+
+    payload = service._execute_optimization_sync("demo")
+
+    assert payload["best_score"] == 1.0
+    assert payload["best_params"] == {"period": 20}
+    assert payload["worst_score"] == 0.2
+    assert payload["worst_params"] == {"period": 5}
+    assert payload["total_combinations"] == 2
+    assert payload["notebook_path"] == "/tmp/result.ipynb"
+
+
+def test_execute_optimization_sync_handles_empty_all_results(monkeypatch):
+    service = OptimizationService()
+
+    class _FakeEngine:
+        def __init__(self, strategy_name: str):
+            assert strategy_name == "demo"
+
+        def optimize(self):
+            return SimpleNamespace(
+                best_score=0.0,
+                best_params={},
+                all_results=[],
+                notebook_path="",
+            )
+
+    monkeypatch.setattr("src.optimization.engine.ParameterOptimizationEngine", _FakeEngine)
+
+    payload = service._execute_optimization_sync("demo")
+
+    assert payload["best_score"] == 0.0
+    assert payload["best_params"] == {}
+    assert payload["worst_score"] is None
+    assert payload["worst_params"] is None
+    assert payload["total_combinations"] == 0
+    assert payload["notebook_path"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_optimization_creates_task_and_returns_job_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _dummy_run_optimization(*args, **kwargs):  # noqa: ANN002
+        _ = (args, kwargs)
+        return None
+
+    manager = SimpleNamespace(
+        create_job=lambda _strategy_name, job_type="optimization": "opt-job-1",
+    )
+    service = OptimizationService(manager=manager)
+    monkeypatch.setattr(service, "_run_optimization", _dummy_run_optimization)
+
+    async def _set_job_task(job_id: str, task):
+        captured["job_id"] = job_id
+        captured["task"] = task
+        await task
+
+    manager.set_job_task = _set_job_task
+
+    job_id = await service.submit_optimization("strategy-x")
+
+    assert job_id == "opt-job-1"
+    assert captured["job_id"] == "opt-job-1"
+    assert captured["task"] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_optimization_success_sets_job_fields(monkeypatch):
+    job = SimpleNamespace(
+        best_score=None,
+        best_params=None,
+        worst_score=None,
+        worst_params=None,
+        total_combinations=None,
+        notebook_path=None,
+    )
+    statuses: list[str] = []
+    events: list[str] = []
+
+    async def _acquire_slot():
+        events.append("acquire")
+
+    async def _update_job_status(job_id: str, status, **kwargs):  # noqa: ANN001
+        _ = (job_id, kwargs)
+        statuses.append(status.value)
+
+    manager = SimpleNamespace(
+        acquire_slot=_acquire_slot,
+        release_slot=lambda: events.append("release"),
+        update_job_status=_update_job_status,
+        get_job=lambda _job_id: job,
+    )
+
+    class _SuccessLoop:
+        def run_in_executor(self, executor, fn, *args):  # noqa: ANN001
+            _ = (executor, fn, args)
+            fut = asyncio.Future()
+            fut.set_result(_success_payload())
+            return fut
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: _SuccessLoop())
+
+    service = OptimizationService(manager=manager)
+    await service._run_optimization("job-1", "strategy-1")
+
+    assert events == ["acquire", "release"]
+    assert statuses == ["running", "completed"]
+    assert job.best_score == 0.9
+    assert job.best_params == {"period": 20}
+    assert job.worst_score == 0.1
+    assert job.worst_params == {"period": 5}
+    assert job.total_combinations == 9
+    assert job.notebook_path == "/tmp/result.ipynb"
+
+
+@pytest.mark.asyncio
+async def test_run_optimization_success_without_job_object(monkeypatch):
+    statuses: list[str] = []
+
+    async def _acquire_slot():
+        return None
+
+    async def _update_job_status(job_id: str, status, **kwargs):  # noqa: ANN001
+        _ = (job_id, kwargs)
+        statuses.append(status.value)
+
+    manager = SimpleNamespace(
+        acquire_slot=_acquire_slot,
+        release_slot=lambda: None,
+        update_job_status=_update_job_status,
+        get_job=lambda _job_id: None,
+    )
+
+    class _SuccessLoop:
+        def run_in_executor(self, executor, fn, *args):  # noqa: ANN001
+            _ = (executor, fn, args)
+            fut = asyncio.Future()
+            fut.set_result(_success_payload())
+            return fut
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: _SuccessLoop())
+
+    service = OptimizationService(manager=manager)
+    await service._run_optimization("job-1", "strategy-1")
+
+    assert statuses == ["running", "completed"]
+
+
+@pytest.mark.asyncio
+async def test_run_optimization_handles_cancelled(monkeypatch):
+    statuses: list[str] = []
+    events: list[str] = []
+
+    async def _acquire_slot():
+        events.append("acquire")
+
+    async def _update_job_status(job_id: str, status, **kwargs):  # noqa: ANN001
+        _ = (job_id, kwargs)
+        statuses.append(status.value)
+
+    manager = SimpleNamespace(
+        acquire_slot=_acquire_slot,
+        release_slot=lambda: events.append("release"),
+        update_job_status=_update_job_status,
+        get_job=lambda _job_id: None,
+    )
+
+    class _CancelledLoop:
+        def run_in_executor(self, executor, fn, *args):  # noqa: ANN001
+            _ = (executor, fn, args)
+            fut = asyncio.Future()
+            fut.set_exception(asyncio.CancelledError())
+            return fut
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: _CancelledLoop())
+
+    service = OptimizationService(manager=manager)
+    await service._run_optimization("job-2", "strategy-2")
+
+    assert events == ["acquire", "release"]
+    assert statuses == ["running", "cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_run_optimization_handles_failure(monkeypatch):
+    statuses: list[str] = []
+    errors: list[str | None] = []
+    events: list[str] = []
+
+    async def _acquire_slot():
+        events.append("acquire")
+
+    async def _update_job_status(job_id: str, status, **kwargs):  # noqa: ANN001
+        _ = job_id
+        statuses.append(status.value)
+        errors.append(kwargs.get("error"))
+
+    manager = SimpleNamespace(
+        acquire_slot=_acquire_slot,
+        release_slot=lambda: events.append("release"),
+        update_job_status=_update_job_status,
+        get_job=lambda _job_id: None,
+    )
+
+    class _FailedLoop:
+        def run_in_executor(self, executor, fn, *args):  # noqa: ANN001
+            _ = (executor, fn, args)
+            fut = asyncio.Future()
+            fut.set_exception(RuntimeError("boom"))
+            return fut
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: _FailedLoop())
+
+    service = OptimizationService(manager=manager)
+    await service._run_optimization("job-3", "strategy-3")
+
+    assert events == ["acquire", "release"]
+    assert statuses == ["running", "failed"]
+    assert errors[-1] == "boom"

--- a/apps/ts/packages/clients-ts/src/backtest/types.ts
+++ b/apps/ts/packages/clients-ts/src/backtest/types.ts
@@ -308,6 +308,9 @@ export interface OptimizationJobResponse {
   completed_at: string | null;
   error: string | null;
   best_score: number | null;
+  best_params: Record<string, unknown> | null;
+  worst_score: number | null;
+  worst_params: Record<string, unknown> | null;
   total_combinations: number | null;
   notebook_path: string | null;
 }

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -205,16 +205,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -231,6 +221,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -286,16 +286,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -312,6 +302,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -357,16 +357,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -383,6 +373,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -447,16 +447,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -473,6 +463,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -530,16 +530,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -556,6 +546,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -613,16 +613,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -639,6 +629,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -735,16 +735,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -761,6 +751,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -807,16 +807,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -833,6 +823,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -880,16 +880,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -906,6 +896,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -958,16 +958,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -984,6 +974,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1031,16 +1031,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1057,6 +1047,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1114,16 +1114,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1140,6 +1130,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1186,16 +1186,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1212,6 +1202,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1259,16 +1259,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1285,6 +1275,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1332,16 +1332,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1358,6 +1348,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1403,16 +1403,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1429,6 +1419,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1476,16 +1476,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1502,6 +1492,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1566,16 +1566,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1592,6 +1582,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1648,16 +1648,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1674,6 +1664,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1738,16 +1738,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1764,6 +1754,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1820,16 +1820,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1846,6 +1836,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1900,16 +1900,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1926,6 +1916,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1992,16 +1992,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2018,6 +2008,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2063,16 +2063,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2089,6 +2079,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2135,16 +2135,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2161,6 +2151,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2208,16 +2208,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2234,6 +2224,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2279,16 +2279,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2305,6 +2295,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2404,16 +2404,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2430,6 +2420,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2485,16 +2485,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2511,6 +2501,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2556,16 +2556,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2582,6 +2572,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2646,16 +2646,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2672,6 +2662,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2728,16 +2728,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2754,6 +2744,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2808,16 +2808,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2834,6 +2824,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2900,16 +2900,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2926,6 +2916,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3078,16 +3078,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3104,6 +3094,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3150,16 +3150,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3176,6 +3166,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3222,16 +3222,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3248,6 +3238,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3294,16 +3294,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3320,6 +3310,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3366,16 +3366,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3392,6 +3382,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3439,16 +3439,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3465,6 +3455,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3519,16 +3519,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3545,6 +3535,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3590,16 +3590,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3616,6 +3606,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3663,16 +3663,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3689,6 +3679,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3735,16 +3735,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3761,6 +3751,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3807,16 +3807,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3833,6 +3823,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3879,16 +3879,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3905,6 +3895,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3951,16 +3951,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3977,6 +3967,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4132,16 +4132,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4158,6 +4148,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4268,16 +4268,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4294,6 +4284,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4370,16 +4370,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4396,6 +4386,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4497,16 +4497,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4523,6 +4513,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4572,16 +4572,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4598,6 +4588,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4647,16 +4647,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4673,6 +4663,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4765,16 +4765,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4791,6 +4781,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4925,16 +4925,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4951,6 +4941,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5012,16 +5012,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5038,6 +5028,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5085,16 +5085,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5111,6 +5101,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5231,16 +5231,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5257,6 +5247,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5328,16 +5328,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5354,6 +5344,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5400,16 +5400,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5426,6 +5416,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5512,16 +5512,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5538,6 +5528,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5615,16 +5615,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5641,6 +5631,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5783,16 +5783,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5809,6 +5799,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5855,16 +5855,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5881,6 +5871,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5945,16 +5945,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -5971,6 +5961,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6046,16 +6046,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6072,6 +6062,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6214,16 +6214,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6240,6 +6230,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6341,16 +6341,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6367,6 +6357,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6426,16 +6426,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6452,6 +6442,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6620,16 +6620,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6646,6 +6636,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6705,16 +6705,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6731,6 +6721,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6878,16 +6878,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6904,6 +6894,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6950,16 +6950,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -6976,6 +6966,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7020,16 +7020,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7046,6 +7036,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7091,16 +7091,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7117,6 +7107,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7178,16 +7178,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7204,6 +7194,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7260,20 +7260,10 @@
                   "additionalProperties": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/OHLCVRecord"
+                      "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                     }
                   },
                   "title": "Response Get Dataset Ohlcv Batch Api Dataset  Name  Stocks Ohlcv Batch Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7294,6 +7284,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7380,19 +7380,9 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/OHLCVRecord"
+                    "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                   },
                   "title": "Response Get Dataset Stock Ohlcv Api Dataset  Name  Stocks  Code  Ohlcv Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7413,6 +7403,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7497,16 +7497,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7523,6 +7513,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7584,16 +7584,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7610,6 +7600,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7703,16 +7703,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7729,6 +7719,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7793,16 +7793,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7819,6 +7809,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7912,16 +7912,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -7938,6 +7928,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7999,16 +7999,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8025,6 +8015,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8150,16 +8150,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8176,6 +8166,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8296,16 +8296,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8322,6 +8312,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8372,16 +8372,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8398,6 +8388,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8448,16 +8448,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8474,6 +8464,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8527,16 +8527,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8553,6 +8543,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8612,16 +8612,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8638,6 +8628,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8736,16 +8736,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8762,6 +8752,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8808,16 +8808,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8834,6 +8824,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -8908,16 +8908,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -8934,6 +8924,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9004,16 +9004,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9030,6 +9020,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9076,16 +9076,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9102,6 +9092,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9146,16 +9146,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9172,6 +9162,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9217,16 +9217,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9243,6 +9233,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9291,16 +9291,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9317,6 +9307,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9419,16 +9419,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9445,6 +9435,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9491,16 +9491,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9517,6 +9507,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9571,16 +9571,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9597,6 +9587,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9641,16 +9641,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9667,6 +9657,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9723,16 +9723,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9749,6 +9739,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9814,16 +9814,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9840,6 +9830,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9893,16 +9893,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -9919,6 +9909,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -9984,16 +9984,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10010,6 +10000,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10063,16 +10063,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10089,6 +10079,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10135,16 +10135,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10161,6 +10151,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10228,16 +10228,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10254,6 +10244,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10356,16 +10356,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10382,6 +10372,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10428,16 +10428,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10454,6 +10444,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10508,16 +10508,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10534,6 +10524,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10578,16 +10578,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10604,6 +10594,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10660,16 +10660,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10686,6 +10676,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10741,16 +10741,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10767,6 +10757,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10814,16 +10814,6 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -10840,6 +10830,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -10913,22 +10913,22 @@
           },
           "open": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Open"
           },
           "high": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "High"
           },
           "low": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Low"
           },
           "close": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Close"
           }
         },
@@ -11124,19 +11124,19 @@
           },
           "shortMarginTradeVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Shortmargintradevolume"
           },
           "longMarginTradeVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Longmargintradevolume"
           },
           "shortMarginOutstandingBalance": {
             "anyOf": [
               {
                 "type": "number",
-                "minimum": 0.0
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -11148,7 +11148,7 @@
             "anyOf": [
               {
                 "type": "number",
-                "minimum": 0.0
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -11971,8 +11971,8 @@
           },
           "timeoutMinutes": {
             "type": "integer",
-            "maximum": 120.0,
-            "minimum": 1.0,
+            "maximum": 120,
+            "minimum": 1,
             "title": "Timeoutminutes",
             "description": "Build timeout in minutes",
             "default": 35
@@ -12286,7 +12286,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__dataset__DateRange"
               },
               {
                 "type": "null"
@@ -12334,19 +12334,19 @@
       },
       "DateRange": {
         "properties": {
-          "min": {
+          "from": {
             "type": "string",
-            "title": "Min"
+            "title": "From"
           },
-          "max": {
+          "to": {
             "type": "string",
-            "title": "Max"
+            "title": "To"
           }
         },
         "type": "object",
         "required": [
-          "min",
-          "max"
+          "from",
+          "to"
         ],
         "title": "DateRange"
       },
@@ -13138,8 +13138,8 @@
           },
           "trading_value_period": {
             "type": "integer",
-            "maximum": 250.0,
-            "minimum": 1.0,
+            "maximum": 250,
+            "minimum": 1,
             "title": "Trading Value Period",
             "description": "Rolling period (days) for market cap to trading value ratio",
             "default": 15
@@ -13303,31 +13303,31 @@
             "type": "number",
             "title": "Sharpe Ratio",
             "description": "シャープレシオ",
-            "default": 0.0
+            "default": 0
           },
           "calmar_ratio": {
             "type": "number",
             "title": "Calmar Ratio",
             "description": "カルマーレシオ",
-            "default": 0.0
+            "default": 0
           },
           "total_return": {
             "type": "number",
             "title": "Total Return",
             "description": "トータルリターン",
-            "default": 0.0
+            "default": 0
           },
           "max_drawdown": {
             "type": "number",
             "title": "Max Drawdown",
             "description": "最大ドローダウン",
-            "default": 0.0
+            "default": 0
           },
           "win_rate": {
             "type": "number",
             "title": "Win Rate",
             "description": "勝率",
-            "default": 0.0
+            "default": 0
           },
           "trade_count": {
             "type": "integer",
@@ -14293,16 +14293,16 @@
           },
           "generations": {
             "type": "integer",
-            "maximum": 100.0,
-            "minimum": 1.0,
+            "maximum": 100,
+            "minimum": 1,
             "title": "Generations",
             "description": "世代数",
             "default": 20
           },
           "population": {
             "type": "integer",
-            "maximum": 500.0,
-            "minimum": 10.0,
+            "maximum": 500,
+            "minimum": 10,
             "title": "Population",
             "description": "個体数",
             "default": 50
@@ -14319,16 +14319,16 @@
           },
           "random_add_entry_signals": {
             "type": "integer",
-            "maximum": 10.0,
-            "minimum": 0.0,
+            "maximum": 10,
+            "minimum": 0,
             "title": "Random Add Entry Signals",
             "description": "random_add時に追加するentryシグナル数（ベースに対する追加分）",
             "default": 1
           },
           "random_add_exit_signals": {
             "type": "integer",
-            "maximum": 10.0,
-            "minimum": 0.0,
+            "maximum": 10,
+            "minimum": 0,
             "title": "Random Add Exit Signals",
             "description": "random_add時に追加するexitシグナル数（ベースに対する追加分）",
             "default": 1
@@ -14465,16 +14465,16 @@
         "properties": {
           "count": {
             "type": "integer",
-            "maximum": 10000.0,
-            "minimum": 1.0,
+            "maximum": 10000,
+            "minimum": 1,
             "title": "Count",
             "description": "生成する戦略数",
             "default": 100
           },
           "top": {
             "type": "integer",
-            "maximum": 100.0,
-            "minimum": 1.0,
+            "maximum": 100,
+            "minimum": 1,
             "title": "Top",
             "description": "評価する上位戦略数",
             "default": 10
@@ -14672,7 +14672,7 @@
             "type": "number",
             "title": "Max Drawdown",
             "description": "最大ドローダウン",
-            "default": 0.0
+            "default": 0
           },
           "max_drawdown_duration_days": {
             "type": "integer",
@@ -14878,8 +14878,8 @@
           },
           "trials": {
             "type": "integer",
-            "maximum": 1000.0,
-            "minimum": 10.0,
+            "maximum": 1000,
+            "minimum": 10,
             "title": "Trials",
             "description": "試行回数",
             "default": 100
@@ -14907,16 +14907,16 @@
           },
           "random_add_entry_signals": {
             "type": "integer",
-            "maximum": 10.0,
-            "minimum": 0.0,
+            "maximum": 10,
+            "minimum": 0,
             "title": "Random Add Entry Signals",
             "description": "random_add時に追加するentryシグナル数（ベースに対する追加分）",
             "default": 1
           },
           "random_add_exit_signals": {
             "type": "integer",
-            "maximum": 10.0,
-            "minimum": 0.0,
+            "maximum": 10,
+            "minimum": 0,
             "title": "Random Add Exit Signals",
             "description": "random_add時に追加するexitシグナル数（ベースに対する追加分）",
             "default": 1
@@ -15099,7 +15099,7 @@
           },
           "avgVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Avgvolume"
           }
         },
@@ -15146,8 +15146,8 @@
           },
           "average_period": {
             "type": "integer",
-            "maximum": 200.0,
-            "minimum": 1.0,
+            "maximum": 200,
+            "minimum": 1,
             "title": "Average Period",
             "description": "出来高平均期間",
             "default": 15
@@ -15292,17 +15292,17 @@
           },
           "longVol": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Longvol"
           },
           "shortVol": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Shortvol"
           },
           "avgVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Avgvolume"
           }
         },
@@ -15327,7 +15327,7 @@
           },
           "averagePeriod": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Averageperiod",
             "description": "Rolling average period in days"
           },
@@ -15412,18 +15412,18 @@
           },
           "turnoverDays": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Turnoverdays",
             "description": "LongVol / N-day avg volume"
           },
           "longVol": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Longvol"
           },
           "avgVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Avgvolume"
           }
         },
@@ -15445,17 +15445,17 @@
           },
           "ratio": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Ratio"
           },
           "weeklyAvgVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Weeklyavgvolume"
           },
           "marginVolume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Marginvolume"
           }
         },
@@ -15906,27 +15906,33 @@
         "properties": {
           "date": {
             "type": "string",
-            "title": "Date"
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
           },
           "open": {
             "type": "number",
-            "title": "Open"
+            "title": "Open",
+            "description": "始値"
           },
           "high": {
             "type": "number",
-            "title": "High"
+            "title": "High",
+            "description": "高値"
           },
           "low": {
             "type": "number",
-            "title": "Low"
+            "title": "Low",
+            "description": "安値"
           },
           "close": {
             "type": "number",
-            "title": "Close"
+            "title": "Close",
+            "description": "終値"
           },
           "volume": {
-            "type": "integer",
-            "title": "Volume"
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
           }
         },
         "type": "object",
@@ -15938,7 +15944,8 @@
           "close",
           "volume"
         ],
-        "title": "OHLCVRecord"
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
       },
       "OHLCVResampleRequest": {
         "properties": {
@@ -16059,7 +16066,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__indicators__OHLCVRecord"
+              "$ref": "#/components/schemas/OHLCVRecord"
             },
             "type": "array",
             "title": "Data",
@@ -16382,6 +16389,44 @@
             "title": "Best Score",
             "description": "最良スコア"
           },
+          "best_params": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Best Params",
+            "description": "最良スコア時のパラメータ"
+          },
+          "worst_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worst Score",
+            "description": "最悪スコア"
+          },
+          "worst_params": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worst Params",
+            "description": "最悪スコア時のパラメータ"
+          },
           "total_combinations": {
             "anyOf": [
               {
@@ -16694,12 +16739,12 @@
           },
           "quantity": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Quantity"
           },
           "purchasePrice": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Purchaseprice"
           },
           "purchaseDate": {
@@ -16822,7 +16867,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "exclusiveMinimum": 0.0
+                "exclusiveMinimum": 0
               },
               {
                 "type": "null"
@@ -16834,7 +16879,7 @@
             "anyOf": [
               {
                 "type": "number",
-                "exclusiveMinimum": 0.0
+                "exclusiveMinimum": 0
               },
               {
                 "type": "null"
@@ -16949,7 +16994,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__portfolio_performance__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -18573,14 +18618,14 @@
           },
           "shapley_top_n": {
             "type": "integer",
-            "minimum": 1.0,
+            "minimum": 1,
             "title": "Shapley Top N",
             "description": "Shapley計算対象にする上位シグナル数",
             "default": 5
           },
           "shapley_permutations": {
             "type": "integer",
-            "minimum": 1.0,
+            "minimum": 1,
             "title": "Shapley Permutations",
             "description": "Shapley近似時の順列サンプル数",
             "default": 128
@@ -19660,27 +19705,27 @@
           },
           "open": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Open"
           },
           "high": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "High"
           },
           "low": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Low"
           },
           "close": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Close"
           },
           "volume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Volume",
             "default": 0
           }
@@ -19959,7 +20004,7 @@
           },
           "count": {
             "type": "integer",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Count"
           }
         },
@@ -20057,7 +20102,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "exclusiveMinimum": 0.0
+                "exclusiveMinimum": 0
               },
               {
                 "type": "null"
@@ -20069,7 +20114,7 @@
             "anyOf": [
               {
                 "type": "number",
-                "exclusiveMinimum": 0.0
+                "exclusiveMinimum": 0
               },
               {
                 "type": "null"
@@ -20694,27 +20739,27 @@
           },
           "open": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Open"
           },
           "high": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "High"
           },
           "low": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Low"
           },
           "close": {
             "type": "number",
-            "exclusiveMinimum": 0.0,
+            "exclusiveMinimum": 0,
             "title": "Close"
           },
           "volume": {
             "type": "number",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Volume",
             "default": 0
           }
@@ -21213,6 +21258,62 @@
         "type": "object",
         "title": "WatchlistUpdateRequest"
       },
+      "src__server__schemas__dataset__DateRange": {
+        "properties": {
+          "min": {
+            "type": "string",
+            "title": "Min"
+          },
+          "max": {
+            "type": "string",
+            "title": "Max"
+          }
+        },
+        "type": "object",
+        "required": [
+          "min",
+          "max"
+        ],
+        "title": "DateRange"
+      },
+      "src__server__schemas__dataset_data__OHLCVRecord": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date"
+          },
+          "open": {
+            "type": "number",
+            "title": "Open"
+          },
+          "high": {
+            "type": "number",
+            "title": "High"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close"
+          },
+          "volume": {
+            "type": "integer",
+            "title": "Volume"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
+        ],
+        "title": "OHLCVRecord"
+      },
       "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
@@ -21284,70 +21385,7 @@
         "title": "IndexMatch",
         "description": "指数マッチ結果"
       },
-      "src__server__schemas__indicators__OHLCVRecord": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
-          },
-          "open": {
-            "type": "number",
-            "title": "Open",
-            "description": "始値"
-          },
-          "high": {
-            "type": "number",
-            "title": "High",
-            "description": "高値"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low",
-            "description": "安値"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close",
-            "description": "終値"
-          },
-          "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
-        ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
-      },
       "src__server__schemas__portfolio_factor_regression__DateRange": {
-        "properties": {
-          "from": {
-            "type": "string",
-            "title": "From"
-          },
-          "to": {
-            "type": "string",
-            "title": "To"
-          }
-        },
-        "type": "object",
-        "required": [
-          "from",
-          "to"
-        ],
-        "title": "DateRange"
-      },
-      "src__server__schemas__portfolio_performance__DateRange": {
         "properties": {
           "from": {
             "type": "string",

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -2968,7 +2968,7 @@ export interface components {
              * @description Stocks with OHLCV data
              */
             stocksWithQuotes: number;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__dataset__DateRange"] | null;
             validation: components["schemas"]["DatasetValidation"];
         };
         /** DatasetValidation */
@@ -2982,10 +2982,10 @@ export interface components {
         };
         /** DateRange */
         DateRange: {
-            /** Min */
-            min: string;
-            /** Max */
-            max: string;
+            /** From */
+            from: string;
+            /** To */
+            to: string;
         };
         /**
          * DefaultConfigResponse
@@ -4799,19 +4799,40 @@ export interface components {
             /** Close */
             close: number;
         };
-        /** OHLCVRecord */
+        /**
+         * OHLCVRecord
+         * @description OHLCVレコード
+         */
         OHLCVRecord: {
-            /** Date */
+            /**
+             * Date
+             * @description 日付 (YYYY-MM-DD)
+             */
             date: string;
-            /** Open */
+            /**
+             * Open
+             * @description 始値
+             */
             open: number;
-            /** High */
+            /**
+             * High
+             * @description 高値
+             */
             high: number;
-            /** Low */
+            /**
+             * Low
+             * @description 安値
+             */
             low: number;
-            /** Close */
+            /**
+             * Close
+             * @description 終値
+             */
             close: number;
-            /** Volume */
+            /**
+             * Volume
+             * @description 出来高
+             */
             volume: number;
         };
         /**
@@ -4890,7 +4911,7 @@ export interface components {
              * Data
              * @description OHLCVデータ
              */
-            data: components["schemas"]["src__server__schemas__indicators__OHLCVRecord"][];
+            data: components["schemas"]["OHLCVRecord"][];
         };
         /**
          * OptimizationGridConfig
@@ -5104,6 +5125,25 @@ export interface components {
              */
             best_score?: number | null;
             /**
+             * Best Params
+             * @description 最良スコア時のパラメータ
+             */
+            best_params?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Worst Score
+             * @description 最悪スコア
+             */
+            worst_score?: number | null;
+            /**
+             * Worst Params
+             * @description 最悪スコア時のパラメータ
+             */
+            worst_params?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Total Combinations
              * @description パラメータ組み合わせ総数
              */
@@ -5302,7 +5342,7 @@ export interface components {
             benchmarkTimeSeries?: components["schemas"]["BenchmarkTimeSeriesPoint"][] | null;
             /** Analysisdate */
             analysisDate: string;
-            dateRange?: components["schemas"]["src__server__schemas__portfolio_performance__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             /** Datapoints */
             dataPoints: number;
             /** Warnings */
@@ -7114,6 +7154,28 @@ export interface components {
             description?: string | null;
         };
         /** DateRange */
+        src__server__schemas__dataset__DateRange: {
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
+        };
+        /** OHLCVRecord */
+        src__server__schemas__dataset_data__OHLCVRecord: {
+            /** Date */
+            date: string;
+            /** Open */
+            open: number;
+            /** High */
+            high: number;
+            /** Low */
+            low: number;
+            /** Close */
+            close: number;
+            /** Volume */
+            volume: number;
+        };
+        /** DateRange */
         src__server__schemas__db__DateRange: {
             /** Min */
             min: string;
@@ -7146,51 +7208,8 @@ export interface components {
             /** Beta */
             beta: number;
         };
-        /**
-         * OHLCVRecord
-         * @description OHLCVレコード
-         */
-        src__server__schemas__indicators__OHLCVRecord: {
-            /**
-             * Date
-             * @description 日付 (YYYY-MM-DD)
-             */
-            date: string;
-            /**
-             * Open
-             * @description 始値
-             */
-            open: number;
-            /**
-             * High
-             * @description 高値
-             */
-            high: number;
-            /**
-             * Low
-             * @description 安値
-             */
-            low: number;
-            /**
-             * Close
-             * @description 終値
-             */
-            close: number;
-            /**
-             * Volume
-             * @description 出来高
-             */
-            volume: number;
-        };
         /** DateRange */
         src__server__schemas__portfolio_factor_regression__DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
-        };
-        /** DateRange */
-        src__server__schemas__portfolio_performance__DateRange: {
             /** From */
             from: string;
             /** To */
@@ -12384,7 +12403,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: components["schemas"]["OHLCVRecord"][];
+                        [key: string]: components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                     };
                 };
             };
@@ -12447,7 +12466,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["OHLCVRecord"][];
+                    "application/json": components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                 };
             };
             /** @description Bad Request */

--- a/apps/ts/packages/web/src/components/Backtest/BacktestRunner.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/BacktestRunner.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { Play, Settings, Settings2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -22,6 +22,7 @@ import { DefaultConfigEditor } from './DefaultConfigEditor';
 import { JobProgressCard } from './JobProgressCard';
 import { OptimizationJobProgressCard } from './OptimizationJobProgressCard';
 import { StrategySelector } from './StrategySelector';
+import { extractGridParameterEntries, formatGridParameterValue } from './optimizationGridParams';
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: UI component with conditional rendering
 export function BacktestRunner() {
@@ -46,6 +47,10 @@ export function BacktestRunner() {
   const runOptimization = useRunOptimization();
   const { data: gridConfig } = useOptimizationGridConfig(
     selectedStrategy ? (selectedStrategy.split('/').pop() ?? selectedStrategy) : null
+  );
+  const gridParameterEntries = useMemo(
+    () => (gridConfig ? extractGridParameterEntries(gridConfig.content) : []),
+    [gridConfig]
   );
 
   useEffect(() => {
@@ -150,9 +155,22 @@ export function BacktestRunner() {
         </div>
 
         {gridConfig ? (
-          <p className="text-xs text-muted-foreground">
-            Grid config: {gridConfig.param_count} params, {gridConfig.combinations} combinations
-          </p>
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">
+              Grid config: {gridConfig.param_count} params, {gridConfig.combinations} combinations
+            </p>
+            {gridParameterEntries.length > 0 && (
+              <div className="max-h-32 overflow-auto rounded-md border border-border/50 bg-muted/20 p-2">
+                <ul className="space-y-1">
+                  {gridParameterEntries.map((entry) => (
+                    <li key={entry.path} className="text-xs font-mono text-muted-foreground break-all">
+                      {entry.path}: [{entry.values.map((value) => formatGridParameterValue(value)).join(', ')}]
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
         ) : (
           <p className="text-xs text-muted-foreground">
             No grid config found. Configure in Strategies &gt; Optimize tab.

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationJobProgressCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationJobProgressCard.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { OptimizationJobResponse } from '@/types/backtest';
+import { OptimizationJobProgressCard } from './OptimizationJobProgressCard';
+
+const baseJob: OptimizationJobResponse = {
+  job_id: 'opt-job-1',
+  status: 'completed',
+  progress: 1,
+  message: 'done',
+  created_at: '2026-02-17T10:00:00Z',
+  started_at: '2026-02-17T10:00:05Z',
+  completed_at: '2026-02-17T10:01:00Z',
+  error: null,
+  best_score: 1.0,
+  best_params: { period: 20, threshold: 0.4 },
+  worst_score: 0.12,
+  worst_params: { period: 5, threshold: 0.9 },
+  total_combinations: 9,
+  notebook_path: null,
+};
+
+function createJob(overrides: Partial<OptimizationJobResponse>): OptimizationJobResponse {
+  return {
+    ...baseJob,
+    ...overrides,
+  };
+}
+
+describe('OptimizationJobProgressCard', () => {
+  it('renders nothing when no job and not loading', () => {
+    const { container } = render(<OptimizationJobProgressCard job={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders submitting state while loading without job', () => {
+    render(<OptimizationJobProgressCard job={null} isLoading={true} />);
+    expect(screen.getByText('Submitting...')).toBeInTheDocument();
+  });
+
+  it('renders running state with progress message and elapsed timer', () => {
+    const job = createJob({
+      status: 'running',
+      message: 'trial 3/9',
+      best_params: null,
+      worst_params: null,
+    });
+
+    render(<OptimizationJobProgressCard job={job} />);
+
+    expect(screen.getByText('Optimizing')).toBeInTheDocument();
+    expect(screen.getByText('trial 3/9')).toBeInTheDocument();
+    expect(screen.getByText(/⏱/)).toBeInTheDocument();
+  });
+
+  it('renders failed state error', () => {
+    const job = createJob({
+      status: 'failed',
+      error: 'optimization failed',
+      best_params: null,
+      worst_params: null,
+    });
+
+    render(<OptimizationJobProgressCard job={job} />);
+
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('optimization failed')).toBeInTheDocument();
+  });
+
+  it('renders cancelled state label', () => {
+    const job = createJob({
+      status: 'cancelled',
+      best_params: null,
+      worst_params: null,
+    });
+
+    render(<OptimizationJobProgressCard job={job} />);
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+  });
+
+  it('handles unknown status defensively', () => {
+    const job = createJob({
+      status: 'unknown' as OptimizationJobResponse['status'],
+      best_params: null,
+      worst_params: null,
+    });
+
+    const { container } = render(<OptimizationJobProgressCard job={job} />);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it('renders best/worst params and scores for completed jobs', () => {
+    render(<OptimizationJobProgressCard job={baseJob} />);
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('Combinations:')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
+    expect(screen.getByText('Best Params')).toBeInTheDocument();
+    expect(screen.getByText('Worst Params')).toBeInTheDocument();
+    expect(screen.getByText('score: 1.0000')).toBeInTheDocument();
+    expect(screen.getByText('score: 0.1200')).toBeInTheDocument();
+    expect(screen.getByText(/"period": 20/)).toBeInTheDocument();
+    expect(screen.getByText(/"period": 5/)).toBeInTheDocument();
+  });
+
+  it('falls back to score-only summary when params are unavailable', () => {
+    const job = createJob({
+      best_params: null,
+      worst_params: null,
+      best_score: 0.82,
+      worst_score: 0.11,
+    });
+
+    render(<OptimizationJobProgressCard job={job} />);
+
+    expect(screen.getByText('Best Score:')).toBeInTheDocument();
+    expect(screen.getByText('Worst Score:')).toBeInTheDocument();
+    expect(screen.getByText('0.8200')).toBeInTheDocument();
+    expect(screen.getByText('0.1100')).toBeInTheDocument();
+  });
+
+  it('shows score fallback for only the missing param side', () => {
+    const job = createJob({
+      best_params: { period: 20 },
+      best_score: 0.9,
+      worst_params: null,
+      worst_score: 0.2,
+    });
+
+    render(<OptimizationJobProgressCard job={job} />);
+
+    expect(screen.getByText('Best Params')).toBeInTheDocument();
+    expect(screen.getByText('score: 0.9000')).toBeInTheDocument();
+    expect(screen.getByText('Worst Score:')).toBeInTheDocument();
+    expect(screen.getByText('0.2000')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationJobProgressCard.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationJobProgressCard.tsx
@@ -8,6 +8,17 @@ interface OptimizationJobProgressCardProps {
   isLoading?: boolean;
 }
 
+function formatScore(score: number | null | undefined): string {
+  return score != null ? score.toFixed(4) : '-';
+}
+
+function stringifyParams(params: Record<string, unknown> | null | undefined): string | null {
+  if (!params || Object.keys(params).length === 0) {
+    return null;
+  }
+  return JSON.stringify(params, null, 2);
+}
+
 function StatusIcon({ status }: { status: JobStatus }) {
   switch (status) {
     case 'pending':
@@ -73,6 +84,9 @@ export function OptimizationJobProgressCard({ job, isLoading }: OptimizationJobP
     return `${m}:${String(sec).padStart(2, '0')}`;
   };
 
+  const bestParamsText = stringifyParams(job.best_params);
+  const worstParamsText = stringifyParams(job.worst_params);
+
   return (
     <Card className="mt-2">
       <CardHeader className="pb-3">
@@ -99,21 +113,50 @@ export function OptimizationJobProgressCard({ job, isLoading }: OptimizationJobP
 
         {/* Completed result summary */}
         {job.status === 'completed' && (
-          <div className="space-y-2 text-sm">
-            <div className="grid grid-cols-2 gap-2">
-              {job.best_score != null && (
-                <div>
-                  <span className="text-muted-foreground">Best Score:</span>
-                  <span className="ml-2 font-medium">{job.best_score.toFixed(4)}</span>
+          <div className="space-y-3 text-sm">
+            {job.total_combinations != null && (
+              <div>
+                <span className="text-muted-foreground">Combinations:</span>
+                <span className="ml-2 font-medium">{job.total_combinations}</span>
+              </div>
+            )}
+
+            {bestParamsText && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">Best Params</span>
+                  <span className="font-medium">score: {formatScore(job.best_score)}</span>
                 </div>
-              )}
-              {job.total_combinations != null && (
-                <div>
-                  <span className="text-muted-foreground">Combinations:</span>
-                  <span className="ml-2 font-medium">{job.total_combinations}</span>
+                <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-2 text-xs whitespace-pre-wrap break-all">
+                  {bestParamsText}
+                </pre>
+              </div>
+            )}
+
+            {worstParamsText && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">Worst Params</span>
+                  <span className="font-medium">score: {formatScore(job.worst_score)}</span>
                 </div>
-              )}
-            </div>
+                <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-2 text-xs whitespace-pre-wrap break-all">
+                  {worstParamsText}
+                </pre>
+              </div>
+            )}
+
+            {!bestParamsText && job.best_score != null && (
+              <div>
+                <span className="text-muted-foreground">Best Score:</span>
+                <span className="ml-2 font-medium">{formatScore(job.best_score)}</span>
+              </div>
+            )}
+            {!worstParamsText && job.worst_score != null && (
+              <div>
+                <span className="text-muted-foreground">Worst Score:</span>
+                <span className="ml-2 font-medium">{formatScore(job.worst_score)}</span>
+              </div>
+            )}
           </div>
         )}
 

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationJobProgressCard.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationJobProgressCard.tsx
@@ -19,6 +19,64 @@ function stringifyParams(params: Record<string, unknown> | null | undefined): st
   return JSON.stringify(params, null, 2);
 }
 
+function CompletedSummary({
+  job,
+  bestParamsText,
+  worstParamsText,
+}: {
+  job: OptimizationJobResponse;
+  bestParamsText: string | null;
+  worstParamsText: string | null;
+}) {
+  return (
+    <div className="space-y-3 text-sm">
+      {job.total_combinations != null && (
+        <div>
+          <span className="text-muted-foreground">Combinations:</span>
+          <span className="ml-2 font-medium">{job.total_combinations}</span>
+        </div>
+      )}
+
+      {bestParamsText && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Best Params</span>
+            <span className="font-medium">score: {formatScore(job.best_score)}</span>
+          </div>
+          <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-2 text-xs whitespace-pre-wrap break-all">
+            {bestParamsText}
+          </pre>
+        </div>
+      )}
+
+      {worstParamsText && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Worst Params</span>
+            <span className="font-medium">score: {formatScore(job.worst_score)}</span>
+          </div>
+          <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-2 text-xs whitespace-pre-wrap break-all">
+            {worstParamsText}
+          </pre>
+        </div>
+      )}
+
+      {!bestParamsText && job.best_score != null && (
+        <div>
+          <span className="text-muted-foreground">Best Score:</span>
+          <span className="ml-2 font-medium">{formatScore(job.best_score)}</span>
+        </div>
+      )}
+      {!worstParamsText && job.worst_score != null && (
+        <div>
+          <span className="text-muted-foreground">Worst Score:</span>
+          <span className="ml-2 font-medium">{formatScore(job.worst_score)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function StatusIcon({ status }: { status: JobStatus }) {
   switch (status) {
     case 'pending':
@@ -113,51 +171,7 @@ export function OptimizationJobProgressCard({ job, isLoading }: OptimizationJobP
 
         {/* Completed result summary */}
         {job.status === 'completed' && (
-          <div className="space-y-3 text-sm">
-            {job.total_combinations != null && (
-              <div>
-                <span className="text-muted-foreground">Combinations:</span>
-                <span className="ml-2 font-medium">{job.total_combinations}</span>
-              </div>
-            )}
-
-            {bestParamsText && (
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground">Best Params</span>
-                  <span className="font-medium">score: {formatScore(job.best_score)}</span>
-                </div>
-                <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-2 text-xs whitespace-pre-wrap break-all">
-                  {bestParamsText}
-                </pre>
-              </div>
-            )}
-
-            {worstParamsText && (
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground">Worst Params</span>
-                  <span className="font-medium">score: {formatScore(job.worst_score)}</span>
-                </div>
-                <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-2 text-xs whitespace-pre-wrap break-all">
-                  {worstParamsText}
-                </pre>
-              </div>
-            )}
-
-            {!bestParamsText && job.best_score != null && (
-              <div>
-                <span className="text-muted-foreground">Best Score:</span>
-                <span className="ml-2 font-medium">{formatScore(job.best_score)}</span>
-              </div>
-            )}
-            {!worstParamsText && job.worst_score != null && (
-              <div>
-                <span className="text-muted-foreground">Worst Score:</span>
-                <span className="ml-2 font-medium">{formatScore(job.worst_score)}</span>
-              </div>
-            )}
-          </div>
+          <CompletedSummary job={job} bestParamsText={bestParamsText} worstParamsText={worstParamsText} />
         )}
 
         {/* Failed error */}

--- a/apps/ts/packages/web/src/components/Backtest/optimizationGridParams.test.ts
+++ b/apps/ts/packages/web/src/components/Backtest/optimizationGridParams.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { extractGridParameterEntries, formatGridParameterValue } from './optimizationGridParams';
+
+describe('optimizationGridParams', () => {
+  it('extracts nested parameter ranges from grid yaml', () => {
+    const yamlContent = `
+parameter_ranges:
+  entry_filter_params:
+    period_breakout:
+      period: [10, 20, 30]
+  exit_trigger_params:
+    atr_stop:
+      atr_multiplier: [1.5, 2.0]
+`;
+
+    expect(extractGridParameterEntries(yamlContent)).toEqual([
+      {
+        path: 'entry_filter_params.period_breakout.period',
+        values: [10, 20, 30],
+      },
+      {
+        path: 'exit_trigger_params.atr_stop.atr_multiplier',
+        values: [1.5, 2.0],
+      },
+    ]);
+  });
+
+  it('returns empty array for invalid yaml', () => {
+    expect(extractGridParameterEntries('invalid: [yaml')).toEqual([]);
+  });
+
+  it('formats parameter values for display', () => {
+    expect(formatGridParameterValue(undefined)).toBe('undefined');
+    expect(formatGridParameterValue('prime')).toBe('"prime"');
+    expect(formatGridParameterValue(5)).toBe('5');
+    expect(formatGridParameterValue(true)).toBe('true');
+    expect(formatGridParameterValue({ min: 1 })).toBe('{"min":1}');
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/optimizationGridParams.ts
+++ b/apps/ts/packages/web/src/components/Backtest/optimizationGridParams.ts
@@ -1,0 +1,72 @@
+import yaml from 'js-yaml';
+
+export interface GridParameterEntry {
+  path: string;
+  values: unknown[];
+}
+
+type RecordLike = Record<string, unknown>;
+
+function isRecordLike(value: unknown): value is RecordLike {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function extractGridParameterEntries(content: string): GridParameterEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(content);
+  } catch {
+    return [];
+  }
+
+  if (!isRecordLike(parsed)) {
+    return [];
+  }
+
+  const parameterRanges = parsed.parameter_ranges;
+  if (!isRecordLike(parameterRanges)) {
+    return [];
+  }
+
+  const entries: GridParameterEntry[] = [];
+  const walk = (node: RecordLike, prefix: string[]) => {
+    for (const [key, value] of Object.entries(node)) {
+      const currentPath = [...prefix, key];
+
+      if (Array.isArray(value)) {
+        entries.push({
+          path: currentPath.join('.'),
+          values: value,
+        });
+        continue;
+      }
+
+      if (isRecordLike(value)) {
+        walk(value, currentPath);
+      }
+    }
+  };
+
+  walk(parameterRanges, []);
+  return entries;
+}
+
+export function formatGridParameterValue(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
## Summary
- extend optimize job response with best_params, worst_score, and worst_params
- show concrete grid parameter_ranges values in Backtest Runner optimization section
- replace score-only completion summary with best/worst params + scores in optimization progress card
- add focused unit tests for optimization service and web components/utilities
- update AGENTS.md to document the new optimization UI/API behavior

## Testing
- uv run ruff check src/server/schemas/optimize.py src/server/services/job_manager.py src/server/services/optimization_service.py src/server/routes/optimize.py tests/unit/server/routes/test_optimize.py tests/unit/server/services/test_optimization_service.py
- uv run pytest tests/unit/server/services/test_optimization_service.py tests/unit/server/routes/test_optimize.py
- uv run pytest tests/unit/server/services/test_optimization_service.py --cov=src.server.services.optimization_service --cov-branch --cov-report=term-missing
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/clients-ts typecheck
- bun run --filter @trading25/web test -- src/components/Backtest/optimizationGridParams.test.ts src/components/Backtest/OptimizationJobProgressCard.test.tsx
- bun run --filter @trading25/web test:coverage -- src/components/Backtest/optimizationGridParams.test.ts src/components/Backtest/OptimizationJobProgressCard.test.tsx --coverage.include=src/components/Backtest/optimizationGridParams.ts --coverage.include=src/components/Backtest/OptimizationJobProgressCard.tsx --coverage.reporter=text