### PR TITLE
feat: replace screening with production-strategy YAML pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新し、`/indices` 取得失敗時は日付指定フォールバックで継続する（`indices-only` は指数再同期専用モード）。フォールバック時は不足 `index_master` をプレースホルダ補完して、FK 制約付きの既存DBでも継続可能にする
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
+- `/api/analytics/screening` は production 戦略YAML駆動（SignalProcessor で entry/exit 両方判定）を SoT とし、銘柄集約（`bestStrategyName`/`bestStrategyScore`/`matchStrategyCount`/`matchedStrategies`）で返却する。旧 `rangeBreakFast/Slow` クエリ互換は廃止済み
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う
 - **ts/web** は `/api` パスを FastAPI (:3002) にプロキシ
@@ -129,6 +130,7 @@ bun run cli backtest attribution run <strategy> --wait
 
 - Backtest UI は `Attribution` サブタブ内に `Run` / `History` を持ち、進捗取得は 2 秒ポーリング
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
+- `analysis screening`（web/cli）は production 戦略を動的選択し、`backtestMetric`（`sharpe_ratio` 等）と `sortBy`（`bestStrategyScore`/`matchedDate`/`stockCode`/`matchStrategyCount`）で結果を制御する。`null` score は並び順に関係なく末尾
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ uv run bt lab optimize experimental/base_strategy_01 --trials 50 --structure-mod
 - API では `/api/lab/evolve` と `/api/lab/optimize` に `structure_mode` / `random_add_*` / `seed` も指定可能
 - Web の Backtest > Lab ページでも `evolve` / `optimize` に同じ `structure_mode` 設定を反映済み
 
+### 5) Analysis Screening（戦略YAML駆動）
+`/api/analytics/screening` は production 戦略YAMLに基づく動的スクリーニングへ移行済みです。
+
+- Web: Analysis > Screening で production 戦略を動的選択（未選択=全production）
+- CLI:
+```bash
+cd apps/ts
+bun run cli analysis screening --strategies production/forward_eps_driven --backtest-metric sharpe_ratio --sort-by bestStrategyScore
+```
+- クエリは `markets`, `strategies`, `recentDays`, `date`, `backtestMetric`, `sortBy`, `order`, `limit`
+- 旧 `rangeBreakFast/Slow`, `minBreakPercentage`, `minVolumeRatio` は廃止（後方互換なし）
+
 ## Monorepo Commands (root)
 
 ```bash

--- a/apps/bt/src/server/services/screening_service.py
+++ b/apps/bt/src/server/services/screening_service.py
@@ -1,349 +1,650 @@
 """
 Screening Service
 
-レンジブレイク検出サービス。
-Hono ScreeningEngine / MarketScreeningService 互換。
+production戦略YAML駆動の動的スクリーニングサービス。
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 
-from src.lib.market_db.market_reader import MarketDbReader
-from src.server.services.market_code_alias import resolve_market_codes
-from src.server.schemas.screening import (
-    MarketScreeningResponse,
-    RangeBreakDetails,
-    ScreeningDetails,
-    ScreeningResultItem,
-    ScreeningSummary,
+import pandas as pd
+from loguru import logger
+
+from src.data.access.mode import data_access_mode_context
+from src.data.loaders import (
+    get_stock_sector_mapping,
+    load_all_sector_indices,
+    load_topix_data,
+    prepare_multi_data,
 )
+from src.lib.market_db.market_reader import MarketDbReader
+from src.lib.market_db.query_helpers import normalize_stock_code
+from src.lib.strategy_runtime.loader import ConfigLoader
+from src.models.config import SharedConfig
+from src.models.signals import SignalParams, Signals
+from src.paths import get_backtest_results_dir
+from src.server.schemas.screening import (
+    BacktestMetric,
+    MarketScreeningResponse,
+    MatchedStrategyItem,
+    ScreeningResultItem,
+    ScreeningSortBy,
+    ScreeningSummary,
+    SortOrder,
+)
+from src.server.services.market_code_alias import resolve_market_codes
+from src.strategies.signals.processor import SignalProcessor
+from src.strategies.signals.registry import SIGNAL_REGISTRY
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-@dataclass
-class StockDataPoint:
-    """OHLCV データポイント"""
-
-    date: str
-    open: float
-    high: float
-    low: float
-    close: float
-    volume: float
+def _format_date(value: Any) -> str:
+    """Datetime/文字列をYYYY-MM-DDへ正規化する。"""
+    if hasattr(value, "strftime"):
+        return value.strftime("%Y-%m-%d")
+    text = str(value)
+    return text.split("T", 1)[0]
 
 
-@dataclass
-class RangeBreakParams:
-    """レンジブレイクパラメータ"""
-
-    period: int = 200
-    lookback_days: int = 10
-    volume_ratio_threshold: float = 1.7
-    volume_short_period: int = 30
-    volume_long_period: int = 120
-    volume_type: str = "ema"  # "sma" or "ema"
+@dataclass(frozen=True)
+class StockUniverseItem:
+    code: str
+    company_name: str
+    scale_category: str | None
+    sector_33_name: str | None
 
 
-# デフォルト設定
-DEFAULT_FAST_PARAMS = RangeBreakParams(
-    period=200, lookback_days=10,
-    volume_ratio_threshold=1.7, volume_short_period=30, volume_long_period=120,
-    volume_type="ema",
-)
-
-DEFAULT_SLOW_PARAMS = RangeBreakParams(
-    period=200, lookback_days=10,
-    volume_ratio_threshold=1.7, volume_short_period=50, volume_long_period=150,
-    volume_type="sma",
-)
-
-
-# --- Volume utilities ---
-
-
-def _sma(values: list[float], period: int) -> list[float]:
-    """Simple Moving Average"""
-    if period <= 0 or len(values) < period:
-        return []
-    result: list[float] = []
-    s = sum(values[:period])
-    result.append(s / period)
-    for i in range(1, len(values) - period + 1):
-        s = s - values[i - 1] + values[i + period - 1]
-        result.append(s / period)
-    return result
-
-
-def _ema(values: list[float], period: int) -> list[float]:
-    """Exponential Moving Average"""
-    if period <= 0 or len(values) < period:
-        return []
-    multiplier = 2.0 / (period + 1)
-    s = sum(values[:period]) / period
-    result = [s]
-    for i in range(period, len(values)):
-        s = (values[i] - s) * multiplier + s
-        result.append(s)
-    return result
-
-
-def _get_volume_avg(
-    data: list[StockDataPoint], period: int, end_index: int, vol_type: str
-) -> float | None:
-    """指定インデックスにおけるボリュームMA値を取得"""
-    if end_index < period - 1 or end_index >= len(data):
-        return None
-
-    volumes = [d.volume for d in data]
-    ma = _ema(volumes, period) if vol_type == "ema" else _sma(volumes, period)
-
-    # ma のインデックス = end_index - period + 1
-    ma_index = end_index - period + 1
-    if ma_index < 0 or ma_index >= len(ma):
-        return None
-    return ma[ma_index]
-
-
-def _check_volume_condition(
-    data: list[StockDataPoint],
-    params: RangeBreakParams,
-    index: int,
-) -> tuple[bool, float, float, float]:
-    """ボリューム条件チェック。(matched, ratio, short_avg, long_avg) を返す"""
-    short_avg = _get_volume_avg(data, params.volume_short_period, index, params.volume_type)
-    long_avg = _get_volume_avg(data, params.volume_long_period, index, params.volume_type)
-
-    if short_avg is None or long_avg is None or long_avg <= 0:
-        return False, 0.0, 0.0, 0.0
-
-    matched = short_avg > long_avg * params.volume_ratio_threshold
-    ratio = short_avg / long_avg if long_avg > 0 else 0.0
-    return matched, ratio, short_avg, long_avg
-
-
-# --- Range break detection ---
-
-
-def _find_max_high(data: list[StockDataPoint], start: int, end: int) -> float:
-    """範囲内の最大高値"""
-    if start < 0 or end >= len(data) or start > end:
-        return 0.0
-    return max(data[i].high for i in range(start, end + 1))
-
-
-def _detect_range_break(
-    data: list[StockDataPoint],
-    params: RangeBreakParams,
-    recent_days: int,
-) -> RangeBreakDetails | None:
-    """レンジブレイクを検出"""
-    if len(data) < params.period + recent_days:
-        return None
-
-    end_index = len(data) - 1
-    start_index = max(params.period, end_index - recent_days + 1)
-
-    for i in range(end_index, start_index - 1, -1):
-        if i < params.period:
-            continue
-
-        # Recent max high
-        recent_start = i - params.lookback_days + 1
-        recent_max = _find_max_high(data, recent_start, i)
-
-        # Period max high (before lookback)
-        period_start = i - params.period
-        period_end = i - params.lookback_days
-        period_max = _find_max_high(data, period_start, period_end)
-
-        if period_max <= 0 or recent_max <= 0:
-            continue
-
-        if recent_max >= period_max:
-            # ボリューム条件チェック
-            matched, ratio, short_avg, long_avg = _check_volume_condition(data, params, i)
-            if matched:
-                break_pct = ((recent_max - period_max) / period_max) * 100
-                return RangeBreakDetails(
-                    breakDate=data[i].date,
-                    currentHigh=recent_max,
-                    maxHighInLookback=period_max,
-                    breakPercentage=break_pct,
-                    volumeRatio=ratio,
-                    avgVolume20Days=short_avg,
-                    avgVolume100Days=long_avg,
-                )
-
-    return None
+@dataclass(frozen=True)
+class StrategyRuntime:
+    name: str
+    response_name: str
+    basename: str
+    entry_params: SignalParams
+    exit_params: SignalParams
+    shared_config: SharedConfig
 
 
 class ScreeningService:
-    """スクリーニングサービス"""
+    """戦略YAML駆動のスクリーニングサービス"""
+
+    _WARNING_LIMIT = 50
 
     def __init__(self, reader: MarketDbReader) -> None:
         self._reader = reader
+        self._config_loader = ConfigLoader()
+        self._signal_processor = SignalProcessor()
 
     def run_screening(
         self,
         markets: str = "prime",
-        range_break_fast: bool = True,
-        range_break_slow: bool = True,
+        strategies: str | None = None,
         recent_days: int = 10,
         reference_date: str | None = None,
-        min_break_percentage: float | None = None,
-        min_volume_ratio: float | None = None,
-        sort_by: str = "date",
-        order: str = "desc",
+        backtest_metric: BacktestMetric = "sharpe_ratio",
+        sort_by: ScreeningSortBy = "bestStrategyScore",
+        order: SortOrder = "desc",
         limit: int | None = None,
     ) -> MarketScreeningResponse:
         """スクリーニングを実行"""
         requested_market_codes, query_market_codes = resolve_market_codes(markets)
 
-        # 銘柄データをロード
-        stocks = self._load_stocks(query_market_codes)
+        stock_universe = self._load_stock_universe(query_market_codes)
+        strategy_runtimes = self._resolve_strategies(strategies)
+        strategy_scores, missing_metric_strategies, metric_warnings = self._load_strategy_scores(
+            strategy_runtimes,
+            backtest_metric,
+        )
 
-        results: list[ScreeningResultItem] = []
-        skipped = 0
-        type_counts: dict[str, int] = {"rangeBreakFast": 0, "rangeBreakSlow": 0}
+        warnings: list[str] = list(metric_warnings)
+        by_strategy = {s.response_name: 0 for s in strategy_runtimes}
+        processed_codes: set[str] = set()
 
-        for stock_info, data in stocks:
-            # reference_date でデータを切り詰め
-            if reference_date:
-                data = [d for d in data if d.date <= reference_date]
+        aggregated: dict[str, dict[str, Any]] = {}
 
-            if len(data) < 220:  # period(200) + some margin
-                skipped += 1
+        for strategy in strategy_runtimes:
+            try:
+                matched_rows, processed, strategy_warnings = self._evaluate_strategy(
+                    strategy,
+                    stock_universe,
+                    recent_days,
+                    reference_date,
+                )
+            except Exception as exc:
+                logger.exception(f"Strategy screening failed: {strategy.name}")
+                warnings.append(f"{strategy.response_name}: evaluation failed ({exc})")
                 continue
 
-            # Range Break Fast
-            if range_break_fast:
-                details = _detect_range_break(data, DEFAULT_FAST_PARAMS, recent_days)
-                if details:
-                    self._maybe_add_result(
-                        results, stock_info, "rangeBreakFast", details,
-                        min_break_percentage, min_volume_ratio,
+            processed_codes |= processed
+            warnings.extend(strategy_warnings)
+
+            strategy_score = strategy_scores.get(strategy.response_name)
+            for stock, matched_date in matched_rows:
+                by_strategy[strategy.response_name] += 1
+
+                existing = aggregated.get(stock.code)
+                if existing is None:
+                    existing = {
+                        "stock": stock,
+                        "matchedDate": matched_date,
+                        "matchedStrategies": [],
+                    }
+                    aggregated[stock.code] = existing
+                elif matched_date > existing["matchedDate"]:
+                    existing["matchedDate"] = matched_date
+
+                existing["matchedStrategies"].append(
+                    MatchedStrategyItem(
+                        strategyName=strategy.response_name,
+                        matchedDate=matched_date,
+                        strategyScore=strategy_score,
                     )
-                    type_counts["rangeBreakFast"] += 1
+                )
 
-            # Range Break Slow
-            if range_break_slow:
-                details = _detect_range_break(data, DEFAULT_SLOW_PARAMS, recent_days)
-                if details:
-                    self._maybe_add_result(
-                        results, stock_info, "rangeBreakSlow", details,
-                        min_break_percentage, min_volume_ratio,
-                    )
-                    type_counts["rangeBreakSlow"] += 1
+        all_results = [self._build_result_item(item) for item in aggregated.values()]
+        sorted_results = self._sort_results(all_results, sort_by=sort_by, order=order)
 
-        # ソート
-        results = self._sort_results(results, sort_by, order)
-
-        # リミット
+        match_count = len(sorted_results)
         if limit is not None and limit > 0:
-            results = results[:limit]
+            sorted_results = sorted_results[:limit]
 
-        total_screened = len(stocks)
-        match_count = len(results)
+        summary = ScreeningSummary(
+            totalStocksScreened=len(stock_universe),
+            matchCount=match_count,
+            skippedCount=max(0, len(stock_universe) - len(processed_codes)),
+            byStrategy=by_strategy,
+            strategiesEvaluated=[s.response_name for s in strategy_runtimes],
+            strategiesWithoutBacktestMetrics=missing_metric_strategies,
+            warnings=self._dedupe_warnings(warnings),
+        )
 
         return MarketScreeningResponse(
-            results=results,
-            summary=ScreeningSummary(
-                totalStocksScreened=total_screened,
-                matchCount=match_count,
-                skippedCount=skipped,
-                byScreeningType=type_counts,
-            ),
+            results=sorted_results,
+            summary=summary,
             markets=requested_market_codes,
             recentDays=recent_days,
             referenceDate=reference_date,
+            backtestMetric=backtest_metric,
+            sortBy=sort_by,
+            order=order,
             lastUpdated=_now_iso(),
         )
 
-    def _load_stocks(
-        self, market_codes: list[str]
-    ) -> list[tuple[dict, list[StockDataPoint]]]:
-        """銘柄とOHLCVデータをロード"""
+    def _load_stock_universe(self, market_codes: list[str]) -> list[StockUniverseItem]:
+        """市場フィルタ済み銘柄母集団を読み込む。"""
         if not market_codes:
             return []
 
-        # マーケットフィルタ
         placeholders = ",".join("?" for _ in market_codes)
-        stocks_rows = self._reader.query(
-            f"""SELECT code, company_name, scale_category, sector_33_name
-            FROM stocks WHERE market_code IN ({placeholders})""",
+        rows = self._reader.query(
+            f"""
+            SELECT code, company_name, scale_category, sector_33_name
+            FROM stocks
+            WHERE market_code IN ({placeholders})
+            ORDER BY code
+            """,
             tuple(market_codes),
         )
 
-        result: list[tuple[dict, list[StockDataPoint]]] = []
-        for stock in stocks_rows:
-            ohlcv_rows = self._reader.query(
-                "SELECT date, open, high, low, close, volume FROM stock_data WHERE code = ? ORDER BY date",
-                (stock["code"],),
+        deduped: dict[str, StockUniverseItem] = {}
+        for row in rows:
+            code = normalize_stock_code(str(row["code"]))
+            if code in deduped:
+                continue
+            deduped[code] = StockUniverseItem(
+                code=code,
+                company_name=row["company_name"],
+                scale_category=row["scale_category"],
+                sector_33_name=row["sector_33_name"],
             )
-            data = [
-                StockDataPoint(
-                    date=r["date"],
-                    open=r["open"],
-                    high=r["high"],
-                    low=r["low"],
-                    close=r["close"],
-                    volume=r["volume"],
+
+        return list(deduped.values())
+
+    def _resolve_strategies(self, strategies: str | None) -> list[StrategyRuntime]:
+        """対象戦略をproductionカテゴリから解決する。"""
+        metadata = [m for m in self._config_loader.get_strategy_metadata() if m.category == "production"]
+        if not metadata:
+            raise ValueError("No production strategies found")
+
+        metadata_by_name = {m.name: m for m in metadata}
+        basename_map: dict[str, list[str]] = {}
+        for m in metadata:
+            basename_map.setdefault(m.path.stem, []).append(m.name)
+
+        selected_names: list[str]
+        if strategies is None or not strategies.strip():
+            selected_names = sorted(metadata_by_name.keys())
+        else:
+            requested = [s.strip() for s in strategies.split(",") if s.strip()]
+            selected_names = []
+            invalid: list[str] = []
+
+            for token in requested:
+                resolved = self._resolve_strategy_token(token, metadata_by_name, basename_map)
+                if resolved is None:
+                    invalid.append(token)
+                    continue
+                if resolved not in selected_names:
+                    selected_names.append(resolved)
+
+            if invalid:
+                raise ValueError(
+                    "Invalid strategies (production only): " + ", ".join(sorted(set(invalid)))
                 )
-                for r in ohlcv_rows
-            ]
-            result.append((dict(stock), data))
 
-        return result
+        if not selected_names:
+            raise ValueError("No valid production strategies selected")
 
-    def _maybe_add_result(
+        selected_metadata = [metadata_by_name[name] for name in selected_names]
+
+        # basename重複時はフルネームをレスポンス名に使用
+        basename_counts: dict[str, int] = {}
+        for m in selected_metadata:
+            basename_counts[m.path.stem] = basename_counts.get(m.path.stem, 0) + 1
+
+        runtimes: list[StrategyRuntime] = []
+        for m in selected_metadata:
+            config = self._config_loader.load_strategy_config(m.name)
+            shared_config_dict = self._config_loader.merge_shared_config(config)
+
+            response_name = m.path.stem
+            if basename_counts[response_name] > 1:
+                response_name = m.name
+
+            runtimes.append(
+                StrategyRuntime(
+                    name=m.name,
+                    response_name=response_name,
+                    basename=m.path.stem,
+                    entry_params=SignalParams(**config.get("entry_filter_params", {})),
+                    exit_params=SignalParams(**config.get("exit_trigger_params", {})),
+                    shared_config=SharedConfig.model_validate(
+                        shared_config_dict,
+                        context={"resolve_stock_codes": False},
+                    ),
+                )
+            )
+
+        return runtimes
+
+    def _resolve_strategy_token(
         self,
-        results: list[ScreeningResultItem],
-        stock_info: dict,
-        screening_type: str,
-        details: RangeBreakDetails,
-        min_break_pct: float | None,
-        min_vol_ratio: float | None,
-    ) -> None:
-        """フィルタ適用してresultsに追加"""
-        if min_break_pct is not None and details.breakPercentage < min_break_pct:
-            return
-        if min_vol_ratio is not None and details.volumeRatio < min_vol_ratio:
-            return
+        token: str,
+        metadata_by_name: dict[str, Any],
+        basename_map: dict[str, list[str]],
+    ) -> str | None:
+        """クエリ指定戦略名をproduction戦略へ解決する。"""
+        if token in metadata_by_name:
+            return token
 
-        results.append(
-            ScreeningResultItem(
-                stockCode=stock_info["code"][:4],
-                companyName=stock_info["company_name"],
-                scaleCategory=stock_info.get("scale_category"),
-                sector33Name=stock_info.get("sector_33_name"),
-                screeningType=screening_type,
-                matchedDate=details.breakDate,
-                details=ScreeningDetails(rangeBreak=details),
+        if token.startswith("production/"):
+            return token if token in metadata_by_name else None
+
+        production_prefixed = f"production/{token}"
+        if production_prefixed in metadata_by_name:
+            return production_prefixed
+
+        candidates = basename_map.get(token, [])
+        if len(candidates) == 1:
+            return candidates[0]
+
+        return None
+
+    def _load_strategy_scores(
+        self,
+        strategies: list[StrategyRuntime],
+        metric: BacktestMetric,
+    ) -> tuple[dict[str, float | None], list[str], list[str]]:
+        """各戦略の最新バックテスト指標を取得する。"""
+        scores: dict[str, float | None] = {}
+        missing: list[str] = []
+        warnings: list[str] = []
+
+        for strategy in strategies:
+            score, warning = self._load_latest_metric(strategy.basename, metric)
+            scores[strategy.response_name] = score
+            if score is None:
+                missing.append(strategy.response_name)
+            if warning:
+                warnings.append(f"{strategy.response_name}: {warning}")
+
+        return scores, missing, warnings
+
+    def _load_latest_metric(
+        self,
+        strategy_basename: str,
+        metric: BacktestMetric,
+    ) -> tuple[float | None, str | None]:
+        """戦略ディレクトリ内の最新*.metrics.jsonから指標を取得する。"""
+        strategy_dir = get_backtest_results_dir(strategy_basename)
+        if not strategy_dir.exists():
+            return None, None
+
+        metric_files = sorted(
+            strategy_dir.glob("*.metrics.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not metric_files:
+            return None, None
+
+        latest = metric_files[0]
+        try:
+            payload = json.loads(latest.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, f"failed to read metrics ({latest.name}: {exc})"
+
+        value = payload.get(metric)
+        if value is None:
+            return None, None
+
+        if isinstance(value, (int, float)):
+            return float(value), None
+
+        try:
+            return float(value), None
+        except (TypeError, ValueError):
+            return None, f"metric {metric} is not numeric in {latest.name}"
+
+    def _evaluate_strategy(
+        self,
+        strategy: StrategyRuntime,
+        stock_universe: list[StockUniverseItem],
+        recent_days: int,
+        reference_date: str | None,
+    ) -> tuple[list[tuple[StockUniverseItem, str]], set[str], list[str]]:
+        """1戦略分のスクリーニング評価を実行する。"""
+        if not stock_universe:
+            return [], set(), []
+
+        stock_codes = [s.code for s in stock_universe]
+        start_date, end_date = self._resolve_date_range(strategy.shared_config, reference_date)
+
+        include_margin = (
+            strategy.shared_config.include_margin_data
+            and self._needs_data_requirement(strategy.entry_params, strategy.exit_params, "margin")
+        )
+        include_statements = (
+            strategy.shared_config.include_statements_data
+            and self._needs_data_requirement(strategy.entry_params, strategy.exit_params, "statements")
+        )
+        include_forecast_revision = self._should_include_forecast_revision(
+            strategy.entry_params,
+            strategy.exit_params,
+        )
+        needs_benchmark = self._needs_data_requirement(strategy.entry_params, strategy.exit_params, "benchmark")
+        needs_sector = self._needs_data_requirement(strategy.entry_params, strategy.exit_params, "sector")
+
+        warnings: list[str] = []
+
+        with data_access_mode_context("direct"):
+            multi_data = prepare_multi_data(
+                dataset=strategy.shared_config.dataset,
+                stock_codes=stock_codes,
+                start_date=start_date,
+                end_date=end_date,
+                include_margin_data=include_margin,
+                include_statements_data=include_statements,
+                timeframe=strategy.shared_config.timeframe,
+                period_type=self._resolve_period_type(strategy.entry_params, strategy.exit_params),
+                include_forecast_revision=include_forecast_revision,
+            )
+
+            benchmark_data = None
+            if needs_benchmark:
+                try:
+                    benchmark_data = load_topix_data(
+                        strategy.shared_config.dataset,
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
+                except Exception as exc:
+                    warnings.append(f"benchmark load failed ({exc})")
+
+            sector_data = None
+            stock_sector_mapping: dict[str, str] = {}
+            if needs_sector:
+                try:
+                    sector_data = load_all_sector_indices(
+                        strategy.shared_config.dataset,
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
+                    stock_sector_mapping = get_stock_sector_mapping(strategy.shared_config.dataset)
+                except Exception as exc:
+                    warnings.append(f"sector data load failed ({exc})")
+
+        matches: list[tuple[StockUniverseItem, str]] = []
+        processed: set[str] = set()
+
+        for stock in stock_universe:
+            stock_data = multi_data.get(stock.code)
+            if not stock_data:
+                continue
+
+            daily = stock_data.get("daily")
+            if not isinstance(daily, pd.DataFrame) or daily.empty:
+                continue
+
+            processed.add(stock.code)
+
+            margin_data = stock_data.get("margin_daily") if include_margin else None
+            statements_data = stock_data.get("statements_daily") if include_statements else None
+
+            try:
+                signals = self._signal_processor.generate_signals(
+                    strategy_entries=pd.Series(True, index=daily.index),
+                    strategy_exits=pd.Series(False, index=daily.index),
+                    ohlc_data=daily,
+                    entry_signal_params=strategy.entry_params,
+                    exit_signal_params=strategy.exit_params,
+                    margin_data=margin_data,
+                    statements_data=statements_data,
+                    benchmark_data=benchmark_data,
+                    sector_data=sector_data,
+                    stock_sector_name=stock_sector_mapping.get(stock.code),
+                )
+            except Exception as exc:
+                warnings.append(f"{stock.code} signal generation failed ({exc})")
+                continue
+
+            matched_date = self._find_recent_match_date(signals, recent_days)
+            if matched_date is None:
+                continue
+
+            matches.append((stock, matched_date))
+
+        return matches, processed, warnings
+
+    def _resolve_date_range(
+        self,
+        shared_config: SharedConfig,
+        reference_date: str | None,
+    ) -> tuple[str | None, str | None]:
+        """shared_config とクエリ日付からロード対象期間を解決する。"""
+        start_date = shared_config.start_date or None
+        end_date = shared_config.end_date or None
+
+        if reference_date:
+            if end_date is None or reference_date < end_date:
+                end_date = reference_date
+
+        return start_date, end_date
+
+    def _needs_data_requirement(
+        self,
+        entry_params: SignalParams,
+        exit_params: SignalParams,
+        requirement: str,
+    ) -> bool:
+        """指定データ要件に依存する有効シグナルがあるか判定する。"""
+        for signal_def in SIGNAL_REGISTRY:
+            if not any(
+                req == requirement or req.startswith(f"{requirement}:")
+                for req in signal_def.data_requirements
+            ):
+                continue
+
+            if signal_def.enabled_checker(entry_params):
+                return True
+            if signal_def.enabled_checker(exit_params):
+                return True
+
+        return False
+
+    def _resolve_period_type(
+        self,
+        entry_params: SignalParams,
+        exit_params: SignalParams,
+    ) -> str:
+        """fundamental設定から period_type を解決する。"""
+        for params in (entry_params, exit_params):
+            fundamental = params.fundamental
+            period_type = getattr(fundamental, "period_type", None)
+            if isinstance(period_type, str) and period_type:
+                return period_type
+
+        return "FY"
+
+    def _should_include_forecast_revision(
+        self,
+        entry_params: SignalParams,
+        exit_params: SignalParams,
+    ) -> bool:
+        """forward_eps_growth/peg_ratio 有効時に四半期修正取得を有効化。"""
+
+        def _enabled(params: SignalParams) -> bool:
+            fundamental = params.fundamental
+            if not fundamental.enabled:
+                return False
+            return bool(
+                fundamental.forward_eps_growth.enabled
+                or fundamental.peg_ratio.enabled
+            )
+
+        return _enabled(entry_params) or _enabled(exit_params)
+
+    def _find_recent_match_date(self, signals: Signals, recent_days: int) -> str | None:
+        """entries=True かつ exits=False の直近一致日を返す。"""
+        entries = signals.entries.fillna(False).astype(bool)
+        exits = signals.exits.fillna(False).astype(bool)
+        candidates = entries & (~exits)
+
+        recent = candidates.tail(recent_days)
+        if not recent.any():
+            return None
+
+        matched_index = recent[recent].index[-1]
+        return _format_date(matched_index)
+
+    def _build_result_item(self, aggregated_item: dict[str, Any]) -> ScreeningResultItem:
+        """銘柄集約データをレスポンス項目へ変換する。"""
+        stock: StockUniverseItem = aggregated_item["stock"]
+        matched_date: str = aggregated_item["matchedDate"]
+        matched_strategies: list[MatchedStrategyItem] = aggregated_item["matchedStrategies"]
+
+        # 戦略一覧はスコア優先（nullは常に最後）で整列
+        matched_strategies.sort(
+            key=lambda s: (
+                s.strategyScore is None,
+                -(s.strategyScore or 0.0),
+                s.strategyName,
             )
         )
 
+        best = self._pick_best_strategy(matched_strategies)
+
+        return ScreeningResultItem(
+            stockCode=stock.code,
+            companyName=stock.company_name,
+            scaleCategory=stock.scale_category,
+            sector33Name=stock.sector_33_name,
+            matchedDate=matched_date,
+            bestStrategyName=best.strategyName,
+            bestStrategyScore=best.strategyScore,
+            matchStrategyCount=len(matched_strategies),
+            matchedStrategies=matched_strategies,
+        )
+
+    def _pick_best_strategy(
+        self,
+        matched_strategies: list[MatchedStrategyItem],
+    ) -> MatchedStrategyItem:
+        """最適戦略を決定する（score優先、nullは最後）。"""
+        if not matched_strategies:
+            raise ValueError("matched_strategies is empty")
+
+        non_null = [s for s in matched_strategies if s.strategyScore is not None]
+        if non_null:
+            return max(non_null, key=lambda s: (float(s.strategyScore), s.strategyName))
+
+        # 全てnullの場合は最新一致日を優先
+        return max(matched_strategies, key=lambda s: (s.matchedDate, s.strategyName))
+
     def _sort_results(
-        self, results: list[ScreeningResultItem], sort_by: str, order: str
+        self,
+        results: list[ScreeningResultItem],
+        sort_by: ScreeningSortBy,
+        order: SortOrder,
     ) -> list[ScreeningResultItem]:
-        """ソート"""
+        """結果ソート。bestStrategyScoreではnullを常に末尾へ配置。"""
+        if sort_by == "bestStrategyScore":
+            if order == "asc":
+                return sorted(
+                    results,
+                    key=lambda r: (
+                        r.bestStrategyScore is None,
+                        r.bestStrategyScore if r.bestStrategyScore is not None else float("inf"),
+                        r.stockCode,
+                    ),
+                )
+
+            return sorted(
+                results,
+                key=lambda r: (
+                    r.bestStrategyScore is None,
+                    -(r.bestStrategyScore or 0.0),
+                    r.stockCode,
+                ),
+            )
+
         reverse = order == "desc"
-        if sort_by == "date":
-            results.sort(key=lambda r: r.matchedDate, reverse=reverse)
-        elif sort_by == "stockCode":
-            results.sort(key=lambda r: r.stockCode, reverse=reverse)
-        elif sort_by == "volumeRatio":
-            results.sort(
-                key=lambda r: r.details.rangeBreak.volumeRatio if r.details.rangeBreak else 0,
+
+        if sort_by == "matchedDate":
+            return sorted(results, key=lambda r: (r.matchedDate, r.stockCode), reverse=reverse)
+
+        if sort_by == "stockCode":
+            return sorted(results, key=lambda r: r.stockCode, reverse=reverse)
+
+        if sort_by == "matchStrategyCount":
+            return sorted(
+                results,
+                key=lambda r: (r.matchStrategyCount, r.stockCode),
                 reverse=reverse,
             )
-        elif sort_by == "breakPercentage":
-            results.sort(
-                key=lambda r: r.details.rangeBreak.breakPercentage if r.details.rangeBreak else 0,
-                reverse=reverse,
-            )
+
         return results
+
+    def _dedupe_warnings(self, warnings: list[str]) -> list[str]:
+        """警告を順序保持で重複排除し、件数を制限する。"""
+        deduped: list[str] = []
+        seen: set[str] = set()
+
+        for warning in warnings:
+            if warning in seen:
+                continue
+            seen.add(warning)
+            deduped.append(warning)
+            if len(deduped) >= self._WARNING_LIMIT:
+                break
+
+        if len(warnings) > len(deduped):
+            deduped.append("additional warnings were truncated")
+
+        return deduped

--- a/apps/bt/tests/unit/server/services/test_screening_service.py
+++ b/apps/bt/tests/unit/server/services/test_screening_service.py
@@ -2,12 +2,19 @@
 Screening Service Unit Tests
 """
 
+from __future__ import annotations
+
 import sqlite3
+from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 from src.lib.market_db.market_reader import MarketDbReader
-from src.server.services.screening_service import ScreeningService
+from src.models.config import SharedConfig
+from src.models.signals import SignalParams
+from src.paths.resolver import StrategyMetadata
+from src.server.services.screening_service import ScreeningService, StrategyRuntime
 
 
 @pytest.fixture
@@ -16,7 +23,8 @@ def screening_db(tmp_path):
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
 
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE stocks (
             code TEXT PRIMARY KEY,
             company_name TEXT NOT NULL,
@@ -24,19 +32,8 @@ def screening_db(tmp_path):
             scale_category TEXT,
             sector_33_name TEXT
         )
-    """)
-    conn.execute("""
-        CREATE TABLE stock_data (
-            code TEXT NOT NULL,
-            date TEXT NOT NULL,
-            open REAL NOT NULL,
-            high REAL NOT NULL,
-            low REAL NOT NULL,
-            close REAL NOT NULL,
-            volume INTEGER NOT NULL,
-            PRIMARY KEY (code, date)
-        )
-    """)
+        """
+    )
 
     stocks = [
         ("10010", "Numeric Prime", "0111"),
@@ -46,12 +43,11 @@ def screening_db(tmp_path):
     ]
     for code, company_name, market_code in stocks:
         conn.execute(
-            "INSERT INTO stocks (code, company_name, market_code, scale_category, sector_33_name) VALUES (?, ?, ?, ?, ?)",
+            """
+            INSERT INTO stocks (code, company_name, market_code, scale_category, sector_33_name)
+            VALUES (?, ?, ?, ?, ?)
+            """,
             (code, company_name, market_code, "TOPIX Small 1", "情報・通信業"),
-        )
-        conn.execute(
-            "INSERT INTO stock_data (code, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (code, "2026-01-06", 100.0, 101.0, 99.0, 100.0, 1000),
         )
 
     conn.commit()
@@ -66,21 +62,261 @@ def service(screening_db):
     reader.close()
 
 
+def _runtime(name: str) -> StrategyRuntime:
+    return StrategyRuntime(
+        name=f"production/{name}",
+        response_name=name,
+        basename=name,
+        entry_params=SignalParams(),
+        exit_params=SignalParams(),
+        shared_config=SharedConfig.model_validate(
+            {"dataset": "primeExTopix500"},
+            context={"resolve_stock_codes": False},
+        ),
+    )
+
+
 class TestMarketCodeCompatibility:
-    def test_prime_query_matches_legacy_and_numeric_prime(self, service):
+    def test_prime_and_numeric_prime_screen_same_universe(self, service, monkeypatch):
+        runtime = _runtime("range_break_v15")
+
+        monkeypatch.setattr(service, "_resolve_strategies", lambda _: [runtime])
+        monkeypatch.setattr(
+            service,
+            "_load_strategy_scores",
+            lambda strategies, metric: ({runtime.response_name: 1.0}, [], []),
+        )
+        monkeypatch.setattr(
+            service,
+            "_evaluate_strategy",
+            lambda strategy, universe, recent_days, reference_date: (
+                [],
+                {s.code for s in universe},
+                [],
+            ),
+        )
+
+        prime_result = service.run_screening(markets="prime")
+        numeric_result = service.run_screening(markets="0111")
+
+        assert prime_result.summary.totalStocksScreened == 2
+        assert numeric_result.summary.totalStocksScreened == 2
+
+
+class TestStrategyResolution:
+    def test_resolves_production_only_and_supports_basename_and_fullname(
+        self,
+        service,
+        monkeypatch,
+        tmp_path,
+    ):
+        production_1 = StrategyMetadata(
+            name="production/range_break_v15",
+            category="production",
+            path=Path(tmp_path / "production/range_break_v15.yaml"),
+            mtime=datetime.now(),
+        )
+        production_2 = StrategyMetadata(
+            name="production/forward_eps_driven",
+            category="production",
+            path=Path(tmp_path / "production/forward_eps_driven.yaml"),
+            mtime=datetime.now(),
+        )
+        experimental = StrategyMetadata(
+            name="experimental/test_strategy",
+            category="experimental",
+            path=Path(tmp_path / "experimental/test_strategy.yaml"),
+            mtime=datetime.now(),
+        )
+
+        monkeypatch.setattr(
+            service._config_loader,
+            "get_strategy_metadata",
+            lambda: [production_1, production_2, experimental],
+        )
+        monkeypatch.setattr(
+            service._config_loader,
+            "load_strategy_config",
+            lambda _name: {
+                "entry_filter_params": {},
+                "exit_trigger_params": {},
+            },
+        )
+        monkeypatch.setattr(
+            service._config_loader,
+            "merge_shared_config",
+            lambda _config: {"dataset": "primeExTopix500"},
+        )
+
+        auto_resolved = service._resolve_strategies(None)
+        assert [s.name for s in auto_resolved] == [
+            "production/forward_eps_driven",
+            "production/range_break_v15",
+        ]
+
+        specified = service._resolve_strategies(
+            "range_break_v15,production/forward_eps_driven"
+        )
+        assert [s.name for s in specified] == [
+            "production/range_break_v15",
+            "production/forward_eps_driven",
+        ]
+
+        with pytest.raises(ValueError, match="Invalid strategies"):
+            service._resolve_strategies("experimental/test_strategy")
+
+    def test_uses_full_name_when_selected_basenames_collide(
+        self,
+        service,
+        monkeypatch,
+        tmp_path,
+    ):
+        production_a = StrategyMetadata(
+            name="production/group_a/shared_name",
+            category="production",
+            path=Path(tmp_path / "production/group_a/shared_name.yaml"),
+            mtime=datetime.now(),
+        )
+        production_b = StrategyMetadata(
+            name="production/group_b/shared_name",
+            category="production",
+            path=Path(tmp_path / "production/group_b/shared_name.yaml"),
+            mtime=datetime.now(),
+        )
+
+        monkeypatch.setattr(
+            service._config_loader,
+            "get_strategy_metadata",
+            lambda: [production_a, production_b],
+        )
+        monkeypatch.setattr(
+            service._config_loader,
+            "load_strategy_config",
+            lambda _name: {
+                "entry_filter_params": {},
+                "exit_trigger_params": {},
+            },
+        )
+        monkeypatch.setattr(
+            service._config_loader,
+            "merge_shared_config",
+            lambda _config: {"dataset": "primeExTopix500"},
+        )
+
+        resolved = service._resolve_strategies(
+            "production/group_a/shared_name,production/group_b/shared_name"
+        )
+        assert [s.response_name for s in resolved] == [
+            "production/group_a/shared_name",
+            "production/group_b/shared_name",
+        ]
+
+
+class TestAggregationAndSorting:
+    def test_aggregates_by_stock_and_picks_best_strategy(self, service, monkeypatch):
+        s1 = _runtime("range_break_v15")
+        s2 = _runtime("forward_eps_driven")
+
+        monkeypatch.setattr(service, "_resolve_strategies", lambda _: [s1, s2])
+        monkeypatch.setattr(
+            service,
+            "_load_strategy_scores",
+            lambda strategies, metric: (
+                {s1.response_name: 0.8, s2.response_name: 1.2},
+                [],
+                [],
+            ),
+        )
+
+        def _fake_evaluate(strategy, universe, _recent_days, _reference_date):
+            by_code = {s.code: s for s in universe}
+            if strategy.response_name == "range_break_v15":
+                return [(by_code["1001"], "2026-01-05")], {s.code for s in universe}, []
+            return [(by_code["1001"], "2026-01-06")], {s.code for s in universe}, []
+
+        monkeypatch.setattr(service, "_evaluate_strategy", _fake_evaluate)
+
         result = service.run_screening(markets="prime")
-        assert result.markets == ["prime"]
-        assert result.summary.totalStocksScreened == 2
-        assert result.summary.skippedCount == 2
 
-    def test_numeric_prime_query_matches_legacy_and_numeric_prime(self, service):
-        result = service.run_screening(markets="0111")
-        assert result.markets == ["0111"]
-        assert result.summary.totalStocksScreened == 2
-        assert result.summary.skippedCount == 2
+        assert result.summary.matchCount == 1
+        row = result.results[0]
+        assert row.stockCode == "1001"
+        assert row.matchStrategyCount == 2
+        assert row.bestStrategyName == "forward_eps_driven"
+        assert row.bestStrategyScore == pytest.approx(1.2)
 
-    def test_comma_separated_market_query_expands_all_aliases(self, service):
-        result = service.run_screening(markets="prime,standard")
-        assert result.markets == ["prime", "standard"]
-        assert result.summary.totalStocksScreened == 4
-        assert result.summary.skippedCount == 4
+    def test_missing_metrics_strategy_gets_null_score_and_sorted_last(
+        self,
+        service,
+        monkeypatch,
+    ):
+        scored = _runtime("range_break_v15")
+        missing = _runtime("forward_eps_driven")
+
+        monkeypatch.setattr(service, "_resolve_strategies", lambda _: [scored, missing])
+        monkeypatch.setattr(
+            service,
+            "_load_strategy_scores",
+            lambda strategies, metric: (
+                {scored.response_name: 1.0, missing.response_name: None},
+                [missing.response_name],
+                [],
+            ),
+        )
+
+        def _fake_evaluate(strategy, universe, _recent_days, _reference_date):
+            by_code = {s.code: s for s in universe}
+            if strategy.response_name == "range_break_v15":
+                return [(by_code["1001"], "2026-01-05")], {s.code for s in universe}, []
+            return [(by_code["1002"], "2026-01-06")], {s.code for s in universe}, []
+
+        monkeypatch.setattr(service, "_evaluate_strategy", _fake_evaluate)
+
+        result_desc = service.run_screening(
+            markets="prime",
+            sort_by="bestStrategyScore",
+            order="desc",
+        )
+        assert [r.stockCode for r in result_desc.results] == ["1001", "1002"]
+
+        result_asc = service.run_screening(
+            markets="prime",
+            sort_by="bestStrategyScore",
+            order="asc",
+        )
+        assert [r.stockCode for r in result_asc.results] == ["1001", "1002"]
+        assert result_asc.summary.strategiesWithoutBacktestMetrics == ["forward_eps_driven"]
+
+    def test_backtest_metric_switch_sort_order_and_limit(self, service, monkeypatch):
+        s1 = _runtime("range_break_v15")
+        s2 = _runtime("forward_eps_driven")
+
+        captured_metric: dict[str, str] = {}
+
+        monkeypatch.setattr(service, "_resolve_strategies", lambda _: [s1, s2])
+
+        def _fake_scores(_strategies, metric):
+            captured_metric["value"] = metric
+            return {s1.response_name: 0.2, s2.response_name: 0.9}, [], []
+
+        monkeypatch.setattr(service, "_load_strategy_scores", _fake_scores)
+
+        def _fake_evaluate(strategy, universe, _recent_days, _reference_date):
+            by_code = {s.code: s for s in universe}
+            if strategy.response_name == "range_break_v15":
+                return [(by_code["1001"], "2026-01-07")], {s.code for s in universe}, []
+            return [(by_code["1002"], "2026-01-06")], {s.code for s in universe}, []
+
+        monkeypatch.setattr(service, "_evaluate_strategy", _fake_evaluate)
+
+        result = service.run_screening(
+            markets="prime",
+            backtest_metric="calmar_ratio",
+            sort_by="matchedDate",
+            order="asc",
+            limit=1,
+        )
+
+        assert captured_metric["value"] == "calmar_ratio"
+        assert len(result.results) == 1
+        assert result.results[0].stockCode == "1002"

--- a/apps/bt/tests/unit/server/services/test_screening_service_helpers.py
+++ b/apps/bt/tests/unit/server/services/test_screening_service_helpers.py
@@ -1,19 +1,21 @@
 """
-Screening helper function tests.
+Screening service helper tests.
 """
 
-from src.server.schemas.screening import RangeBreakDetails, ScreeningDetails, ScreeningResultItem
-from src.server.services.screening_service import (
-    RangeBreakParams,
-    ScreeningService,
-    StockDataPoint,
-    _check_volume_condition,
-    _detect_range_break,
-    _ema,
-    _find_max_high,
-    _get_volume_avg,
-    _sma,
-)
+from __future__ import annotations
+
+from contextlib import nullcontext
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from src.models.config import SharedConfig
+from src.models.signals import SignalParams, Signals
+from src.server.schemas.screening import MatchedStrategyItem, ScreeningResultItem
+from src.server.services.screening_service import ScreeningService, StockUniverseItem, StrategyRuntime
 
 
 class DummyReader:
@@ -21,149 +23,476 @@ class DummyReader:
         return []
 
 
-def make_point(day: int, high: float, volume: float) -> StockDataPoint:
-    return StockDataPoint(
-        date=f"2026-01-{day:02d}",
-        open=high - 1.0,
-        high=high,
-        low=high - 2.0,
-        close=high - 0.5,
-        volume=volume,
+def _runtime(
+    name: str = "test_strategy",
+    *,
+    shared_overrides: dict[str, object] | None = None,
+    entry_params: SignalParams | None = None,
+    exit_params: SignalParams | None = None,
+) -> StrategyRuntime:
+    shared_payload = {"dataset": "primeExTopix500"}
+    if shared_overrides:
+        shared_payload.update(shared_overrides)
+
+    return StrategyRuntime(
+        name=f"production/{name}",
+        response_name=name,
+        basename=name,
+        entry_params=entry_params or SignalParams(),
+        exit_params=exit_params or SignalParams(),
+        shared_config=SharedConfig.model_validate(
+            shared_payload,
+            context={"resolve_stock_codes": False},
+        ),
     )
 
 
-class TestVolumeHelpers:
-    def test_sma_and_ema_return_empty_for_invalid_period(self):
-        assert _sma([1, 2, 3], 0) == []
-        assert _ema([1, 2, 3], 5) == []
-
-    def test_get_volume_avg_returns_none_for_out_of_range(self):
-        data = [make_point(1, 10, 100), make_point(2, 11, 120)]
-        assert _get_volume_avg(data, period=3, end_index=1, vol_type="sma") is None
-
-    def test_check_volume_condition_handles_zero_long_average(self):
-        params = RangeBreakParams(volume_short_period=1, volume_long_period=1, volume_ratio_threshold=1.1)
-        data = [make_point(1, 10, 0), make_point(2, 11, 0)]
-        matched, ratio, short_avg, long_avg = _check_volume_condition(data, params, 1)
-        assert (matched, ratio, short_avg, long_avg) == (False, 0.0, 0.0, 0.0)
-
-
-class TestRangeBreakHelpers:
-    def test_find_max_high_invalid_range_returns_zero(self):
-        data = [make_point(1, 10, 100), make_point(2, 11, 100)]
-        assert _find_max_high(data, start=-1, end=1) == 0.0
-        assert _find_max_high(data, start=1, end=0) == 0.0
-
-    def test_detect_range_break_returns_none_when_insufficient_data(self):
-        params = RangeBreakParams(period=5, lookback_days=2)
-        data = [make_point(1, 10, 100), make_point(2, 11, 100), make_point(3, 12, 100)]
-        assert _detect_range_break(data, params=params, recent_days=2) is None
-
-    def test_detect_range_break_returns_details_when_conditions_match(self):
-        params = RangeBreakParams(
-            period=3,
-            lookback_days=1,
-            volume_ratio_threshold=1.0,
-            volume_short_period=1,
-            volume_long_period=2,
-            volume_type="sma",
-        )
-        data = [
-            make_point(1, 10, 100),
-            make_point(2, 10, 100),
-            make_point(3, 10, 100),
-            make_point(4, 11, 300),
-            make_point(5, 12, 400),
-        ]
-        details = _detect_range_break(data, params=params, recent_days=2)
-        assert details is not None
-        assert details.breakDate == "2026-01-05"
-        assert details.breakPercentage > 0
-
-
-class TestServiceHelpers:
-    def test_maybe_add_result_respects_filters(self):
+class TestSignalMatchingHelpers:
+    def test_find_recent_match_date_uses_entry_true_and_exit_false(self):
         service = ScreeningService(DummyReader())
-        results: list[ScreeningResultItem] = []
-        details = RangeBreakDetails(
-            breakDate="2026-01-05",
-            currentHigh=12.0,
-            maxHighInLookback=11.0,
-            breakPercentage=1.0,
-            volumeRatio=1.2,
-            avgVolume20Days=300.0,
-            avgVolume100Days=200.0,
+        index = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+
+        signals = Signals(
+            entries=pd.Series([True, True, True], index=index),
+            exits=pd.Series([False, True, False], index=index),
         )
 
-        service._maybe_add_result(  # noqa: SLF001
-            results,
-            {"code": "10010", "company_name": "A"},
-            "rangeBreakFast",
-            details,
-            min_break_pct=2.0,
-            min_vol_ratio=None,
-        )
-        assert results == []
+        matched = service._find_recent_match_date(signals, recent_days=3)  # noqa: SLF001
+        assert matched == "2026-01-03"
 
-        service._maybe_add_result(  # noqa: SLF001
-            results,
-            {"code": "10010", "company_name": "A"},
-            "rangeBreakFast",
-            details,
-            min_break_pct=None,
-            min_vol_ratio=1.5,
-        )
-        assert results == []
-
-        service._maybe_add_result(  # noqa: SLF001
-            results,
-            {"code": "10010", "company_name": "A"},
-            "rangeBreakFast",
-            details,
-            min_break_pct=0.5,
-            min_vol_ratio=1.1,
-        )
-        assert len(results) == 1
-
-    def test_sort_results_handles_all_sort_types(self):
+    def test_find_recent_match_date_returns_none_when_all_recent_entries_are_exited(self):
         service = ScreeningService(DummyReader())
-        item_a = ScreeningResultItem(
+        index = pd.to_datetime(["2026-01-01", "2026-01-02"])
+
+        signals = Signals(
+            entries=pd.Series([True, True], index=index),
+            exits=pd.Series([True, True], index=index),
+        )
+
+        matched = service._find_recent_match_date(signals, recent_days=2)  # noqa: SLF001
+        assert matched is None
+
+
+class TestSortHelpers:
+    def test_sort_best_strategy_score_keeps_null_last_for_both_orders(self):
+        service = ScreeningService(DummyReader())
+
+        scored = ScreeningResultItem(
             stockCode="1001",
             companyName="A",
-            screeningType="rangeBreakFast",
-            matchedDate="2026-01-04",
-            details=ScreeningDetails(
-                rangeBreak=RangeBreakDetails(
-                    breakDate="2026-01-04",
-                    currentHigh=11.0,
-                    maxHighInLookback=10.0,
-                    breakPercentage=10.0,
-                    volumeRatio=1.5,
-                    avgVolume20Days=200.0,
-                    avgVolume100Days=130.0,
+            matchedDate="2026-01-03",
+            bestStrategyName="s1",
+            bestStrategyScore=1.2,
+            matchStrategyCount=1,
+            matchedStrategies=[
+                MatchedStrategyItem(
+                    strategyName="s1",
+                    matchedDate="2026-01-03",
+                    strategyScore=1.2,
                 )
-            ),
+            ],
         )
-        item_b = ScreeningResultItem(
+        missing = ScreeningResultItem(
             stockCode="1002",
             companyName="B",
-            screeningType="rangeBreakSlow",
-            matchedDate="2026-01-05",
-            details=ScreeningDetails(
-                rangeBreak=RangeBreakDetails(
-                    breakDate="2026-01-05",
-                    currentHigh=12.0,
-                    maxHighInLookback=10.0,
-                    breakPercentage=20.0,
-                    volumeRatio=2.0,
-                    avgVolume20Days=300.0,
-                    avgVolume100Days=150.0,
+            matchedDate="2026-01-04",
+            bestStrategyName="s2",
+            bestStrategyScore=None,
+            matchStrategyCount=1,
+            matchedStrategies=[
+                MatchedStrategyItem(
+                    strategyName="s2",
+                    matchedDate="2026-01-04",
+                    strategyScore=None,
                 )
-            ),
+            ],
         )
-        base = [item_a, item_b]
 
-        assert service._sort_results(base.copy(), "date", "desc")[0].stockCode == "1002"  # noqa: SLF001
-        assert service._sort_results(base.copy(), "stockCode", "asc")[0].stockCode == "1001"  # noqa: SLF001
-        assert service._sort_results(base.copy(), "volumeRatio", "desc")[0].stockCode == "1002"  # noqa: SLF001
-        assert service._sort_results(base.copy(), "breakPercentage", "desc")[0].stockCode == "1002"  # noqa: SLF001
+        desc = service._sort_results([missing, scored], "bestStrategyScore", "desc")  # noqa: SLF001
+        asc = service._sort_results([missing, scored], "bestStrategyScore", "asc")  # noqa: SLF001
+
+        assert [r.stockCode for r in desc] == ["1001", "1002"]
+        assert [r.stockCode for r in asc] == ["1001", "1002"]
+
+    def test_sort_helpers_cover_non_score_sorts_and_fallback(self):
+        service = ScreeningService(DummyReader())
+
+        row1 = ScreeningResultItem(
+            stockCode="1001",
+            companyName="A",
+            matchedDate="2026-01-03",
+            bestStrategyName="s1",
+            bestStrategyScore=1.0,
+            matchStrategyCount=2,
+            matchedStrategies=[],
+        )
+        row2 = ScreeningResultItem(
+            stockCode="1002",
+            companyName="B",
+            matchedDate="2026-01-01",
+            bestStrategyName="s2",
+            bestStrategyScore=2.0,
+            matchStrategyCount=1,
+            matchedStrategies=[],
+        )
+
+        by_date = service._sort_results([row1, row2], "matchedDate", "asc")  # noqa: SLF001
+        by_code = service._sort_results([row2, row1], "stockCode", "desc")  # noqa: SLF001
+        by_count = service._sort_results([row2, row1], "matchStrategyCount", "desc")  # noqa: SLF001
+        passthrough = service._sort_results([row1], "unknown", "asc")  # type: ignore[arg-type]  # noqa: SLF001
+
+        assert [r.stockCode for r in by_date] == ["1002", "1001"]
+        assert [r.stockCode for r in by_code] == ["1002", "1001"]
+        assert [r.stockCode for r in by_count] == ["1001", "1002"]
+        assert passthrough == [row1]
+
+
+class TestDataLoadingHelpers:
+    def test_load_stock_universe_returns_empty_when_no_market_codes(self):
+        service = ScreeningService(DummyReader())
+        assert service._load_stock_universe([]) == []  # noqa: SLF001
+
+    def test_load_stock_universe_deduplicates_normalized_codes(self):
+        reader = DummyReader()
+        reader.query = lambda _sql, _params=(): [  # type: ignore[assignment]
+            {
+                "code": "10010",
+                "company_name": "A",
+                "scale_category": "Small",
+                "sector_33_name": "情報・通信業",
+            },
+            {
+                "code": "1001",
+                "company_name": "A duplicate",
+                "scale_category": "Small",
+                "sector_33_name": "情報・通信業",
+            },
+        ]
+        service = ScreeningService(reader)
+
+        universe = service._load_stock_universe(["prime"])  # noqa: SLF001
+        assert len(universe) == 1
+        assert universe[0].code == "1001"
+
+    def test_load_latest_metric_handles_missing_invalid_and_non_numeric(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        service = ScreeningService(DummyReader())
+        monkeypatch.setattr(
+            "src.server.services.screening_service.get_backtest_results_dir",
+            lambda basename: tmp_path / basename,
+        )
+
+        # missing dir
+        score, warning = service._load_latest_metric("missing", "sharpe_ratio")  # noqa: SLF001
+        assert score is None
+        assert warning is None
+
+        # empty dir
+        (tmp_path / "empty").mkdir(parents=True)
+        score, warning = service._load_latest_metric("empty", "sharpe_ratio")  # noqa: SLF001
+        assert score is None
+        assert warning is None
+
+        # invalid json
+        invalid_dir = tmp_path / "invalid"
+        invalid_dir.mkdir(parents=True)
+        (invalid_dir / "x.metrics.json").write_text("{invalid", encoding="utf-8")
+        score, warning = service._load_latest_metric("invalid", "sharpe_ratio")  # noqa: SLF001
+        assert score is None
+        assert warning and "failed to read metrics" in warning
+
+        # missing metric key
+        missing_key_dir = tmp_path / "missing-key"
+        missing_key_dir.mkdir(parents=True)
+        (missing_key_dir / "x.metrics.json").write_text('{"total_return": 1.2}', encoding="utf-8")
+        score, warning = service._load_latest_metric("missing-key", "sharpe_ratio")  # noqa: SLF001
+        assert score is None
+        assert warning is None
+
+        # string metric should be parsed
+        string_metric_dir = tmp_path / "string-metric"
+        string_metric_dir.mkdir(parents=True)
+        (string_metric_dir / "x.metrics.json").write_text(
+            '{"sharpe_ratio": "1.23"}',
+            encoding="utf-8",
+        )
+        score, warning = service._load_latest_metric("string-metric", "sharpe_ratio")  # noqa: SLF001
+        assert score == pytest.approx(1.23)
+        assert warning is None
+
+        # non-numeric string metric
+        bad_metric_dir = tmp_path / "bad-metric"
+        bad_metric_dir.mkdir(parents=True)
+        (bad_metric_dir / "x.metrics.json").write_text(
+            '{"sharpe_ratio": "NaN-value"}',
+            encoding="utf-8",
+        )
+        score, warning = service._load_latest_metric("bad-metric", "sharpe_ratio")  # noqa: SLF001
+        assert score is None
+        assert warning and "is not numeric" in warning
+
+    def test_load_strategy_scores_collects_missing_and_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        service = ScreeningService(DummyReader())
+        r1 = _runtime("r1")
+        r2 = _runtime("r2")
+
+        def _fake_load_latest_metric(basename: str, _metric: str):
+            if basename == "r1":
+                return 1.5, None
+            return None, "broken"
+
+        monkeypatch.setattr(service, "_load_latest_metric", _fake_load_latest_metric)
+        scores, missing, warnings = service._load_strategy_scores([r1, r2], "sharpe_ratio")  # noqa: SLF001
+
+        assert scores == {"r1": 1.5, "r2": None}
+        assert missing == ["r2"]
+        assert warnings == ["r2: broken"]
+
+
+class TestStrategyResolutionHelpers:
+    def test_resolve_strategy_token_paths(self):
+        service = ScreeningService(DummyReader())
+        metadata_by_name = {
+            "production/range_break_v15": object(),
+            "production/forward_eps_driven": object(),
+        }
+        basename_map = {
+            "range_break_v15": ["production/range_break_v15"],
+            "dupe": ["production/dupe_a", "production/dupe_b"],
+        }
+
+        assert (
+            service._resolve_strategy_token("production/range_break_v15", metadata_by_name, basename_map)  # noqa: SLF001
+            == "production/range_break_v15"
+        )
+        assert (
+            service._resolve_strategy_token("range_break_v15", metadata_by_name, basename_map)  # noqa: SLF001
+            == "production/range_break_v15"
+        )
+        assert service._resolve_strategy_token("dupe", metadata_by_name, basename_map) is None  # noqa: SLF001
+        assert service._resolve_strategy_token("missing", metadata_by_name, basename_map) is None  # noqa: SLF001
+
+    def test_resolve_strategies_raises_when_no_production(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        service = ScreeningService(DummyReader())
+        monkeypatch.setattr(service._config_loader, "get_strategy_metadata", lambda: [])
+        with pytest.raises(ValueError, match="No production strategies found"):
+            service._resolve_strategies(None)  # noqa: SLF001
+
+    def test_resolve_strategies_raises_when_requested_list_is_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        from src.paths.resolver import StrategyMetadata
+
+        service = ScreeningService(DummyReader())
+        meta = StrategyMetadata(
+            name="production/range_break_v15",
+            category="production",
+            path=tmp_path / "production/range_break_v15.yaml",
+            mtime=datetime.now(),
+        )
+
+        monkeypatch.setattr(service._config_loader, "get_strategy_metadata", lambda: [meta])
+        monkeypatch.setattr(
+            service._config_loader,
+            "load_strategy_config",
+            lambda _name: {"entry_filter_params": {}, "exit_trigger_params": {}},
+        )
+        monkeypatch.setattr(
+            service._config_loader,
+            "merge_shared_config",
+            lambda _config: {"dataset": "primeExTopix500"},
+        )
+
+        with pytest.raises(ValueError, match="No valid production strategies selected"):
+            service._resolve_strategies(",")  # noqa: SLF001
+
+
+class TestRuntimeEvaluationHelpers:
+    def test_resolve_date_range_prefers_reference_date_when_earlier(self):
+        service = ScreeningService(DummyReader())
+        shared = SharedConfig.model_validate(
+            {
+                "dataset": "primeExTopix500",
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+            },
+            context={"resolve_stock_codes": False},
+        )
+
+        start, end = service._resolve_date_range(shared, "2024-06-30")  # noqa: SLF001
+        assert start == "2024-01-01"
+        assert end == "2024-06-30"
+
+        start, end = service._resolve_date_range(shared, "2025-01-01")  # noqa: SLF001
+        assert start == "2024-01-01"
+        assert end == "2024-12-31"
+
+    def test_needs_data_requirement_with_custom_registry(self, monkeypatch: pytest.MonkeyPatch):
+        service = ScreeningService(DummyReader())
+        entry_params = SignalParams()
+        exit_params = SignalParams()
+
+        registry = [
+            SimpleNamespace(
+                data_requirements=["benchmark:topix"],
+                enabled_checker=lambda _params: True,
+            ),
+            SimpleNamespace(
+                data_requirements=["sector"],
+                enabled_checker=lambda _params: False,
+            ),
+        ]
+        monkeypatch.setattr("src.server.services.screening_service.SIGNAL_REGISTRY", registry)
+
+        assert service._needs_data_requirement(entry_params, exit_params, "benchmark")  # noqa: SLF001
+        assert not service._needs_data_requirement(entry_params, exit_params, "margin")  # noqa: SLF001
+
+    def test_resolve_period_type_and_forecast_revision_flags(self):
+        service = ScreeningService(DummyReader())
+
+        entry = SignalParams()
+        exit_ = SignalParams()
+        entry.fundamental.period_type = ""  # type: ignore[assignment]
+        exit_.fundamental.period_type = ""  # type: ignore[assignment]
+        assert service._resolve_period_type(entry, exit_) == "FY"  # noqa: SLF001
+
+        entry.fundamental.enabled = True
+        entry.fundamental.forward_eps_growth.enabled = True
+        assert service._should_include_forecast_revision(entry, exit_)  # noqa: SLF001
+
+        entry.fundamental.forward_eps_growth.enabled = False
+        entry.fundamental.peg_ratio.enabled = True
+        assert service._should_include_forecast_revision(entry, exit_)  # noqa: SLF001
+
+        entry.fundamental.enabled = False
+        entry.fundamental.peg_ratio.enabled = False
+        assert not service._should_include_forecast_revision(entry, exit_)  # noqa: SLF001
+
+    def test_build_result_item_and_best_strategy_helpers(self):
+        service = ScreeningService(DummyReader())
+        stock = StockUniverseItem(
+            code="1001",
+            company_name="A",
+            scale_category="Large",
+            sector_33_name="情報・通信業",
+        )
+        aggregated = {
+            "stock": stock,
+            "matchedDate": "2026-01-10",
+            "matchedStrategies": [
+                MatchedStrategyItem(strategyName="b", matchedDate="2026-01-08", strategyScore=None),
+                MatchedStrategyItem(strategyName="a", matchedDate="2026-01-09", strategyScore=1.5),
+            ],
+        }
+        row = service._build_result_item(aggregated)  # noqa: SLF001
+        assert row.bestStrategyName == "a"
+        assert row.matchedStrategies[0].strategyName == "a"
+
+        null_only = [
+            MatchedStrategyItem(strategyName="x", matchedDate="2026-01-01", strategyScore=None),
+            MatchedStrategyItem(strategyName="y", matchedDate="2026-01-02", strategyScore=None),
+        ]
+        assert service._pick_best_strategy(null_only).strategyName == "y"  # noqa: SLF001
+        with pytest.raises(ValueError, match="matched_strategies is empty"):
+            service._pick_best_strategy([])  # noqa: SLF001
+
+    def test_dedupe_warnings_truncates_and_keeps_order(self):
+        service = ScreeningService(DummyReader())
+        service._WARNING_LIMIT = 3  # noqa: SLF001
+        warnings = ["a", "a", "b", "c", "d"]
+        deduped = service._dedupe_warnings(warnings)  # noqa: SLF001
+        assert deduped == ["a", "b", "c", "additional warnings were truncated"]
+
+    def test_evaluate_strategy_handles_load_and_signal_failures(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        service = ScreeningService(DummyReader())
+        strategy = _runtime(
+            "range_break_v15",
+            shared_overrides={"include_margin_data": True, "include_statements_data": True},
+        )
+        universe = [
+            StockUniverseItem(code="1001", company_name="A", scale_category=None, sector_33_name=None),
+            StockUniverseItem(code="1002", company_name="B", scale_category=None, sector_33_name=None),
+            StockUniverseItem(code="1003", company_name="C", scale_category=None, sector_33_name=None),
+        ]
+
+        index = pd.to_datetime(["2026-01-01", "2026-01-02"])
+        daily = pd.DataFrame({"close": [1.0, 1.1]}, index=index)
+
+        monkeypatch.setattr("src.server.services.screening_service.data_access_mode_context", lambda _mode: nullcontext())
+        monkeypatch.setattr(
+            "src.server.services.screening_service.prepare_multi_data",
+            lambda **_kwargs: {
+                "1001": {"daily": daily, "margin_daily": "m1", "statements_daily": "s1"},
+                "1002": {},
+                "1003": {"daily": daily, "margin_daily": "m3", "statements_daily": "s3"},
+            },
+        )
+        monkeypatch.setattr(
+            service,
+            "_needs_data_requirement",
+            lambda _entry, _exit, requirement: requirement in {"margin", "statements", "benchmark", "sector"},
+        )
+        monkeypatch.setattr(
+            "src.server.services.screening_service.load_topix_data",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("topix down")),
+        )
+        monkeypatch.setattr(
+            "src.server.services.screening_service.load_all_sector_indices",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("sector down")),
+        )
+
+        calls: list[dict[str, object]] = []
+
+        def _generate_signals(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return Signals(
+                    entries=pd.Series([True, True], index=index),
+                    exits=pd.Series([False, False], index=index),
+                )
+            raise RuntimeError("signal failed")
+
+        monkeypatch.setattr(service._signal_processor, "generate_signals", _generate_signals)
+
+        matches, processed, warnings = service._evaluate_strategy(  # noqa: SLF001
+            strategy=strategy,
+            stock_universe=universe,
+            recent_days=2,
+            reference_date=None,
+        )
+
+        assert len(matches) == 1
+        assert matches[0][0].code == "1001"
+        assert processed == {"1001", "1003"}
+        assert any("benchmark load failed" in warning for warning in warnings)
+        assert any("sector data load failed" in warning for warning in warnings)
+        assert any("signal generation failed" in warning for warning in warnings)
+        assert calls[0]["margin_data"] == "m1"
+        assert calls[0]["statements_data"] == "s1"
+
+    def test_evaluate_strategy_short_circuit_when_universe_empty(self):
+        service = ScreeningService(DummyReader())
+        strategy = _runtime("any")
+        matches, processed, warnings = service._evaluate_strategy(  # noqa: SLF001
+            strategy=strategy,
+            stock_universe=[],
+            recent_days=10,
+            reference_date=None,
+        )
+        assert matches == []
+        assert processed == set()
+        assert warnings == []

--- a/apps/ts/packages/cli/src/commands/analysis/screening.test.ts
+++ b/apps/ts/packages/cli/src/commands/analysis/screening.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test';
+import { buildApiParams } from './screening';
+
+describe('analysis screening buildApiParams', () => {
+  it('builds strategy-driven query params', () => {
+    const params = buildApiParams({
+      markets: 'prime,standard',
+      strategies: 'range_break_v15,forward_eps_driven',
+      recentDays: '15',
+      date: '2026-01-15',
+      backtestMetric: 'calmar_ratio',
+      sortBy: 'matchedDate',
+      order: 'asc',
+      limit: '30',
+    });
+
+    expect(params).toEqual({
+      markets: 'prime,standard',
+      strategies: 'range_break_v15,forward_eps_driven',
+      recentDays: 15,
+      date: '2026-01-15',
+      backtestMetric: 'calmar_ratio',
+      sortBy: 'matchedDate',
+      order: 'asc',
+      limit: 30,
+    });
+  });
+
+  it('does not include removed fast/slow options', () => {
+    const params = buildApiParams({
+      recentDays: '10',
+    });
+
+    expect('rangeBreakFast' in params).toBe(false);
+    expect('rangeBreakSlow' in params).toBe(false);
+    expect('minBreakPercentage' in params).toBe(false);
+    expect('minVolumeRatio' in params).toBe(false);
+  });
+});

--- a/apps/ts/packages/cli/src/commands/screening/output-formatter.test.ts
+++ b/apps/ts/packages/cli/src/commands/screening/output-formatter.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import type { ScreeningResultItem } from '@trading25/shared/types/api-response-types';
+import { formatResults } from './output-formatter';
+
+const sampleResults: ScreeningResultItem[] = [
+  {
+    stockCode: '7203',
+    companyName: 'Toyota Motor',
+    scaleCategory: 'TOPIX Large70',
+    sector33Name: '輸送用機器',
+    matchedDate: '2026-01-07',
+    bestStrategyName: 'range_break_v15',
+    bestStrategyScore: 1.12,
+    matchStrategyCount: 2,
+    matchedStrategies: [
+      {
+        strategyName: 'range_break_v15',
+        matchedDate: '2026-01-07',
+        strategyScore: 1.12,
+      },
+      {
+        strategyName: 'forward_eps_driven',
+        matchedDate: '2026-01-06',
+        strategyScore: null,
+      },
+    ],
+  },
+];
+
+describe('screening output formatter', () => {
+  let logSpy: ReturnType<typeof spyOn> | null = null;
+
+  afterEach(() => {
+    if (logSpy) {
+      logSpy.mockRestore();
+      logSpy = null;
+    }
+  });
+
+  it('prints strategy-centric JSON output', async () => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await formatResults(sampleResults, {
+      format: 'json',
+      verbose: false,
+      debug: false,
+    });
+
+    const payloads = logSpy.mock.calls.map((call: unknown[]) => String(call[0] ?? ''));
+    const jsonPayload = payloads.find((payload: string) => payload.includes('"bestStrategyName"'));
+
+    expect(jsonPayload).toBeDefined();
+    expect(jsonPayload as string).toContain('"bestStrategyName": "range_break_v15"');
+    expect(jsonPayload as string).toContain('"matchStrategyCount": 2');
+    expect(jsonPayload as string).not.toContain('rangeBreakFast');
+    expect(jsonPayload as string).not.toContain('rangeBreakSlow');
+  });
+});

--- a/apps/ts/packages/cli/src/commands/screening/output-formatter.ts
+++ b/apps/ts/packages/cli/src/commands/screening/output-formatter.ts
@@ -3,11 +3,7 @@
  * Format screening results for different output formats
  */
 
-import type {
-  FutureReturns,
-  RangeBreakDetails,
-  ScreeningResultItem,
-} from '@trading25/shared/types/api-response-types';
+import type { ScreeningResultItem } from '@trading25/shared/types/api-response-types';
 import chalk from 'chalk';
 import stringWidth from 'string-width';
 
@@ -17,438 +13,187 @@ interface FormatterOptions {
   debug: boolean;
 }
 
-/**
- * Truncate string to fit within visual width
- * Takes into account full-width characters (Japanese, Chinese, etc.)
- */
 function truncateString(str: string, maxWidth: number): string {
-  // Handle edge cases
-  if (!str || maxWidth <= 0) {
-    return '';
-  }
+  if (!str || maxWidth <= 0) return '';
+  if (stringWidth(str) <= maxWidth) return str;
 
-  // Quick path: if the string is already short enough
-  const totalWidth = stringWidth(str);
-  if (totalWidth <= maxWidth) {
-    return str;
-  }
-
-  // Truncate character by character
   let result = '';
   let width = 0;
-
   for (const char of str) {
     const charWidth = stringWidth(char);
-    if (width + charWidth > maxWidth) {
-      break;
-    }
+    if (width + charWidth > maxWidth) break;
     result += char;
     width += charWidth;
   }
-
   return result;
 }
 
-/**
- * Pad string to visual width
- * Takes into account full-width characters (Japanese, Chinese, etc.)
- */
 function padEndVisual(str: string, targetWidth: number): string {
-  // Handle edge cases
-  if (!str) {
-    return ' '.repeat(Math.max(0, targetWidth));
-  }
-  if (targetWidth <= 0) {
-    return str;
-  }
-
-  const currentWidth = stringWidth(str);
-  if (currentWidth >= targetWidth) {
-    return str;
-  }
-
-  const paddingNeeded = targetWidth - currentWidth;
-  return str + ' '.repeat(paddingNeeded);
+  const currentWidth = stringWidth(str || '');
+  if (currentWidth >= targetWidth) return str;
+  return str + ' '.repeat(targetWidth - currentWidth);
 }
 
-/**
- * Format date for display
- */
 function formatDate(date: string): string {
   return date.split('T')[0] || '';
 }
 
-/**
- * Format number with specified decimal places
- */
-function formatNumber(num: number, decimals: number = 2): string {
-  return num.toFixed(decimals);
+function formatScore(score: number | null): string {
+  if (score === null || score === undefined) return 'N/A';
+  return score.toFixed(3);
 }
 
-/**
- * Format percentage
- */
-function formatPercentage(num: number): string {
-  return `${formatNumber(num, 2)}%`;
-}
-
-/**
- * Format percentage with sign and color
- */
-function formatPercentageWithColor(num: number): string {
-  const sign = num >= 0 ? '+' : '';
-  const formatted = `${sign}${formatNumber(num, 1)}%`;
-  if (num > 0) {
-    return chalk.green(formatted);
-  }
-  if (num < 0) {
-    return chalk.red(formatted);
-  }
-  return chalk.gray(formatted);
-}
-
-/**
- * Format future returns for table display
- */
-function formatFutureReturns(futureReturns: FutureReturns | undefined): string {
-  if (!futureReturns) {
-    return '';
-  }
-
-  const parts: string[] = [];
-
-  if (futureReturns.day5) {
-    parts.push(formatPercentageWithColor(futureReturns.day5.changePercent));
-  } else {
-    parts.push(chalk.gray('N/A'));
-  }
-
-  if (futureReturns.day20) {
-    parts.push(formatPercentageWithColor(futureReturns.day20.changePercent));
-  } else {
-    parts.push(chalk.gray('N/A'));
-  }
-
-  if (futureReturns.day60) {
-    parts.push(formatPercentageWithColor(futureReturns.day60.changePercent));
-  } else {
-    parts.push(chalk.gray('N/A'));
-  }
-
-  return parts.join(' ');
-}
-
-/**
- * Format large numbers with commas
- */
-function formatLargeNumber(num: number): string {
-  return num.toLocaleString();
-}
-
-/**
- * Get screening type display name
- */
-function getScreeningTypeDisplay(type: 'rangeBreakFast' | 'rangeBreakSlow'): string {
-  switch (type) {
-    case 'rangeBreakFast':
-      return 'Range Break Fast';
-    case 'rangeBreakSlow':
-      return 'Range Break Slow';
-    default:
-      return type;
-  }
-}
-
-/**
- * Format range break details for table row
- */
-function formatRangeBreakDetails(rb: RangeBreakDetails, options: FormatterOptions): string {
-  let details = `Break: ${formatPercentage(rb.breakPercentage)}`;
-
-  if (options.verbose) {
-    details += `, High: ¥${formatLargeNumber(rb.currentHigh)}, Max: ¥${formatLargeNumber(rb.maxHighInLookback)}`;
-  }
-
-  return details;
-}
-
-/**
- * Check if any results have future returns
- */
-function hasFutureReturns(results: ScreeningResultItem[]): boolean {
-  return results.some((r) => r.futureReturns !== undefined);
-}
-
-/**
- * Format table row for a single result
- */
-function formatTableRow(result: ScreeningResultItem, options: FormatterOptions, showFutureReturns: boolean): string {
-  const code = chalk.cyan(padEndVisual(result.stockCode, 8));
-  const company = chalk.white(padEndVisual(truncateString(result.companyName, 20), 20));
-  const sector33 = chalk.magenta(padEndVisual(truncateString(result.sector33Name || 'N/A', 15), 15));
-  const type = chalk.yellow(padEndVisual(getScreeningTypeDisplay(result.screeningType), 16));
-  const date = chalk.green(padEndVisual(formatDate(result.matchedDate), 12));
-
-  let volumeRatio = '';
-  let details = '';
-
-  if (
-    (result.screeningType === 'rangeBreakFast' || result.screeningType === 'rangeBreakSlow') &&
-    result.details.rangeBreak
-  ) {
-    volumeRatio = chalk.cyan(padEndVisual(formatNumber(result.details.rangeBreak.volumeRatio, 2), 8));
-    details = formatRangeBreakDetails(result.details.rangeBreak, options);
-  }
-
-  let row = code + company + sector33 + type + date + volumeRatio;
-
-  if (showFutureReturns) {
-    const futureReturnsStr = formatFutureReturns(result.futureReturns);
-    row += padEndVisual(futureReturnsStr, 25);
-  }
-
-  row += chalk.gray(details);
-
-  return row;
-}
-
-/**
- * Format verbose details line for a result
- */
-function formatVerboseDetails(result: ScreeningResultItem): string | null {
-  if (result.screeningType === 'rangeBreakFast' && result.details.rangeBreak) {
-    const rb = result.details.rangeBreak;
-    return chalk.gray(
-      `        Volume (EMA): 30D=${formatLargeNumber(rb.avgVolume20Days)}, 120D=${formatLargeNumber(rb.avgVolume100Days)}`
-    );
-  }
-
-  if (result.screeningType === 'rangeBreakSlow' && result.details.rangeBreak) {
-    const rb = result.details.rangeBreak;
-    return chalk.gray(
-      `        Volume (SMA): 50D=${formatLargeNumber(rb.avgVolume20Days)}, 150D=${formatLargeNumber(rb.avgVolume100Days)}`
-    );
-  }
-
-  return null;
-}
-
-/**
- * Print table header
- */
-function printTableHeader(showFutureReturns: boolean): void {
-  let header =
+function printTableHeader(): void {
+  const header =
     '\n' +
     chalk.bold.white('Code'.padEnd(8)) +
     chalk.bold.white('Company'.padEnd(20)) +
     chalk.bold.white('Sector33'.padEnd(15)) +
-    chalk.bold.white('Type'.padEnd(16)) +
-    chalk.bold.white('Date'.padEnd(12)) +
-    chalk.bold.white('Vol'.padEnd(8));
-
-  if (showFutureReturns) {
-    header += chalk.bold.white('+5日   +20日  +60日'.padEnd(25));
-  }
-
-  header += chalk.bold.white('Details');
+    chalk.bold.white('Best Strategy'.padEnd(20)) +
+    chalk.bold.white('Score'.padEnd(10)) +
+    chalk.bold.white('Matches'.padEnd(8)) +
+    chalk.bold.white('Date'.padEnd(12));
 
   console.log(header);
-
-  const lineWidth = showFutureReturns ? 135 : 110;
-  console.log(chalk.gray('─'.repeat(lineWidth)));
+  console.log(chalk.gray('─'.repeat(95)));
 }
 
-/**
- * Print table summary
- */
-function printTableSummary(results: ScreeningResultItem[], showFutureReturns: boolean): void {
-  const rangeBreakFastCount = results.filter((r) => r.screeningType === 'rangeBreakFast').length;
-  const rangeBreakSlowCount = results.filter((r) => r.screeningType === 'rangeBreakSlow').length;
+function formatTableRow(result: ScreeningResultItem): string {
+  const code = chalk.cyan(padEndVisual(result.stockCode, 8));
+  const company = chalk.white(padEndVisual(truncateString(result.companyName, 20), 20));
+  const sector33 = chalk.magenta(padEndVisual(truncateString(result.sector33Name || 'N/A', 15), 15));
+  const strategy = chalk.yellow(padEndVisual(truncateString(result.bestStrategyName, 20), 20));
+  const scoreRaw = formatScore(result.bestStrategyScore);
+  const score =
+    result.bestStrategyScore === null
+      ? chalk.gray(padEndVisual(scoreRaw, 10))
+      : chalk.green(padEndVisual(scoreRaw, 10));
+  const matches = chalk.white(padEndVisual(String(result.matchStrategyCount), 8));
+  const date = chalk.green(padEndVisual(formatDate(result.matchedDate), 12));
 
-  const lineWidth = showFutureReturns ? 135 : 110;
-  console.log(chalk.gray('─'.repeat(lineWidth)));
-  console.log(
-    chalk.white(`Total: ${results.length} stocks`) +
-      chalk.gray(` (Range Break Fast: ${rangeBreakFastCount}, Range Break Slow: ${rangeBreakSlowCount})`)
-  );
+  return code + company + sector33 + strategy + score + matches + date;
 }
 
-/**
- * Format results as table
- */
+function printTableSummary(results: ScreeningResultItem[]): void {
+  const topStrategies = Object.entries(
+    results.reduce<Record<string, number>>((acc, row) => {
+      acc[row.bestStrategyName] = (acc[row.bestStrategyName] || 0) + 1;
+      return acc;
+    }, {})
+  )
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([name, count]) => `${name}(${count})`)
+    .join(', ');
+
+  console.log(chalk.gray('─'.repeat(95)));
+  if (topStrategies) {
+    console.log(chalk.white(`Total: ${results.length} stocks`) + chalk.gray(` (Top: ${topStrategies})`));
+  } else {
+    console.log(chalk.white(`Total: ${results.length} stocks`));
+  }
+}
+
 function formatAsTable(results: ScreeningResultItem[], options: FormatterOptions): void {
   if (results.length === 0) {
     console.log(chalk.yellow('No results to display'));
     return;
   }
 
-  const showFutureReturns = hasFutureReturns(results);
-  printTableHeader(showFutureReturns);
+  printTableHeader();
 
   for (const result of results) {
-    console.log(formatTableRow(result, options, showFutureReturns));
+    console.log(formatTableRow(result));
 
     if (options.verbose) {
-      const verboseDetails = formatVerboseDetails(result);
-      if (verboseDetails) {
-        console.log(verboseDetails);
-      }
+      const matched = result.matchedStrategies
+        .map((strategy) => `${strategy.strategyName}:${formatScore(strategy.strategyScore)}`)
+        .join(', ');
+      console.log(chalk.gray(`        matched: ${matched}`));
     }
   }
 
-  printTableSummary(results, showFutureReturns);
+  printTableSummary(results);
 }
 
-/**
- * Format results as JSON
- */
-function formatAsJSON(results: ScreeningResultItem[], options: FormatterOptions): void {
+function formatAsJSON(results: ScreeningResultItem[]): void {
   const output = {
     summary: {
       total: results.length,
-      rangeBreakFast: results.filter((r) => r.screeningType === 'rangeBreakFast').length,
-      rangeBreakSlow: results.filter((r) => r.screeningType === 'rangeBreakSlow').length,
+      byBestStrategy: results.reduce<Record<string, number>>((acc, result) => {
+        acc[result.bestStrategyName] = (acc[result.bestStrategyName] || 0) + 1;
+        return acc;
+      }, {}),
+      noScoreCount: results.filter((result) => result.bestStrategyScore === null).length,
     },
-    results: results.map((result) => ({
-      stockCode: result.stockCode,
-      companyName: result.companyName,
-      scaleCategory: result.scaleCategory,
-      sector33Name: result.sector33Name,
-      screeningType: result.screeningType,
-      matchedDate: result.matchedDate,
-      details: options.verbose ? result.details : { rangeBreak: result.details.rangeBreak },
-      futureReturns: result.futureReturns,
-    })),
+    results,
   };
 
   console.log(JSON.stringify(output, null, 2));
 }
 
-/**
- * Get CSV headers
- */
-function getCSVHeaders(verbose: boolean, includeFutureReturns: boolean): string[] {
+function getCSVHeaders(verbose: boolean): string[] {
   const headers = [
     'StockCode',
     'CompanyName',
     'ScaleCategory',
     'Sector33Name',
-    'ScreeningType',
     'MatchedDate',
-    'VolumeRatio',
+    'BestStrategyName',
+    'BestStrategyScore',
+    'MatchStrategyCount',
   ];
 
-  if (includeFutureReturns) {
-    headers.push('Return5D', 'Return20D', 'Return60D');
-  }
-
   if (verbose) {
-    headers.push('BreakPercentage', 'CurrentHigh', 'MaxHighInLookback', 'AvgVolumeShort', 'AvgVolumeLong');
-  } else {
-    headers.push('Details');
+    headers.push('MatchedStrategies');
   }
 
   return headers;
 }
 
-/**
- * Format CSV row for range break result
- */
-function formatRangeBreakCSVRow(rb: RangeBreakDetails, verbose: boolean): string[] {
-  const row = [formatNumber(rb.volumeRatio)];
-
-  if (verbose) {
-    row.push(
-      formatNumber(rb.breakPercentage),
-      formatNumber(rb.currentHigh),
-      formatNumber(rb.maxHighInLookback),
-      '', // MACD values
-      '',
-      '',
-      formatNumber(rb.avgVolume20Days),
-      formatNumber(rb.avgVolume100Days)
-    );
-  } else {
-    row.push(`"Break: ${formatPercentage(rb.breakPercentage)}"`);
-  }
-
-  return row;
-}
-
-/**
- * Format CSV row for a single result
- */
-function formatCSVRow(result: ScreeningResultItem, verbose: boolean, includeFutureReturns: boolean): string {
-  const baseRow = [
+function formatCSVRow(result: ScreeningResultItem, verbose: boolean): string {
+  const row = [
     `"${result.stockCode}"`,
     `"${result.companyName.replace(/"/g, '""')}"`,
-    `"${result.scaleCategory || 'N/A'}"`,
-    `"${result.sector33Name || 'N/A'}"`,
-    `"${result.screeningType}"`,
-    `"${formatDate(result.matchedDate)}"`,
+    `"${(result.scaleCategory || '').replace(/"/g, '""')}"`,
+    `"${(result.sector33Name || '').replace(/"/g, '""')}"`,
+    `"${result.matchedDate}"`,
+    `"${result.bestStrategyName.replace(/"/g, '""')}"`,
+    result.bestStrategyScore === null ? '' : result.bestStrategyScore.toString(),
+    result.matchStrategyCount.toString(),
   ];
 
-  let detailsRow: string[] = [];
-
-  if (
-    (result.screeningType === 'rangeBreakFast' || result.screeningType === 'rangeBreakSlow') &&
-    result.details.rangeBreak
-  ) {
-    detailsRow = formatRangeBreakCSVRow(result.details.rangeBreak, verbose);
+  if (verbose) {
+    const matched = result.matchedStrategies
+      .map((strategy) => `${strategy.strategyName}:${formatScore(strategy.strategyScore)}`)
+      .join('|');
+    row.push(`"${matched.replace(/"/g, '""')}"`);
   }
 
-  // Add future returns if included
-  if (includeFutureReturns) {
-    const fr = result.futureReturns;
-    const day5 = fr?.day5?.changePercent?.toFixed(2) ?? '';
-    const day20 = fr?.day20?.changePercent?.toFixed(2) ?? '';
-    const day60 = fr?.day60?.changePercent?.toFixed(2) ?? '';
-    // Insert future returns after volume ratio (index 0 in detailsRow)
-    detailsRow.splice(1, 0, day5, day20, day60);
-  }
-
-  return [...baseRow, ...detailsRow].join(',');
+  return row.join(',');
 }
 
-/**
- * Format results as CSV
- */
 function formatAsCSV(results: ScreeningResultItem[], options: FormatterOptions): void {
-  const includeFutureReturns = hasFutureReturns(results);
-  const headers = getCSVHeaders(options.verbose, includeFutureReturns);
+  const headers = getCSVHeaders(options.verbose);
   console.log(headers.join(','));
 
   for (const result of results) {
-    console.log(formatCSVRow(result, options.verbose, includeFutureReturns));
+    console.log(formatCSVRow(result, options.verbose));
   }
 }
 
-/**
- * Format results for display
- */
 export async function formatResults(results: ScreeningResultItem[], options: FormatterOptions): Promise<void> {
-  if (results.length === 0) {
-    console.log(chalk.yellow('No results to display'));
-    return;
-  }
-
   switch (options.format) {
+    case 'table':
+      formatAsTable(results, options);
+      break;
     case 'json':
-      formatAsJSON(results, options);
+      formatAsJSON(results);
       break;
     case 'csv':
       formatAsCSV(results, options);
       break;
     default:
-      formatAsTable(results, options);
-      break;
-  }
-
-  // Debug information
-  if (options.debug) {
-    console.log(chalk.gray('\n🔍 Debug Information:'));
-    console.log(chalk.gray(`Results processed: ${results.length}`));
-    console.log(chalk.gray(`Format: ${options.format}`));
-    console.log(chalk.gray(`Verbose: ${options.verbose}`));
+      throw new Error(`Unsupported format: ${options.format}`);
   }
 }

--- a/apps/ts/packages/cli/src/utils/api-clients/analytics-client.ts
+++ b/apps/ts/packages/cli/src/utils/api-clients/analytics-client.ts
@@ -32,24 +32,20 @@ export class AnalyticsClient extends BaseApiClient {
    */
   async runMarketScreening(params: {
     markets?: string;
-    rangeBreakFast?: boolean;
-    rangeBreakSlow?: boolean;
+    strategies?: string;
     recentDays?: number;
     date?: string;
-    minBreakPercentage?: number;
-    minVolumeRatio?: number;
-    sortBy?: 'date' | 'stockCode' | 'volumeRatio' | 'breakPercentage';
+    backtestMetric?: 'sharpe_ratio' | 'calmar_ratio' | 'total_return' | 'win_rate' | 'profit_factor';
+    sortBy?: 'bestStrategyScore' | 'matchedDate' | 'stockCode' | 'matchStrategyCount';
     order?: 'asc' | 'desc';
     limit?: number;
   }): Promise<MarketScreeningResponse> {
     const query = toQueryString({
       markets: params.markets,
-      rangeBreakFast: params.rangeBreakFast,
-      rangeBreakSlow: params.rangeBreakSlow,
+      strategies: params.strategies,
       recentDays: params.recentDays,
       date: params.date,
-      minBreakPercentage: params.minBreakPercentage,
-      minVolumeRatio: params.minVolumeRatio,
+      backtestMetric: params.backtestMetric,
       sortBy: params.sortBy,
       order: params.order,
       limit: params.limit,

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -6558,7 +6558,7 @@
           "Analytics"
         ],
         "summary": "Run stock screening",
-        "description": "Run stock screening analysis with Range Break Fast and Slow strategies.",
+        "description": "Run strategy-driven stock screening based on production strategy YAML configs.",
         "operationId": "get_screening_api_analytics_screening_get",
         "parameters": [
           {
@@ -6572,23 +6572,19 @@
             }
           },
           {
-            "name": "rangeBreakFast",
+            "name": "strategies",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "boolean",
-              "default": true,
-              "title": "Rangebreakfast"
-            }
-          },
-          {
-            "name": "rangeBreakSlow",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true,
-              "title": "Rangebreakslow"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Strategies"
             }
           },
           {
@@ -6621,35 +6617,20 @@
             }
           },
           {
-            "name": "minBreakPercentage",
+            "name": "backtestMetric",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
+              "enum": [
+                "sharpe_ratio",
+                "calmar_ratio",
+                "total_return",
+                "win_rate",
+                "profit_factor"
               ],
-              "title": "Minbreakpercentage"
-            }
-          },
-          {
-            "name": "minVolumeRatio",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Minvolumeratio"
+              "type": "string",
+              "default": "sharpe_ratio",
+              "title": "Backtestmetric"
             }
           },
           {
@@ -6657,9 +6638,14 @@
             "in": "query",
             "required": false,
             "schema": {
+              "enum": [
+                "bestStrategyScore",
+                "matchedDate",
+                "stockCode",
+                "matchStrategyCount"
+              ],
               "type": "string",
-              "pattern": "^(date|stockCode|volumeRatio|breakPercentage)$",
-              "default": "date",
+              "default": "bestStrategyScore",
               "title": "Sortby"
             }
           },
@@ -6668,8 +6654,11 @@
             "in": "query",
             "required": false,
             "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string",
-              "pattern": "^(asc|desc)$",
               "default": "desc",
               "title": "Order"
             }
@@ -7343,7 +7332,7 @@
                   "additionalProperties": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
+                      "$ref": "#/components/schemas/OHLCVRecord"
                     }
                   },
                   "title": "Response Get Dataset Ohlcv Batch Api Dataset  Name  Stocks Ohlcv Batch Get"
@@ -7463,7 +7452,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
+                    "$ref": "#/components/schemas/OHLCVRecord"
                   },
                   "title": "Response Get Dataset Stock Ohlcv Api Dataset  Name  Stocks  Code  Ohlcv Get"
                 }
@@ -12369,7 +12358,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__dataset__DateRange"
+                "$ref": "#/components/schemas/DateRange"
               },
               {
                 "type": "null"
@@ -12417,19 +12406,19 @@
       },
       "DateRange": {
         "properties": {
-          "from": {
+          "min": {
             "type": "string",
-            "title": "From"
+            "title": "Min"
           },
-          "to": {
+          "max": {
             "type": "string",
-            "title": "To"
+            "title": "Max"
           }
         },
         "type": "object",
         "required": [
-          "from",
-          "to"
+          "min",
+          "max"
         ],
         "title": "DateRange"
       },
@@ -13308,67 +13297,6 @@
         ],
         "title": "FundamentalsComputeResponse",
         "description": "Response for fundamentals computation."
-      },
-      "FutureReturnPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "price": {
-            "type": "number",
-            "title": "Price"
-          },
-          "changePercent": {
-            "type": "number",
-            "title": "Changepercent"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "price",
-          "changePercent"
-        ],
-        "title": "FutureReturnPoint",
-        "description": "将来リターンの1データポイント"
-      },
-      "FutureReturns": {
-        "properties": {
-          "day5": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/FutureReturnPoint"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "day20": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/FutureReturnPoint"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "day60": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/FutureReturnPoint"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "FutureReturns",
-        "description": "将来リターン（履歴モード用）"
       },
       "GenerateResultItem": {
         "properties": {
@@ -15750,6 +15678,35 @@
             ],
             "title": "Referencedate"
           },
+          "backtestMetric": {
+            "type": "string",
+            "enum": [
+              "sharpe_ratio",
+              "calmar_ratio",
+              "total_return",
+              "win_rate",
+              "profit_factor"
+            ],
+            "title": "Backtestmetric"
+          },
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "bestStrategyScore",
+              "matchedDate",
+              "stockCode",
+              "matchStrategyCount"
+            ],
+            "title": "Sortby"
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "title": "Order"
+          },
           "lastUpdated": {
             "type": "string",
             "title": "Lastupdated"
@@ -15761,6 +15718,9 @@
           "summary",
           "markets",
           "recentDays",
+          "backtestMetric",
+          "sortBy",
+          "order",
           "lastUpdated"
         ],
         "title": "MarketScreeningResponse",
@@ -15963,6 +15923,36 @@
         ],
         "title": "MarketValidationResponse"
       },
+      "MatchedStrategyItem": {
+        "properties": {
+          "strategyName": {
+            "type": "string",
+            "title": "Strategyname"
+          },
+          "matchedDate": {
+            "type": "string",
+            "title": "Matcheddate"
+          },
+          "strategyScore": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strategyscore"
+          }
+        },
+        "type": "object",
+        "required": [
+          "strategyName",
+          "matchedDate"
+        ],
+        "title": "MatchedStrategyItem",
+        "description": "同一銘柄でヒットした戦略情報"
+      },
       "OHLCRecord": {
         "properties": {
           "date": {
@@ -16000,33 +15990,27 @@
         "properties": {
           "date": {
             "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
+            "title": "Date"
           },
           "open": {
             "type": "number",
-            "title": "Open",
-            "description": "始値"
+            "title": "Open"
           },
           "high": {
             "type": "number",
-            "title": "High",
-            "description": "高値"
+            "title": "High"
           },
           "low": {
             "type": "number",
-            "title": "Low",
-            "description": "安値"
+            "title": "Low"
           },
           "close": {
             "type": "number",
-            "title": "Close",
-            "description": "終値"
+            "title": "Close"
           },
           "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
+            "type": "integer",
+            "title": "Volume"
           }
         },
         "type": "object",
@@ -16038,8 +16022,7 @@
           "close",
           "volume"
         ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
+        "title": "OHLCVRecord"
       },
       "OHLCVResampleRequest": {
         "properties": {
@@ -16160,7 +16143,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/OHLCVRecord"
+              "$ref": "#/components/schemas/src__server__schemas__indicators__OHLCVRecord"
             },
             "type": "array",
             "title": "Data",
@@ -16789,7 +16772,7 @@
             "title": "Datapoints"
           },
           "dateRange": {
-            "$ref": "#/components/schemas/DateRange"
+            "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__DateRange"
           },
           "excludedStocks": {
             "items": {
@@ -17376,50 +17359,6 @@
         ],
         "title": "ROESummary",
         "description": "ROE 集計統計"
-      },
-      "RangeBreakDetails": {
-        "properties": {
-          "breakDate": {
-            "type": "string",
-            "title": "Breakdate"
-          },
-          "currentHigh": {
-            "type": "number",
-            "title": "Currenthigh"
-          },
-          "maxHighInLookback": {
-            "type": "number",
-            "title": "Maxhighinlookback"
-          },
-          "breakPercentage": {
-            "type": "number",
-            "title": "Breakpercentage"
-          },
-          "volumeRatio": {
-            "type": "number",
-            "title": "Volumeratio"
-          },
-          "avgVolume20Days": {
-            "type": "number",
-            "title": "Avgvolume20Days"
-          },
-          "avgVolume100Days": {
-            "type": "number",
-            "title": "Avgvolume100Days"
-          }
-        },
-        "type": "object",
-        "required": [
-          "breakDate",
-          "currentHigh",
-          "maxHighInLookback",
-          "breakPercentage",
-          "volumeRatio",
-          "avgVolume20Days",
-          "avgVolume100Days"
-        ],
-        "title": "RangeBreakDetails",
-        "description": "レンジブレイク詳細"
       },
       "RankingItem": {
         "properties": {
@@ -18170,23 +18109,6 @@
         "title": "RelativeOHLCOptions",
         "description": "相対OHLCオプション"
       },
-      "ScreeningDetails": {
-        "properties": {
-          "rangeBreak": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RangeBreakDetails"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "ScreeningDetails",
-        "description": "スクリーニング詳細"
-      },
       "ScreeningResultItem": {
         "properties": {
           "stockCode": {
@@ -18219,38 +18141,47 @@
             ],
             "title": "Sector33Name"
           },
-          "screeningType": {
-            "type": "string",
-            "title": "Screeningtype"
-          },
           "matchedDate": {
             "type": "string",
             "title": "Matcheddate"
           },
-          "details": {
-            "$ref": "#/components/schemas/ScreeningDetails"
+          "bestStrategyName": {
+            "type": "string",
+            "title": "Beststrategyname"
           },
-          "futureReturns": {
+          "bestStrategyScore": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/FutureReturns"
+                "type": "number"
               },
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Beststrategyscore"
+          },
+          "matchStrategyCount": {
+            "type": "integer",
+            "title": "Matchstrategycount"
+          },
+          "matchedStrategies": {
+            "items": {
+              "$ref": "#/components/schemas/MatchedStrategyItem"
+            },
+            "type": "array",
+            "title": "Matchedstrategies"
           }
         },
         "type": "object",
         "required": [
           "stockCode",
           "companyName",
-          "screeningType",
           "matchedDate",
-          "details"
+          "bestStrategyName",
+          "matchStrategyCount"
         ],
         "title": "ScreeningResultItem",
-        "description": "スクリーニング結果項目"
+        "description": "銘柄集約済みスクリーニング結果項目"
       },
       "ScreeningSummary": {
         "properties": {
@@ -18267,12 +18198,33 @@
             "title": "Skippedcount",
             "default": 0
           },
-          "byScreeningType": {
+          "byStrategy": {
             "additionalProperties": {
               "type": "integer"
             },
             "type": "object",
-            "title": "Byscreeningtype"
+            "title": "Bystrategy"
+          },
+          "strategiesEvaluated": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Strategiesevaluated"
+          },
+          "strategiesWithoutBacktestMetrics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Strategieswithoutbacktestmetrics"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
           }
         },
         "type": "object",
@@ -21411,62 +21363,6 @@
         "type": "object",
         "title": "WatchlistUpdateRequest"
       },
-      "src__server__schemas__dataset__DateRange": {
-        "properties": {
-          "min": {
-            "type": "string",
-            "title": "Min"
-          },
-          "max": {
-            "type": "string",
-            "title": "Max"
-          }
-        },
-        "type": "object",
-        "required": [
-          "min",
-          "max"
-        ],
-        "title": "DateRange"
-      },
-      "src__server__schemas__dataset_data__OHLCVRecord": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "open": {
-            "type": "number",
-            "title": "Open"
-          },
-          "high": {
-            "type": "number",
-            "title": "High"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close"
-          },
-          "volume": {
-            "type": "integer",
-            "title": "Volume"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
-        ],
-        "title": "OHLCVRecord"
-      },
       "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
@@ -21503,6 +21399,69 @@
         ],
         "title": "DateRange",
         "description": "分析期間"
+      },
+      "src__server__schemas__indicators__OHLCVRecord": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
+          },
+          "open": {
+            "type": "number",
+            "title": "Open",
+            "description": "始値"
+          },
+          "high": {
+            "type": "number",
+            "title": "High",
+            "description": "高値"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low",
+            "description": "安値"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close",
+            "description": "終値"
+          },
+          "volume": {
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
+        ],
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
+      },
+      "src__server__schemas__portfolio_factor_regression__DateRange": {
+        "properties": {
+          "from": {
+            "type": "string",
+            "title": "From"
+          },
+          "to": {
+            "type": "string",
+            "title": "To"
+          }
+        },
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "title": "DateRange"
       },
       "src__server__schemas__portfolio_factor_regression__IndexMatch": {
         "properties": {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -1629,7 +1629,7 @@ export interface paths {
         };
         /**
          * Run stock screening
-         * @description Run stock screening analysis with Range Break Fast and Slow strategies.
+         * @description Run strategy-driven stock screening based on production strategy YAML configs.
          */
         get: operations["get_screening_api_analytics_screening_get"];
         put?: never;
@@ -2995,7 +2995,7 @@ export interface components {
              * @description Stocks with OHLCV data
              */
             stocksWithQuotes: number;
-            dateRange?: components["schemas"]["src__server__schemas__dataset__DateRange"] | null;
+            dateRange?: components["schemas"]["DateRange"] | null;
             validation: components["schemas"]["DatasetValidation"];
         };
         /** DatasetValidation */
@@ -3009,10 +3009,10 @@ export interface components {
         };
         /** DateRange */
         DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
         };
         /**
          * DefaultConfigResponse
@@ -3430,27 +3430,6 @@ export interface components {
              * @description Last updated timestamp (ISO 8601)
              */
             lastUpdated: string;
-        };
-        /**
-         * FutureReturnPoint
-         * @description 将来リターンの1データポイント
-         */
-        FutureReturnPoint: {
-            /** Date */
-            date: string;
-            /** Price */
-            price: number;
-            /** Changepercent */
-            changePercent: number;
-        };
-        /**
-         * FutureReturns
-         * @description 将来リターン（履歴モード用）
-         */
-        FutureReturns: {
-            day5?: components["schemas"]["FutureReturnPoint"] | null;
-            day20?: components["schemas"]["FutureReturnPoint"] | null;
-            day60?: components["schemas"]["FutureReturnPoint"] | null;
         };
         /**
          * GenerateResultItem
@@ -4732,6 +4711,21 @@ export interface components {
             recentDays: number;
             /** Referencedate */
             referenceDate?: string | null;
+            /**
+             * Backtestmetric
+             * @enum {string}
+             */
+            backtestMetric: "sharpe_ratio" | "calmar_ratio" | "total_return" | "win_rate" | "profit_factor";
+            /**
+             * Sortby
+             * @enum {string}
+             */
+            sortBy: "bestStrategyScore" | "matchedDate" | "stockCode" | "matchStrategyCount";
+            /**
+             * Order
+             * @enum {string}
+             */
+            order: "asc" | "desc";
             /** Lastupdated */
             lastUpdated: string;
         };
@@ -4820,6 +4814,18 @@ export interface components {
             /** Lastupdated */
             lastUpdated: string;
         };
+        /**
+         * MatchedStrategyItem
+         * @description 同一銘柄でヒットした戦略情報
+         */
+        MatchedStrategyItem: {
+            /** Strategyname */
+            strategyName: string;
+            /** Matcheddate */
+            matchedDate: string;
+            /** Strategyscore */
+            strategyScore?: number | null;
+        };
         /** OHLCRecord */
         OHLCRecord: {
             /** Date */
@@ -4833,40 +4839,19 @@ export interface components {
             /** Close */
             close: number;
         };
-        /**
-         * OHLCVRecord
-         * @description OHLCVレコード
-         */
+        /** OHLCVRecord */
         OHLCVRecord: {
-            /**
-             * Date
-             * @description 日付 (YYYY-MM-DD)
-             */
+            /** Date */
             date: string;
-            /**
-             * Open
-             * @description 始値
-             */
+            /** Open */
             open: number;
-            /**
-             * High
-             * @description 高値
-             */
+            /** High */
             high: number;
-            /**
-             * Low
-             * @description 安値
-             */
+            /** Low */
             low: number;
-            /**
-             * Close
-             * @description 終値
-             */
+            /** Close */
             close: number;
-            /**
-             * Volume
-             * @description 出来高
-             */
+            /** Volume */
             volume: number;
         };
         /**
@@ -4945,7 +4930,7 @@ export interface components {
              * Data
              * @description OHLCVデータ
              */
-            data: components["schemas"]["OHLCVRecord"][];
+            data: components["schemas"]["src__server__schemas__indicators__OHLCVRecord"][];
         };
         /**
          * OptimizationGridConfig
@@ -5296,7 +5281,7 @@ export interface components {
             analysisDate: string;
             /** Datapoints */
             dataPoints: number;
-            dateRange: components["schemas"]["DateRange"];
+            dateRange: components["schemas"]["src__server__schemas__portfolio_factor_regression__DateRange"];
             /** Excludedstocks */
             excludedStocks: components["schemas"]["ExcludedStock"][];
         };
@@ -5492,26 +5477,6 @@ export interface components {
             minROE: number;
             /** Totalcompanies */
             totalCompanies: number;
-        };
-        /**
-         * RangeBreakDetails
-         * @description レンジブレイク詳細
-         */
-        RangeBreakDetails: {
-            /** Breakdate */
-            breakDate: string;
-            /** Currenthigh */
-            currentHigh: number;
-            /** Maxhighinlookback */
-            maxHighInLookback: number;
-            /** Breakpercentage */
-            breakPercentage: number;
-            /** Volumeratio */
-            volumeRatio: number;
-            /** Avgvolume20Days */
-            avgVolume20Days: number;
-            /** Avgvolume100Days */
-            avgVolume100Days: number;
         };
         /**
          * RankingItem
@@ -5718,15 +5683,8 @@ export interface components {
             handle_zero_division: "skip" | "zero" | "null";
         };
         /**
-         * ScreeningDetails
-         * @description スクリーニング詳細
-         */
-        ScreeningDetails: {
-            rangeBreak?: components["schemas"]["RangeBreakDetails"] | null;
-        };
-        /**
          * ScreeningResultItem
-         * @description スクリーニング結果項目
+         * @description 銘柄集約済みスクリーニング結果項目
          */
         ScreeningResultItem: {
             /** Stockcode */
@@ -5737,12 +5695,16 @@ export interface components {
             scaleCategory?: string | null;
             /** Sector33Name */
             sector33Name?: string | null;
-            /** Screeningtype */
-            screeningType: string;
             /** Matcheddate */
             matchedDate: string;
-            details: components["schemas"]["ScreeningDetails"];
-            futureReturns?: components["schemas"]["FutureReturns"] | null;
+            /** Beststrategyname */
+            bestStrategyName: string;
+            /** Beststrategyscore */
+            bestStrategyScore?: number | null;
+            /** Matchstrategycount */
+            matchStrategyCount: number;
+            /** Matchedstrategies */
+            matchedStrategies?: components["schemas"]["MatchedStrategyItem"][];
         };
         /**
          * ScreeningSummary
@@ -5758,10 +5720,16 @@ export interface components {
              * @default 0
              */
             skippedCount: number;
-            /** Byscreeningtype */
-            byScreeningType?: {
+            /** Bystrategy */
+            byStrategy?: {
                 [key: string]: number;
             };
+            /** Strategiesevaluated */
+            strategiesEvaluated?: string[];
+            /** Strategieswithoutbacktestmetrics */
+            strategiesWithoutBacktestMetrics?: string[];
+            /** Warnings */
+            warnings?: string[];
         };
         /** SearchResultItem */
         SearchResultItem: {
@@ -7231,28 +7199,6 @@ export interface components {
             description?: string | null;
         };
         /** DateRange */
-        src__server__schemas__dataset__DateRange: {
-            /** Min */
-            min: string;
-            /** Max */
-            max: string;
-        };
-        /** OHLCVRecord */
-        src__server__schemas__dataset_data__OHLCVRecord: {
-            /** Date */
-            date: string;
-            /** Open */
-            open: number;
-            /** High */
-            high: number;
-            /** Low */
-            low: number;
-            /** Close */
-            close: number;
-            /** Volume */
-            volume: number;
-        };
-        /** DateRange */
         src__server__schemas__db__DateRange: {
             /** Min */
             min: string;
@@ -7264,6 +7210,49 @@ export interface components {
          * @description 分析期間
          */
         src__server__schemas__factor_regression__DateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
+        };
+        /**
+         * OHLCVRecord
+         * @description OHLCVレコード
+         */
+        src__server__schemas__indicators__OHLCVRecord: {
+            /**
+             * Date
+             * @description 日付 (YYYY-MM-DD)
+             */
+            date: string;
+            /**
+             * Open
+             * @description 始値
+             */
+            open: number;
+            /**
+             * High
+             * @description 高値
+             */
+            high: number;
+            /**
+             * Low
+             * @description 安値
+             */
+            low: number;
+            /**
+             * Close
+             * @description 終値
+             */
+            close: number;
+            /**
+             * Volume
+             * @description 出来高
+             */
+            volume: number;
+        };
+        /** DateRange */
+        src__server__schemas__portfolio_factor_regression__DateRange: {
             /** From */
             from: string;
             /** To */
@@ -12001,14 +11990,12 @@ export interface operations {
         parameters: {
             query?: {
                 markets?: string;
-                rangeBreakFast?: boolean;
-                rangeBreakSlow?: boolean;
+                strategies?: string | null;
                 recentDays?: number;
                 date?: string | null;
-                minBreakPercentage?: number | null;
-                minVolumeRatio?: number | null;
-                sortBy?: string;
-                order?: string;
+                backtestMetric?: "sharpe_ratio" | "calmar_ratio" | "total_return" | "win_rate" | "profit_factor";
+                sortBy?: "bestStrategyScore" | "matchedDate" | "stockCode" | "matchStrategyCount";
+                order?: "asc" | "desc";
                 limit?: number | null;
             };
             header?: never;
@@ -12535,7 +12522,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
+                        [key: string]: components["schemas"]["OHLCVRecord"][];
                     };
                 };
             };
@@ -12598,7 +12585,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
+                    "application/json": components["schemas"]["OHLCVRecord"][];
                 };
             };
             /** @description Bad Request */

--- a/apps/ts/packages/shared/src/index.ts
+++ b/apps/ts/packages/shared/src/index.ts
@@ -167,6 +167,7 @@ export { cleanNaNValues } from './ta';
 // ===== API RESPONSE TYPE EXPORTS =====
 export type {
   AdjustmentEvent as ApiAdjustmentEvent,
+  BacktestMetric,
   CancelDatasetJobResponse,
   CancelJobResponse,
   CreateSyncJobResponse,
@@ -188,6 +189,7 @@ export type {
   MarketRankingResponse,
   MarketScreeningResponse,
   MarketValidationResponse,
+  MatchedStrategyItem,
   PresetInfo,
   RankingItem as ApiRankingItem,
   Rankings,
@@ -195,7 +197,6 @@ export type {
   ScreeningResultItem,
   ScreeningSortBy,
   ScreeningSummary,
-  ScreeningType as ApiScreeningType,
   SortOrder,
   SyncJobResponse,
   SyncJobResult,

--- a/apps/ts/packages/shared/src/types/api-response-types.ts
+++ b/apps/ts/packages/shared/src/types/api-response-types.ts
@@ -44,30 +44,19 @@ export type RankingType = 'tradingValue' | 'gainers' | 'losers' | 'periodHigh' |
 
 // ===== SCREENING TYPES =====
 
-export type ScreeningType = 'rangeBreakFast' | 'rangeBreakSlow';
-export type ScreeningSortBy = 'date' | 'stockCode' | 'volumeRatio' | 'breakPercentage';
+export type BacktestMetric =
+  | 'sharpe_ratio'
+  | 'calmar_ratio'
+  | 'total_return'
+  | 'win_rate'
+  | 'profit_factor';
+export type ScreeningSortBy = 'bestStrategyScore' | 'matchedDate' | 'stockCode' | 'matchStrategyCount';
 export type SortOrder = 'asc' | 'desc';
 
-export interface RangeBreakDetails {
-  breakDate: string;
-  currentHigh: number;
-  maxHighInLookback: number;
-  breakPercentage: number;
-  volumeRatio: number;
-  avgVolume20Days: number;
-  avgVolume100Days: number;
-}
-
-export interface FuturePricePoint {
-  date: string;
-  price: number;
-  changePercent: number;
-}
-
-export interface FutureReturns {
-  day5: FuturePricePoint | null;
-  day20: FuturePricePoint | null;
-  day60: FuturePricePoint | null;
+export interface MatchedStrategyItem {
+  strategyName: string;
+  matchedDate: string;
+  strategyScore: number | null;
 }
 
 export interface ScreeningResultItem {
@@ -75,22 +64,21 @@ export interface ScreeningResultItem {
   companyName: string;
   scaleCategory?: string;
   sector33Name?: string;
-  screeningType: ScreeningType;
   matchedDate: string;
-  details: {
-    rangeBreak?: RangeBreakDetails;
-  };
-  futureReturns?: FutureReturns;
+  bestStrategyName: string;
+  bestStrategyScore: number | null;
+  matchStrategyCount: number;
+  matchedStrategies: MatchedStrategyItem[];
 }
 
 export interface ScreeningSummary {
   totalStocksScreened: number;
   matchCount: number;
   skippedCount: number;
-  byScreeningType: {
-    rangeBreakFast: number;
-    rangeBreakSlow: number;
-  };
+  byStrategy: Record<string, number>;
+  strategiesEvaluated: string[];
+  strategiesWithoutBacktestMetrics: string[];
+  warnings: string[];
 }
 
 export interface MarketScreeningResponse {
@@ -99,6 +87,9 @@ export interface MarketScreeningResponse {
   markets: string[];
   recentDays: number;
   referenceDate?: string;
+  backtestMetric: BacktestMetric;
+  sortBy: ScreeningSortBy;
+  order: SortOrder;
   lastUpdated: string;
 }
 

--- a/apps/ts/packages/web/src/components/Screening/ScreeningFilters.test.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningFilters.test.tsx
@@ -6,43 +6,67 @@ import { ScreeningFilters } from './ScreeningFilters';
 describe('ScreeningFilters', () => {
   const defaultParams: ScreeningParams = {
     markets: 'prime',
-    rangeBreakFast: true,
-    rangeBreakSlow: true,
     recentDays: 10,
-    sortBy: 'date',
+    backtestMetric: 'sharpe_ratio',
+    sortBy: 'bestStrategyScore',
     order: 'desc',
     limit: 50,
   };
 
+  const strategyOptions = ['range_break_v15', 'forward_eps_driven'];
+
   it('renders filter card with title', () => {
-    render(<ScreeningFilters params={defaultParams} onChange={vi.fn()} />);
+    render(
+      <ScreeningFilters
+        params={defaultParams}
+        onChange={vi.fn()}
+        strategyOptions={strategyOptions}
+        strategiesLoading={false}
+      />
+    );
 
     expect(screen.getByText('Filters')).toBeInTheDocument();
   });
 
-  it('renders screening type toggles', () => {
-    render(<ScreeningFilters params={defaultParams} onChange={vi.fn()} />);
+  it('renders dynamic strategy options', () => {
+    render(
+      <ScreeningFilters
+        params={defaultParams}
+        onChange={vi.fn()}
+        strategyOptions={strategyOptions}
+        strategiesLoading={false}
+      />
+    );
 
-    expect(screen.getByText('Range Break Fast')).toBeInTheDocument();
-    expect(screen.getByText('Range Break Slow')).toBeInTheDocument();
+    expect(screen.getByText('Strategies')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'range_break_v15' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'forward_eps_driven' })).toBeInTheDocument();
   });
 
-  it('renders number inputs', () => {
-    render(<ScreeningFilters params={defaultParams} onChange={vi.fn()} />);
+  it('renders backtest metric and sort controls', () => {
+    render(
+      <ScreeningFilters
+        params={defaultParams}
+        onChange={vi.fn()}
+        strategyOptions={strategyOptions}
+        strategiesLoading={false}
+      />
+    );
 
-    expect(screen.getByText('Min Break %')).toBeInTheDocument();
-    expect(screen.getByText('Min Volume Ratio')).toBeInTheDocument();
-  });
-
-  it('renders sort and order selects', () => {
-    render(<ScreeningFilters params={defaultParams} onChange={vi.fn()} />);
-
+    expect(screen.getByText('Backtest Metric')).toBeInTheDocument();
     expect(screen.getByText('Sort By')).toBeInTheDocument();
     expect(screen.getByText('Order')).toBeInTheDocument();
   });
 
   it('renders recent days and limit selects', () => {
-    render(<ScreeningFilters params={defaultParams} onChange={vi.fn()} />);
+    render(
+      <ScreeningFilters
+        params={defaultParams}
+        onChange={vi.fn()}
+        strategyOptions={strategyOptions}
+        strategiesLoading={false}
+      />
+    );
 
     expect(screen.getByText('Recent Days')).toBeInTheDocument();
     expect(screen.getByText('Limit')).toBeInTheDocument();

--- a/apps/ts/packages/web/src/components/Screening/ScreeningSummary.test.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningSummary.test.tsx
@@ -7,10 +7,13 @@ const mockSummary: Summary = {
   totalStocksScreened: 1500,
   matchCount: 42,
   skippedCount: 0,
-  byScreeningType: {
-    rangeBreakFast: 28,
-    rangeBreakSlow: 14,
+  byStrategy: {
+    range_break_v15: 28,
+    forward_eps_driven: 14,
   },
+  strategiesEvaluated: ['range_break_v15', 'forward_eps_driven'],
+  strategiesWithoutBacktestMetrics: ['forward_eps_driven'],
+  warnings: ['benchmark load failed'],
 };
 
 describe('ScreeningSummary', () => {
@@ -19,26 +22,21 @@ describe('ScreeningSummary', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders total screened count', () => {
+  it('renders total screened count and match hit rate', () => {
     render(<ScreeningSummary summary={mockSummary} markets={['prime']} recentDays={10} />);
 
     expect(screen.getByText('1,500')).toBeInTheDocument();
-  });
-
-  it('renders match count and hit rate', () => {
-    render(<ScreeningSummary summary={mockSummary} markets={['prime']} recentDays={10} />);
-
     expect(screen.getByText('42')).toBeInTheDocument();
     expect(screen.getByText('2.8% hit rate')).toBeInTheDocument();
   });
 
-  it('renders screening type breakdown', () => {
+  it('renders strategy and warning metrics', () => {
     render(<ScreeningSummary summary={mockSummary} markets={['prime']} recentDays={10} />);
 
-    expect(screen.getByText('28')).toBeInTheDocument();
-    expect(screen.getByText('14')).toBeInTheDocument();
-    expect(screen.getByText('EMA 30/120')).toBeInTheDocument();
-    expect(screen.getByText('SMA 50/150')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('range_break_v15 (28)')).toBeInTheDocument();
+    expect(screen.getByText('1 warnings')).toBeInTheDocument();
   });
 
   it('shows market info with reference date when provided', () => {
@@ -52,11 +50,5 @@ describe('ScreeningSummary', () => {
     );
 
     expect(screen.getByText('prime, standard / 20d / 2025-01-30')).toBeInTheDocument();
-  });
-
-  it('shows market info without reference date when not provided', () => {
-    render(<ScreeningSummary summary={mockSummary} markets={['prime']} recentDays={10} />);
-
-    expect(screen.getByText('prime / 10d')).toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/Screening/ScreeningSummary.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningSummary.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, TrendingUp, Zap } from 'lucide-react';
+import { AlertTriangle, BarChart3, TrendingUp, Trophy } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import type { ScreeningSummary as Summary } from '@/types/screening';
 
@@ -16,53 +16,59 @@ export function ScreeningSummary({ summary, markets, recentDays, referenceDate }
     ? `${markets.join(', ')} / ${recentDays}d / ${referenceDate}`
     : `${markets.join(', ')} / ${recentDays}d`;
 
+  const hitRate = summary.totalStocksScreened > 0 ? (summary.matchCount / summary.totalStocksScreened) * 100 : 0;
+
+  const topStrategy = Object.entries(summary.byStrategy).sort((a, b) => b[1] - a[1])[0] || null;
+
   return (
-    <div className="grid grid-cols-4 gap-3 mb-4">
-      <Card className="glass-panel">
-        <CardContent className="p-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <BarChart3 className="h-4 w-4" />
-            <span className="text-xs">Screened</span>
-          </div>
-          <p className="text-xl font-bold tabular-nums">{summary.totalStocksScreened.toLocaleString()}</p>
-          <p className="text-xs text-muted-foreground mt-1">{marketInfo}</p>
-        </CardContent>
-      </Card>
+    <>
+      <div className="grid grid-cols-4 gap-3 mb-4">
+        <Card className="glass-panel">
+          <CardContent className="p-3">
+            <div className="flex items-center gap-2 text-muted-foreground mb-1">
+              <BarChart3 className="h-4 w-4" />
+              <span className="text-xs">Screened</span>
+            </div>
+            <p className="text-xl font-bold tabular-nums">{summary.totalStocksScreened.toLocaleString()}</p>
+            <p className="text-xs text-muted-foreground mt-1">{marketInfo}</p>
+          </CardContent>
+        </Card>
 
-      <Card className="glass-panel">
-        <CardContent className="p-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <TrendingUp className="h-4 w-4" />
-            <span className="text-xs">Matches</span>
-          </div>
-          <p className="text-xl font-bold tabular-nums text-green-600 dark:text-green-400">{summary.matchCount}</p>
-          <p className="text-xs text-muted-foreground mt-1">
-            {((summary.matchCount / summary.totalStocksScreened) * 100).toFixed(1)}% hit rate
-          </p>
-        </CardContent>
-      </Card>
+        <Card className="glass-panel">
+          <CardContent className="p-3">
+            <div className="flex items-center gap-2 text-muted-foreground mb-1">
+              <TrendingUp className="h-4 w-4" />
+              <span className="text-xs">Matches</span>
+            </div>
+            <p className="text-xl font-bold tabular-nums text-green-600 dark:text-green-400">{summary.matchCount}</p>
+            <p className="text-xs text-muted-foreground mt-1">{hitRate.toFixed(1)}% hit rate</p>
+          </CardContent>
+        </Card>
 
-      <Card className="glass-panel">
-        <CardContent className="p-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <Zap className="h-4 w-4" />
-            <span className="text-xs">Fast</span>
-          </div>
-          <p className="text-xl font-bold tabular-nums">{summary.byScreeningType.rangeBreakFast}</p>
-          <p className="text-xs text-muted-foreground mt-1">EMA 30/120</p>
-        </CardContent>
-      </Card>
+        <Card className="glass-panel">
+          <CardContent className="p-3">
+            <div className="flex items-center gap-2 text-muted-foreground mb-1">
+              <Trophy className="h-4 w-4" />
+              <span className="text-xs">Strategies</span>
+            </div>
+            <p className="text-xl font-bold tabular-nums">{summary.strategiesEvaluated.length}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {topStrategy ? `${topStrategy[0]} (${topStrategy[1]})` : 'No strategy hits'}
+            </p>
+          </CardContent>
+        </Card>
 
-      <Card className="glass-panel">
-        <CardContent className="p-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <TrendingUp className="h-4 w-4" />
-            <span className="text-xs">Slow</span>
-          </div>
-          <p className="text-xl font-bold tabular-nums">{summary.byScreeningType.rangeBreakSlow}</p>
-          <p className="text-xs text-muted-foreground mt-1">SMA 50/150</p>
-        </CardContent>
-      </Card>
-    </div>
+        <Card className="glass-panel">
+          <CardContent className="p-3">
+            <div className="flex items-center gap-2 text-muted-foreground mb-1">
+              <AlertTriangle className="h-4 w-4" />
+              <span className="text-xs">Missing Metrics</span>
+            </div>
+            <p className="text-xl font-bold tabular-nums">{summary.strategiesWithoutBacktestMetrics.length}</p>
+            <p className="text-xs text-muted-foreground mt-1">{summary.warnings.length} warnings</p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
   );
 }

--- a/apps/ts/packages/web/src/components/Screening/ScreeningTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningTable.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ScreeningResultItem } from '@/types/screening';
+import { ScreeningTable } from './ScreeningTable';
+
+const mockResults: ScreeningResultItem[] = [
+  {
+    stockCode: '7203',
+    companyName: 'Toyota Motor',
+    sector33Name: '輸送用機器',
+    matchedDate: '2026-01-07',
+    bestStrategyName: 'range_break_v15',
+    bestStrategyScore: 1.2345,
+    matchStrategyCount: 2,
+    matchedStrategies: [
+      { strategyName: 'range_break_v15', matchedDate: '2026-01-07', strategyScore: 1.2345 },
+      { strategyName: 'forward_eps_driven', matchedDate: '2026-01-06', strategyScore: 0.9 },
+    ],
+  },
+];
+
+describe('ScreeningTable', () => {
+  it('renders strategy-centric columns', () => {
+    render(<ScreeningTable results={mockResults} isLoading={false} error={null} onStockClick={vi.fn()} />);
+
+    expect(screen.getByText('Best Strategy')).toBeInTheDocument();
+    expect(screen.getByText('Score')).toBeInTheDocument();
+    expect(screen.getByText('Matches')).toBeInTheDocument();
+  });
+
+  it('renders best strategy and score values', () => {
+    render(<ScreeningTable results={mockResults} isLoading={false} error={null} onStockClick={vi.fn()} />);
+
+    expect(screen.getByText('range_break_v15')).toBeInTheDocument();
+    expect(screen.getByText('1.234')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Screening/ScreeningTable.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningTable.tsx
@@ -1,10 +1,8 @@
-import { TrendingUp, Zap } from 'lucide-react';
+import { TrendingUp } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DataStateWrapper } from '@/components/ui/data-state-wrapper';
-import { cn } from '@/lib/utils';
 import type { ScreeningResultItem } from '@/types/screening';
-import { getReturnColor } from '@/utils/color-schemes';
-import { formatDateShort, formatPercentage, formatReturnPercent, formatVolumeRatio } from '@/utils/formatters';
+import { formatDateShort } from '@/utils/formatters';
 
 interface ScreeningTableProps {
   results: ScreeningResultItem[];
@@ -13,25 +11,11 @@ interface ScreeningTableProps {
   onStockClick: (code: string) => void;
 }
 
-function hasFutureReturns(results: ScreeningResultItem[]): boolean {
-  return results.some((r) => r.futureReturns !== undefined);
-}
-
-function ScreeningTypeIcon({ type }: { type: ScreeningResultItem['screeningType'] }) {
-  if (type === 'rangeBreakFast') {
-    return (
-      <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
-        <Zap className="h-3 w-3" />
-        <span className="text-xs">Fast</span>
-      </span>
-    );
+function formatScore(score: number | null): string {
+  if (score === null || score === undefined) {
+    return '-';
   }
-  return (
-    <span className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400">
-      <TrendingUp className="h-3 w-3" />
-      <span className="text-xs">Slow</span>
-    </span>
-  );
+  return score.toFixed(3);
 }
 
 export function ScreeningTable({ results, isLoading, error, onStockClick }: ScreeningTableProps) {
@@ -40,9 +24,7 @@ export function ScreeningTable({ results, isLoading, error, onStockClick }: Scre
       <CardHeader className="border-b border-border/30 py-3">
         <CardTitle className="text-base">
           Screening Results
-          {results.length > 0 && (
-            <span className="text-sm font-normal text-muted-foreground ml-2">({results.length})</span>
-          )}
+          {results.length > 0 && <span className="text-sm font-normal text-muted-foreground ml-2">({results.length})</span>}
         </CardTitle>
       </CardHeader>
       <CardContent className="p-0 overflow-auto" style={{ maxHeight: 'calc(100vh - 280px)' }}>
@@ -61,82 +43,31 @@ export function ScreeningTable({ results, isLoading, error, onStockClick }: Scre
                 <th className="text-left p-2 w-16">Code</th>
                 <th className="text-left p-2">Company</th>
                 <th className="text-left p-2 w-24">Sector</th>
-                <th className="text-center p-2 w-16">Type</th>
-                <th className="text-right p-2 w-20">Vol Ratio</th>
-                <th className="text-right p-2 w-20">Break %</th>
-                {hasFutureReturns(results) && (
-                  <>
-                    <th className="text-right p-2 w-16">+5日</th>
-                    <th className="text-right p-2 w-16">+20日</th>
-                    <th className="text-right p-2 w-16">+60日</th>
-                  </>
-                )}
+                <th className="text-left p-2 w-40">Best Strategy</th>
+                <th className="text-right p-2 w-20">Score</th>
+                <th className="text-right p-2 w-16">Matches</th>
+                <th className="text-left p-2">Matched Strategies</th>
               </tr>
             </thead>
             <tbody>
-              {results.map((result, index) => {
-                const details = result.details.rangeBreak;
-                const showFutureReturns = hasFutureReturns(results);
-                return (
-                  <tr
-                    key={`${result.stockCode}-${result.matchedDate}-${index}`}
-                    className="border-b border-border/30 hover:bg-accent/30 cursor-pointer transition-colors"
-                    onClick={() => onStockClick(result.stockCode)}
-                  >
-                    <td className="p-2 text-muted-foreground tabular-nums">{formatDateShort(result.matchedDate)}</td>
-                    <td className="p-2 font-medium">{result.stockCode}</td>
-                    <td className="p-2 truncate max-w-[200px]">{result.companyName}</td>
-                    <td className="p-2 truncate max-w-[120px] text-muted-foreground">{result.sector33Name || '-'}</td>
-                    <td className="p-2 text-center">
-                      <ScreeningTypeIcon type={result.screeningType} />
-                    </td>
-                    <td
-                      className={cn(
-                        'p-2 text-right tabular-nums',
-                        details && details.volumeRatio >= 2 && 'text-green-600 dark:text-green-400 font-medium'
-                      )}
-                    >
-                      {formatVolumeRatio(details?.volumeRatio)}
-                    </td>
-                    <td
-                      className={cn(
-                        'p-2 text-right tabular-nums',
-                        details && details.breakPercentage >= 5 && 'text-green-600 dark:text-green-400 font-medium'
-                      )}
-                    >
-                      {formatPercentage(details?.breakPercentage, { showSign: false, decimals: 1 })}
-                    </td>
-                    {showFutureReturns && (
-                      <>
-                        <td
-                          className={cn(
-                            'p-2 text-right tabular-nums',
-                            getReturnColor(result.futureReturns?.day5?.changePercent)
-                          )}
-                        >
-                          {formatReturnPercent(result.futureReturns?.day5?.changePercent)}
-                        </td>
-                        <td
-                          className={cn(
-                            'p-2 text-right tabular-nums',
-                            getReturnColor(result.futureReturns?.day20?.changePercent)
-                          )}
-                        >
-                          {formatReturnPercent(result.futureReturns?.day20?.changePercent)}
-                        </td>
-                        <td
-                          className={cn(
-                            'p-2 text-right tabular-nums',
-                            getReturnColor(result.futureReturns?.day60?.changePercent)
-                          )}
-                        >
-                          {formatReturnPercent(result.futureReturns?.day60?.changePercent)}
-                        </td>
-                      </>
-                    )}
-                  </tr>
-                );
-              })}
+              {results.map((result) => (
+                <tr
+                  key={result.stockCode}
+                  className="border-b border-border/30 hover:bg-accent/30 cursor-pointer transition-colors"
+                  onClick={() => onStockClick(result.stockCode)}
+                >
+                  <td className="p-2 text-muted-foreground tabular-nums">{formatDateShort(result.matchedDate)}</td>
+                  <td className="p-2 font-medium">{result.stockCode}</td>
+                  <td className="p-2 truncate max-w-[200px]">{result.companyName}</td>
+                  <td className="p-2 truncate max-w-[120px] text-muted-foreground">{result.sector33Name || '-'}</td>
+                  <td className="p-2 truncate max-w-[180px]">{result.bestStrategyName}</td>
+                  <td className="p-2 text-right tabular-nums">{formatScore(result.bestStrategyScore)}</td>
+                  <td className="p-2 text-right tabular-nums">{result.matchStrategyCount}</td>
+                  <td className="p-2 text-muted-foreground truncate max-w-[260px]">
+                    {result.matchedStrategies.map((strategy) => strategy.strategyName).join(', ')}
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </DataStateWrapper>

--- a/apps/ts/packages/web/src/hooks/useScreening.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useScreening.test.tsx
@@ -21,12 +21,32 @@ afterEach(() => {
 
 describe('useScreening', () => {
   it('fetches screening data when enabled', async () => {
-    vi.mocked(apiGet).mockResolvedValueOnce({ items: [] });
+    vi.mocked(apiGet).mockResolvedValueOnce({
+      results: [],
+      summary: {
+        totalStocksScreened: 0,
+        matchCount: 0,
+        skippedCount: 0,
+        byStrategy: {},
+        strategiesEvaluated: [],
+        strategiesWithoutBacktestMetrics: [],
+        warnings: [],
+      },
+      markets: ['prime'],
+      recentDays: 10,
+      backtestMetric: 'sharpe_ratio',
+      sortBy: 'bestStrategyScore',
+      order: 'desc',
+      lastUpdated: '2026-01-01T00:00:00Z',
+    });
     const { wrapper } = createTestWrapper();
-    const params = { limit: 50 };
+    const params = { limit: 50, backtestMetric: 'calmar_ratio' as const, strategies: 'range_break_v15' };
     const { result } = renderHook(() => useScreening(params, true), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(apiGet).toHaveBeenCalledWith('/api/analytics/screening', expect.objectContaining({ limit: 50 }));
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/analytics/screening',
+      expect.objectContaining({ limit: 50, backtestMetric: 'calmar_ratio', strategies: 'range_break_v15' })
+    );
   });
 
   it('is disabled when enabled is false', () => {

--- a/apps/ts/packages/web/src/hooks/useScreening.ts
+++ b/apps/ts/packages/web/src/hooks/useScreening.ts
@@ -6,12 +6,10 @@ import { logger } from '@/utils/logger';
 function fetchScreening(params: ScreeningParams): Promise<MarketScreeningResponse> {
   return apiGet<MarketScreeningResponse>('/api/analytics/screening', {
     markets: params.markets,
-    rangeBreakFast: params.rangeBreakFast,
-    rangeBreakSlow: params.rangeBreakSlow,
+    strategies: params.strategies,
     recentDays: params.recentDays,
     date: params.date,
-    minBreakPercentage: params.minBreakPercentage,
-    minVolumeRatio: params.minVolumeRatio,
+    backtestMetric: params.backtestMetric,
     sortBy: params.sortBy,
     order: params.order,
     limit: params.limit,

--- a/apps/ts/packages/web/src/pages/AnalysisPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/AnalysisPage.test.tsx
@@ -9,6 +9,8 @@ const mockChartStore = {
   setSelectedSymbol: vi.fn(),
 };
 
+const mockScreeningFilters = vi.fn((_props: unknown) => <div>Screening Filters</div>);
+
 vi.mock('@/stores/chartStore', () => ({
   useChartStore: () => mockChartStore,
 }));
@@ -33,8 +35,21 @@ vi.mock('@/hooks/useRanking', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useBacktest', () => ({
+  useStrategies: () => ({
+    data: {
+      strategies: [
+        { name: 'production/range_break_v15', category: 'production' },
+        { name: 'production/forward_eps_driven', category: 'production' },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 vi.mock('@/components/Screening/ScreeningFilters', () => ({
-  ScreeningFilters: () => <div>Screening Filters</div>,
+  ScreeningFilters: (props: unknown) => mockScreeningFilters(props),
 }));
 
 vi.mock('@/components/Screening/ScreeningSummary', () => ({
@@ -60,6 +75,16 @@ vi.mock('@/components/Ranking', () => ({
 }));
 
 describe('AnalysisPage', () => {
+  it('passes full production strategy names to screening filters', () => {
+    render(<AnalysisPage />);
+
+    expect(mockScreeningFilters).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strategyOptions: ['production/forward_eps_driven', 'production/range_break_v15'],
+      })
+    );
+  });
+
   it('renders screening view by default and switches to ranking', async () => {
     const user = userEvent.setup();
     render(<AnalysisPage />);

--- a/apps/ts/packages/web/src/types/screening.ts
+++ b/apps/ts/packages/web/src/types/screening.ts
@@ -3,29 +3,25 @@
  * Re-exports from @trading25/shared and adds frontend-specific types
  */
 
-import type { ScreeningSortBy, SortOrder } from '@trading25/shared/types/api-response-types';
+import type { BacktestMetric, ScreeningSortBy, SortOrder } from '@trading25/shared/types/api-response-types';
 
 export type {
-  FuturePricePoint,
-  FutureReturns,
+  BacktestMetric,
+  MatchedStrategyItem,
   MarketScreeningResponse,
-  RangeBreakDetails,
   ScreeningResultItem,
   ScreeningSortBy,
   ScreeningSummary,
-  ScreeningType,
   SortOrder,
 } from '@trading25/shared/types/api-response-types';
 
 // Frontend-specific types
 export interface ScreeningParams {
   markets?: string;
-  rangeBreakFast?: boolean;
-  rangeBreakSlow?: boolean;
+  strategies?: string;
   recentDays?: number;
   date?: string;
-  minBreakPercentage?: number;
-  minVolumeRatio?: number;
+  backtestMetric?: BacktestMetric;
   sortBy?: ScreeningSortBy;
   order?: SortOrder;
   limit?: number;


### PR DESCRIPTION
Summary:
- Replace analytics screening with production strategy YAML-driven pipeline.
- Evaluate entry and exit via SignalProcessor and aggregate per stock.
- Remove legacy fast/slow screening query parameters.
- Update shared generated types, web screening UI, and CLI screening options/output.
- Add deep bt route/service tests and coverage improvements.

Validation:
- bt screening service/route tests passed.
- web test passed.
- cli test passed.
- typecheck all passed.

Breaking changes:
- Removed params: rangeBreakFast, rangeBreakSlow, minBreakPercentage, minVolumeRatio.
- Response is now stock-aggregated strategy-centric fields.