### PR TITLE
feat(web): show forecast PER in fundamentals card

### DIFF
--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -58,6 +58,7 @@ describe('FundamentalsSummaryCard', () => {
     expect(screen.getByText('時価総額/20日売買代金')).toBeInTheDocument();
     expect(screen.getByText('1.50x')).toBeInTheDocument();
     expect(screen.getByText('8.33x')).toBeInTheDocument();
+    expect(screen.getByText('(17.43x)')).toBeInTheDocument();
   });
 
   it('uses 15-day label by default', () => {
@@ -84,6 +85,7 @@ describe('FundamentalsSummaryCard', () => {
     expect(screen.getByText('予: 280')).toBeInTheDocument();
     expect(screen.getByText('(-12.5%)')).toBeInTheDocument();
     expect(screen.getByText('(2億)')).toBeInTheDocument();
+    expect(screen.queryByText('(22.86x)')).not.toBeInTheDocument();
     expect(screen.getByText(/単体 \/ JGAAP/)).toBeInTheDocument();
     expect(screen.queryByText(/株価 @ 開示日/)).not.toBeInTheDocument();
   });
@@ -98,5 +100,6 @@ describe('FundamentalsSummaryCard', () => {
 
     render(<FundamentalsSummaryCard metrics={metrics} />);
     expect(screen.queryByText(/予:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('(17.43x)')).not.toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -8,7 +8,7 @@ interface MetricCardProps {
   value: number | null;
   format: 'percent' | 'times' | 'yen' | 'millions';
   colorScheme?: FundamentalColorScheme;
-  /** Previous period value to show in parentheses */
+  /** Secondary value to show in parentheses */
   prevValue?: number | null;
   decimals?: number;
 }
@@ -89,6 +89,12 @@ interface FundamentalsSummaryCardProps {
   tradingValuePeriod?: number;
 }
 
+function resolveForecastPer(stockPrice: number | null, forecastEps: number | null): number | null {
+  if (stockPrice == null || forecastEps == null || forecastEps === 0) return null;
+  const forecastPer = stockPrice / forecastEps;
+  return Number.isFinite(forecastPer) ? forecastPer : null;
+}
+
 export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: FundamentalsSummaryCardProps) {
   if (!metrics) {
     return (
@@ -100,6 +106,7 @@ export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: Fu
 
   const displayEps = metrics.adjustedEps ?? metrics.eps;
   const displayForecastEps = metrics.adjustedForecastEps ?? metrics.forecastEps;
+  const displayForecastPer = resolveForecastPer(metrics.stockPrice, displayForecastEps ?? null);
   const displayBps = metrics.adjustedBps ?? metrics.bps;
   const displayDividendFy = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;
 
@@ -107,7 +114,7 @@ export function FundamentalsSummaryCard({ metrics, tradingValuePeriod = 15 }: Fu
     <div className="h-full min-h-0 flex flex-col">
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="grid grid-cols-8 gap-1.5 p-2">
-          <MetricCard label="PER" value={metrics.per} format="times" colorScheme="per" />
+          <MetricCard label="PER" value={metrics.per} format="times" colorScheme="per" prevValue={displayForecastPer} />
           <MetricCard label="PBR" value={metrics.pbr} format="times" colorScheme="pbr" />
           <MetricCard label="ROE" value={metrics.roe} format="percent" colorScheme="roe" />
           <MetricCard label="ROA" value={metrics.roa} format="percent" colorScheme="roe" />


### PR DESCRIPTION
## Summary\n- add forecast-based PER calculation in FundamentalsSummaryCard\n- show forecast PER in parentheses under PER when stock price and forecast EPS are available\n- add tests for display and non-display cases\n\n## Testing\n- bun run --filter @trading25/web test -- src/components/Chart/FundamentalsSummaryCard.test.tsx