### PR TITLE
fix(bt-screening): enforce market.db SoT and latest reference date

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Screening API は非同期ジョブ方式（`POST /api/analytics/screening/jobs` / `GET /api/analytics/screening/jobs/{id}` / `POST /api/analytics/screening/jobs/{id}/cancel` / `GET /api/analytics/screening/result/{id}`）を SoT とする。旧 `GET /api/analytics/screening` は 410
+- Screening 実行時のデータ SoT は `market.db`（`stock_data` / `topix_data` / `indices_data` / `stocks`）とし、dataset へのフォールバックを禁止する
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - Strategy YAML更新の SoT は `/api/strategies/{name}` で、`production` / `experimental` を更新可能（`production` は既存ファイルの編集のみ許可）。`rename` / `delete` は引き続き `experimental` 限定
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う


### PR DESCRIPTION
## Summary
- enforce screening data SoT as market.db only (no dataset fallback)
- align screening referenceDate with latest trading day when omitted and clamp end-date to referenceDate
- improve forward EPS missing-data warning to requirement-based details instead of benchmark-presence wording
- add regression tests for screening service cache/date behaviors and signal processor requirement diagnostics
- update AGENTS.md with screening SoT rule

## Verification
- uv run pytest tests/unit/strategies/test_signal_processor.py tests/unit/server/services/test_screening_service.py tests/unit/server/services/test_screening_service_helpers.py
- API E2E: POST /api/analytics/screening/jobs -> GET status/result (referenceDate=2026-02-17, warning wording verified in server logs)
- uv run ruff check src/server/services/screening_service.py src/strategies/signals/processor.py tests/unit/server/services/test_screening_service.py tests/unit/server/services/test_screening_service_helpers.py tests/unit/strategies/test_signal_processor.py
- uv run pyright src/server/services/screening_service.py src/strategies/signals/processor.py