### PR TITLE
feat(web): enrich backtest optimization grid editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ bun run cli backtest attribution run <strategy> --wait
 
 - Backtest UI は `Attribution` サブタブ内に `Run` / `History` を持ち、進捗取得は 2 秒ポーリング
 - Backtest `Strategies` 画面の YAML Editor は `production` / `experimental` の編集を許可し、`Rename` / `Delete` は `experimental` のみ許可
+- Backtest `Strategies > Optimize` の Grid Editor は Monaco + helper panel（preset 適用 / 検出 parameter path プレビュー / live YAML フィードバック）を提供し、保存ブロックは YAML 構文エラー時のみとする
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 - `analysis screening`（web/cli）は production 戦略を動的選択し、非同期ジョブ（2秒ポーリング）で実行する。`sortBy` 既定は `matchedDate`、`order` 既定は `desc`。`backtestMetric` は廃止
 

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationGridEditor.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationGridEditor.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OptimizationGridEditor } from './OptimizationGridEditor';
+
+const mockSaveMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+
+const mockHookState = {
+  gridConfig: {
+    strategy_name: 'demo',
+    content: `parameter_ranges:
+  entry_filter_params:
+    period_breakout:
+      period: [10, 20]
+  exit_trigger_params:
+    atr_stop:
+      atr_multiplier: [1.5, 2.0, 2.5]
+`,
+    param_count: 2,
+    combinations: 6,
+  },
+  isLoading: false,
+  isError: false,
+  savePending: false,
+  saveError: null as Error | null,
+  saveData: null as { strategy_name: string; param_count: number; combinations: number } | null,
+  deletePending: false,
+  deleteError: null as Error | null,
+};
+
+vi.mock('@/hooks/useOptimization', () => ({
+  useOptimizationGridConfig: () => ({
+    data: mockHookState.gridConfig,
+    isLoading: mockHookState.isLoading,
+    isError: mockHookState.isError,
+  }),
+  useSaveOptimizationGrid: () => ({
+    mutate: mockSaveMutate,
+    isPending: mockHookState.savePending,
+    isError: !!mockHookState.saveError,
+    error: mockHookState.saveError,
+    data: mockHookState.saveData,
+  }),
+  useDeleteOptimizationGrid: () => ({
+    mutate: mockDeleteMutate,
+    isPending: mockHookState.deletePending,
+    isError: !!mockHookState.deleteError,
+    error: mockHookState.deleteError,
+  }),
+}));
+
+vi.mock('@/components/Editor/MonacoYamlEditor', () => ({
+  MonacoYamlEditor: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="Optimization YAML Editor"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+describe('OptimizationGridEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHookState.gridConfig = {
+      strategy_name: 'demo',
+      content: `parameter_ranges:
+  entry_filter_params:
+    period_breakout:
+      period: [10, 20]
+  exit_trigger_params:
+    atr_stop:
+      atr_multiplier: [1.5, 2.0, 2.5]
+`,
+      param_count: 2,
+      combinations: 6,
+    };
+    mockHookState.isLoading = false;
+    mockHookState.isError = false;
+    mockHookState.savePending = false;
+    mockHookState.saveError = null;
+    mockHookState.saveData = null;
+    mockHookState.deletePending = false;
+    mockHookState.deleteError = null;
+  });
+
+  it('renders rich status and detected parameter previews', async () => {
+    render(<OptimizationGridEditor strategyName="production/demo" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Optimization YAML Editor') as HTMLTextAreaElement).value).toContain(
+        'parameter_ranges'
+      );
+    });
+
+    expect(screen.getByText('Optimization Grid Editor')).toBeInTheDocument();
+    expect(screen.getByText('2 params, 6 combinations')).toBeInTheDocument();
+    expect(screen.getByText('entry_filter_params.period_breakout.period')).toBeInTheDocument();
+    expect(screen.getByText('exit_trigger_params.atr_stop.atr_multiplier')).toBeInTheDocument();
+    expect(screen.getByText('Ready: 2 parameters, 6 combinations detected.')).toBeInTheDocument();
+  });
+
+  it('shows YAML parse error and disables save', async () => {
+    render(<OptimizationGridEditor strategyName="production/demo" />);
+
+    const editor = await screen.findByLabelText('Optimization YAML Editor');
+    fireEvent.change(editor, { target: { value: 'parameter_ranges: [invalid' } });
+
+    expect(await screen.findByText(/YAML parse error:/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('shows warning when parameter_ranges is missing but allows save', async () => {
+    render(<OptimizationGridEditor strategyName="production/demo" />);
+
+    const editor = await screen.findByLabelText('Optimization YAML Editor');
+    fireEvent.change(editor, { target: { value: 'foo: 1' } });
+
+    expect(
+      screen.getByText('Missing "parameter_ranges" key. Saving is allowed, but optimization combinations will be 0.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('shows warning when parameter arrays are not detected', async () => {
+    render(<OptimizationGridEditor strategyName="production/demo" />);
+
+    const editor = await screen.findByLabelText('Optimization YAML Editor');
+    fireEvent.change(editor, {
+      target: {
+        value: `parameter_ranges:
+  entry_filter_params:
+    rsi:
+      period:
+        min: 10
+`,
+      },
+    });
+
+    expect(
+      screen.getByText('No parameter arrays found under "parameter_ranges". Add list values like period: [10, 20, 30].')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('saves with basename strategy key and edited content', async () => {
+    const user = userEvent.setup();
+    mockSaveMutate.mockImplementation((_payload: unknown, options?: { onSuccess?: () => void }) => {
+      options?.onSuccess?.();
+    });
+
+    render(<OptimizationGridEditor strategyName="production/demo" />);
+
+    const editor = await screen.findByLabelText('Optimization YAML Editor');
+    fireEvent.change(editor, {
+      target: {
+        value: `parameter_ranges:
+  entry_filter_params:
+    period_breakout:
+      period: [5, 10]
+`,
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockSaveMutate).toHaveBeenCalledWith(
+      {
+        strategy: 'demo',
+        request: {
+          content: expect.stringContaining('period: [5, 10]'),
+        },
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('applies preset template content from helper panel', async () => {
+    const user = userEvent.setup();
+    render(<OptimizationGridEditor strategyName="production/demo" />);
+
+    await user.click(screen.getByRole('button', { name: /Breakout Focus/i }));
+
+    const editor = screen.getByLabelText('Optimization YAML Editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('volume_breakout');
+    expect(editor.value).toContain('atr_multiplier');
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationGridEditor.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationGridEditor.tsx
@@ -1,8 +1,10 @@
-import { Loader2, Save, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { AlertCircle, CheckCircle2, Info, Loader2, RotateCcw, Save, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { MonacoYamlEditor } from '@/components/Editor/MonacoYamlEditor';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { useDeleteOptimizationGrid, useOptimizationGridConfig, useSaveOptimizationGrid } from '@/hooks/useOptimization';
+import { analyzeGridParameters, formatGridParameterValue, type GridParameterAnalysis } from './optimizationGridParams';
 
 const TEMPLATE_YAML = `# Parameter ranges for optimization grid search
 # Each parameter should be a list of values to try
@@ -15,8 +17,83 @@ parameter_ranges:
       atr_multiplier: [1.5, 2.0, 2.5, 3.0]
 `;
 
+const PRESET_TEMPLATES = [
+  {
+    id: 'starter',
+    label: 'Starter',
+    description: 'Minimal entry + exit ranges',
+    content: TEMPLATE_YAML,
+  },
+  {
+    id: 'breakout-heavy',
+    label: 'Breakout Focus',
+    description: 'Period/volume breakout combinations',
+    content: `parameter_ranges:
+  entry_filter_params:
+    period_breakout:
+      period: [10, 15, 20, 30]
+    volume_breakout:
+      period: [10, 20]
+      ratio: [1.1, 1.3, 1.5]
+  exit_trigger_params:
+    atr_stop:
+      atr_multiplier: [1.8, 2.2, 2.8]
+`,
+  },
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    description: 'Momentum + fundamental + risk control',
+    content: `parameter_ranges:
+  entry_filter_params:
+    rsi:
+      period: [10, 14]
+      lower: [25, 30, 35]
+    forward_eps_growth:
+      threshold: [0.05, 0.1, 0.15]
+  exit_trigger_params:
+    take_profit:
+      pct: [0.08, 0.12, 0.16]
+    atr_stop:
+      atr_multiplier: [1.5, 2.0, 2.5]
+`,
+  },
+] as const;
+
 interface OptimizationGridEditorProps {
   strategyName: string;
+}
+
+type ValidationTone = 'error' | 'warning' | 'success';
+
+interface ValidationState {
+  tone: ValidationTone;
+  message: string;
+}
+
+function buildValidationState(analysis: GridParameterAnalysis): ValidationState {
+  if (analysis.parseError) {
+    return { tone: 'error', message: analysis.parseError };
+  }
+
+  if (!analysis.hasParameterRanges) {
+    return {
+      tone: 'warning',
+      message: 'Missing "parameter_ranges" key. Saving is allowed, but optimization combinations will be 0.',
+    };
+  }
+
+  if (analysis.paramCount === 0) {
+    return {
+      tone: 'warning',
+      message: 'No parameter arrays found under "parameter_ranges". Add list values like period: [10, 20, 30].',
+    };
+  }
+
+  return {
+    tone: 'success',
+    message: `Ready: ${analysis.paramCount} parameters, ${analysis.combinations} combinations detected.`,
+  };
 }
 
 export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorProps) {
@@ -28,28 +105,39 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
   const deleteGrid = useDeleteOptimizationGrid();
 
   const [content, setContent] = useState('');
+  const [baselineContent, setBaselineContent] = useState('');
+  const [hasPersistedConfig, setHasPersistedConfig] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     if (gridConfig) {
       setContent(gridConfig.content);
+      setBaselineContent(gridConfig.content);
+      setHasPersistedConfig(true);
       setIsDirty(false);
     } else if (isError) {
       setContent(TEMPLATE_YAML);
+      setBaselineContent(TEMPLATE_YAML);
+      setHasPersistedConfig(false);
       setIsDirty(false);
     }
   }, [gridConfig, isError]);
 
   const handleContentChange = useCallback((value: string) => {
     setContent(value);
-    setIsDirty(true);
-  }, []);
+    setIsDirty(value !== baselineContent);
+  }, [baselineContent]);
+
+  const analysis = useMemo(() => analyzeGridParameters(content), [content]);
+  const validationState = useMemo(() => buildValidationState(analysis), [analysis]);
 
   const handleSave = useCallback(() => {
     saveGrid.mutate(
       { strategy: basename, request: { content } },
       {
         onSuccess: () => {
+          setBaselineContent(content);
+          setHasPersistedConfig(true);
           setIsDirty(false);
         },
       }
@@ -60,10 +148,25 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
     deleteGrid.mutate(basename, {
       onSuccess: () => {
         setContent(TEMPLATE_YAML);
+        setBaselineContent(TEMPLATE_YAML);
+        setHasPersistedConfig(false);
         setIsDirty(false);
       },
     });
   }, [basename, deleteGrid]);
+
+  const handleReset = useCallback(() => {
+    setContent(baselineContent);
+    setIsDirty(false);
+  }, [baselineContent]);
+
+  const handleApplyPreset = useCallback(
+    (presetContent: string) => {
+      setContent(presetContent);
+      setIsDirty(presetContent !== baselineContent);
+    },
+    [baselineContent]
+  );
 
   if (isLoading) {
     return (
@@ -73,56 +176,166 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
     );
   }
 
-  const savedInfo = gridConfig ? `${gridConfig.param_count} params, ${gridConfig.combinations} combinations` : null;
+  const savedInfo = gridConfig
+    ? `${gridConfig.param_count} params, ${gridConfig.combinations} combinations`
+    : 'Not saved';
 
-  const lastSaveInfo = saveGrid.data
+  const lastSaveInfo =
+    saveGrid.data && saveGrid.data.strategy_name === basename
     ? `${saveGrid.data.param_count} params, ${saveGrid.data.combinations} combinations`
     : null;
 
+  const canDelete = hasPersistedConfig;
+
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <div>
-          <h4 className="text-sm font-medium">Grid Configuration</h4>
-          {(lastSaveInfo || savedInfo) && (
-            <p className="text-xs text-muted-foreground mt-0.5">{lastSaveInfo || savedInfo}</p>
-          )}
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <h4 className="text-sm font-semibold">Optimization Grid Editor</h4>
+          <p className="text-xs text-muted-foreground">
+            Edit optimization parameter ranges and validate combinations before running jobs.
+          </p>
+          <p className="text-xs font-mono text-muted-foreground">strategy: {basename}</p>
         </div>
-        <div className="flex gap-2">
-          {gridConfig && (
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleReset}
+            disabled={!isDirty || saveGrid.isPending || deleteGrid.isPending}
+          >
+            <RotateCcw className="h-4 w-4 mr-1" />
+            Reset
+          </Button>
+          {canDelete && (
             <Button
               variant="outline"
               size="sm"
               onClick={handleDelete}
-              disabled={deleteGrid.isPending}
+              disabled={deleteGrid.isPending || saveGrid.isPending}
               className="text-destructive hover:text-destructive"
             >
               <Trash2 className="h-4 w-4 mr-1" />
               Delete
             </Button>
           )}
-          <Button size="sm" onClick={handleSave} disabled={!isDirty || saveGrid.isPending}>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!isDirty || !!analysis.parseError || saveGrid.isPending || deleteGrid.isPending}
+          >
             {saveGrid.isPending ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Save className="h-4 w-4 mr-1" />}
             Save
           </Button>
         </div>
       </div>
 
-      <MonacoYamlEditor value={content} onChange={handleContentChange} height="320px" />
+      <div className="grid gap-2 md:grid-cols-3">
+        <div className="rounded-md border bg-muted/20 p-2">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Current</p>
+          <p className="text-sm font-medium">
+            {analysis.paramCount} params / {analysis.combinations} combos
+          </p>
+        </div>
+        <div className="rounded-md border bg-muted/20 p-2">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Saved</p>
+          <p className="text-sm font-medium">{lastSaveInfo || savedInfo}</p>
+        </div>
+        <div className="rounded-md border bg-muted/20 p-2">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">State</p>
+          <p className={cn('text-sm font-medium', isDirty ? 'text-amber-600' : 'text-muted-foreground')}>
+            {isDirty ? 'Unsaved changes' : 'Synced'}
+          </p>
+        </div>
+      </div>
 
-      {saveGrid.isError && (
-        <div className="rounded-md bg-red-500/10 p-2 text-sm text-red-500">{saveGrid.error.message}</div>
-      )}
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 min-h-[460px]">
+        <div className="xl:col-span-2 flex flex-col min-h-0">
+          <div className="flex-1 min-h-0">
+            <MonacoYamlEditor value={content} onChange={handleContentChange} height="380px" />
+          </div>
 
-      {deleteGrid.isError && (
-        <div className="rounded-md bg-red-500/10 p-2 text-sm text-red-500">{deleteGrid.error.message}</div>
-      )}
+          <div className="mt-3 space-y-2">
+            <div
+              className={cn(
+                'flex items-start gap-2 rounded-md p-3 text-sm',
+                validationState.tone === 'error'
+                  ? 'bg-destructive/10 text-destructive'
+                  : validationState.tone === 'warning'
+                    ? 'bg-yellow-500/10 text-yellow-700'
+                    : 'bg-green-500/10 text-green-700'
+              )}
+            >
+              {validationState.tone === 'error' ? (
+                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+              ) : validationState.tone === 'warning' ? (
+                <Info className="h-4 w-4 mt-0.5 shrink-0" />
+              ) : (
+                <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+              )}
+              <span>{validationState.message}</span>
+            </div>
 
-      {!gridConfig && !isError && (
-        <p className="text-xs text-muted-foreground">
-          No grid config exists for this strategy. Edit the template above and save to create one.
-        </p>
-      )}
+            {saveGrid.isError && (
+              <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>{saveGrid.error.message}</span>
+              </div>
+            )}
+
+            {deleteGrid.isError && (
+              <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>{deleteGrid.error.message}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="border rounded-md overflow-hidden min-h-0 flex flex-col">
+          <div className="border-b p-3">
+            <h5 className="text-sm font-medium">Grid Helper</h5>
+            <p className="text-xs text-muted-foreground mt-1">Apply presets and inspect detected parameter paths.</p>
+          </div>
+          <div className="flex-1 overflow-y-auto p-3 space-y-4">
+            <section className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">Presets</p>
+              {PRESET_TEMPLATES.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  className="w-full rounded-md border p-2 text-left hover:bg-muted/30 transition-colors"
+                  onClick={() => handleApplyPreset(preset.content)}
+                  disabled={saveGrid.isPending || deleteGrid.isPending}
+                >
+                  <p className="text-sm font-medium">{preset.label}</p>
+                  <p className="text-xs text-muted-foreground">{preset.description}</p>
+                </button>
+              ))}
+            </section>
+
+            <section className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">Detected Parameters ({analysis.paramCount})</p>
+              {analysis.entries.length > 0 ? (
+                <ul className="space-y-1">
+                  {analysis.entries.map((entry) => (
+                    <li key={entry.path} className="rounded bg-muted/30 px-2 py-1 text-xs">
+                      <p className="font-mono break-all">{entry.path}</p>
+                      <p className="text-muted-foreground break-all">
+                        [{entry.values.map((value) => formatGridParameterValue(value)).join(', ')}]
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Parameter lists are not detected yet. Add arrays under <code>parameter_ranges</code>.
+                </p>
+              )}
+            </section>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationGridEditor.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationGridEditor.tsx
@@ -71,6 +71,72 @@ interface ValidationState {
   message: string;
 }
 
+interface EditorActionsProps {
+  canDelete: boolean;
+  isDirty: boolean;
+  isSavePending: boolean;
+  isDeletePending: boolean;
+  hasParseError: boolean;
+  onReset: () => void;
+  onDelete: () => void;
+  onSave: () => void;
+}
+
+interface SummaryCardsProps {
+  paramCount: number;
+  combinations: number;
+  savedInfo: string;
+  isDirty: boolean;
+}
+
+interface GridHelperPanelProps {
+  analysis: GridParameterAnalysis;
+  isBusy: boolean;
+  onApplyPreset: (presetContent: string) => void;
+}
+
+interface EditorWorkspaceProps {
+  content: string;
+  analysis: GridParameterAnalysis;
+  validationState: ValidationState;
+  isBusy: boolean;
+  saveErrorMessage: string | null;
+  deleteErrorMessage: string | null;
+  onContentChange: (value: string) => void;
+  onApplyPreset: (presetContent: string) => void;
+}
+
+interface OptimizationGridEditorViewProps {
+  basename: string;
+  content: string;
+  analysis: GridParameterAnalysis;
+  validationState: ValidationState;
+  savedInfo: string;
+  isDirty: boolean;
+  canDelete: boolean;
+  isSavePending: boolean;
+  isDeletePending: boolean;
+  saveErrorMessage: string | null;
+  deleteErrorMessage: string | null;
+  onContentChange: (value: string) => void;
+  onReset: () => void;
+  onDelete: () => void;
+  onSave: () => void;
+  onApplyPreset: (presetContent: string) => void;
+}
+
+const VALIDATION_TONE_CLASS: Record<ValidationTone, string> = {
+  error: 'bg-destructive/10 text-destructive',
+  warning: 'bg-yellow-500/10 text-yellow-700',
+  success: 'bg-green-500/10 text-green-700',
+};
+
+const VALIDATION_TONE_ICON = {
+  error: AlertCircle,
+  warning: Info,
+  success: CheckCircle2,
+} as const;
+
 function buildValidationState(analysis: GridParameterAnalysis): ValidationState {
   if (analysis.parseError) {
     return { tone: 'error', message: analysis.parseError };
@@ -96,8 +162,234 @@ function buildValidationState(analysis: GridParameterAnalysis): ValidationState 
   };
 }
 
+function LoadingState() {
+  return (
+    <div className="flex items-center justify-center h-32">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+function ValidationBanner({ validationState }: { validationState: ValidationState }) {
+  const Icon = VALIDATION_TONE_ICON[validationState.tone];
+
+  return (
+    <div className={cn('flex items-start gap-2 rounded-md p-3 text-sm', VALIDATION_TONE_CLASS[validationState.tone])}>
+      <Icon className="h-4 w-4 mt-0.5 shrink-0" />
+      <span>{validationState.message}</span>
+    </div>
+  );
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+      <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+function EditorActions({
+  canDelete,
+  isDirty,
+  isSavePending,
+  isDeletePending,
+  hasParseError,
+  onReset,
+  onDelete,
+  onSave,
+}: EditorActionsProps) {
+  const isBusy = isSavePending || isDeletePending;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button variant="outline" size="sm" onClick={onReset} disabled={!isDirty || isBusy}>
+        <RotateCcw className="h-4 w-4 mr-1" />
+        Reset
+      </Button>
+      {canDelete && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDelete}
+          disabled={isBusy}
+          className="text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4 mr-1" />
+          Delete
+        </Button>
+      )}
+      <Button size="sm" onClick={onSave} disabled={!isDirty || hasParseError || isBusy}>
+        {isSavePending ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Save className="h-4 w-4 mr-1" />}
+        Save
+      </Button>
+    </div>
+  );
+}
+
+function SummaryCards({ paramCount, combinations, savedInfo, isDirty }: SummaryCardsProps) {
+  return (
+    <div className="grid gap-2 md:grid-cols-3">
+      <div className="rounded-md border bg-muted/20 p-2">
+        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Current</p>
+        <p className="text-sm font-medium">
+          {paramCount} params / {combinations} combos
+        </p>
+      </div>
+      <div className="rounded-md border bg-muted/20 p-2">
+        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Saved</p>
+        <p className="text-sm font-medium">{savedInfo}</p>
+      </div>
+      <div className="rounded-md border bg-muted/20 p-2">
+        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">State</p>
+        <p className={cn('text-sm font-medium', isDirty ? 'text-amber-600' : 'text-muted-foreground')}>
+          {isDirty ? 'Unsaved changes' : 'Synced'}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function GridHelperPanel({ analysis, isBusy, onApplyPreset }: GridHelperPanelProps) {
+  return (
+    <div className="border rounded-md overflow-hidden min-h-0 flex flex-col">
+      <div className="border-b p-3">
+        <h5 className="text-sm font-medium">Grid Helper</h5>
+        <p className="text-xs text-muted-foreground mt-1">Apply presets and inspect detected parameter paths.</p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 space-y-4">
+        <section className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground">Presets</p>
+          {PRESET_TEMPLATES.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className="w-full rounded-md border p-2 text-left hover:bg-muted/30 transition-colors"
+              onClick={() => onApplyPreset(preset.content)}
+              disabled={isBusy}
+            >
+              <p className="text-sm font-medium">{preset.label}</p>
+              <p className="text-xs text-muted-foreground">{preset.description}</p>
+            </button>
+          ))}
+        </section>
+
+        <section className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground">Detected Parameters ({analysis.paramCount})</p>
+          {analysis.entries.length > 0 ? (
+            <ul className="space-y-1">
+              {analysis.entries.map((entry) => (
+                <li key={entry.path} className="rounded bg-muted/30 px-2 py-1 text-xs">
+                  <p className="font-mono break-all">{entry.path}</p>
+                  <p className="text-muted-foreground break-all">
+                    [{entry.values.map((value) => formatGridParameterValue(value)).join(', ')}]
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Parameter lists are not detected yet. Add arrays under <code>parameter_ranges</code>.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function EditorWorkspace({
+  content,
+  analysis,
+  validationState,
+  isBusy,
+  saveErrorMessage,
+  deleteErrorMessage,
+  onContentChange,
+  onApplyPreset,
+}: EditorWorkspaceProps) {
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 min-h-[460px]">
+      <div className="xl:col-span-2 flex flex-col min-h-0">
+        <div className="flex-1 min-h-0">
+          <MonacoYamlEditor value={content} onChange={onContentChange} height="380px" />
+        </div>
+
+        <div className="mt-3 space-y-2">
+          <ValidationBanner validationState={validationState} />
+          {saveErrorMessage && <ErrorBanner message={saveErrorMessage} />}
+          {deleteErrorMessage && <ErrorBanner message={deleteErrorMessage} />}
+        </div>
+      </div>
+
+      <GridHelperPanel analysis={analysis} isBusy={isBusy} onApplyPreset={onApplyPreset} />
+    </div>
+  );
+}
+
+function OptimizationGridEditorView({
+  basename,
+  content,
+  analysis,
+  validationState,
+  savedInfo,
+  isDirty,
+  canDelete,
+  isSavePending,
+  isDeletePending,
+  saveErrorMessage,
+  deleteErrorMessage,
+  onContentChange,
+  onReset,
+  onDelete,
+  onSave,
+  onApplyPreset,
+}: OptimizationGridEditorViewProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <h4 className="text-sm font-semibold">Optimization Grid Editor</h4>
+          <p className="text-xs text-muted-foreground">
+            Edit optimization parameter ranges and validate combinations before running jobs.
+          </p>
+          <p className="text-xs font-mono text-muted-foreground">strategy: {basename}</p>
+        </div>
+        <EditorActions
+          canDelete={canDelete}
+          isDirty={isDirty}
+          isSavePending={isSavePending}
+          isDeletePending={isDeletePending}
+          hasParseError={Boolean(analysis.parseError)}
+          onReset={onReset}
+          onDelete={onDelete}
+          onSave={onSave}
+        />
+      </div>
+
+      <SummaryCards
+        paramCount={analysis.paramCount}
+        combinations={analysis.combinations}
+        savedInfo={savedInfo}
+        isDirty={isDirty}
+      />
+
+      <EditorWorkspace
+        content={content}
+        analysis={analysis}
+        validationState={validationState}
+        isBusy={isSavePending || isDeletePending}
+        saveErrorMessage={saveErrorMessage}
+        deleteErrorMessage={deleteErrorMessage}
+        onContentChange={onContentChange}
+        onApplyPreset={onApplyPreset}
+      />
+    </div>
+  );
+}
+
 export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorProps) {
-  // Extract basename for grid config lookup
   const basename = strategyName.split('/').pop() ?? strategyName;
 
   const { data: gridConfig, isLoading, isError } = useOptimizationGridConfig(basename);
@@ -115,7 +407,10 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
       setBaselineContent(gridConfig.content);
       setHasPersistedConfig(true);
       setIsDirty(false);
-    } else if (isError) {
+      return;
+    }
+
+    if (isError) {
       setContent(TEMPLATE_YAML);
       setBaselineContent(TEMPLATE_YAML);
       setHasPersistedConfig(false);
@@ -123,10 +418,13 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
     }
   }, [gridConfig, isError]);
 
-  const handleContentChange = useCallback((value: string) => {
-    setContent(value);
-    setIsDirty(value !== baselineContent);
-  }, [baselineContent]);
+  const handleContentChange = useCallback(
+    (value: string) => {
+      setContent(value);
+      setIsDirty(value !== baselineContent);
+    },
+    [baselineContent]
+  );
 
   const analysis = useMemo(() => analyzeGridParameters(content), [content]);
   const validationState = useMemo(() => buildValidationState(analysis), [analysis]);
@@ -169,11 +467,7 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
   );
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-32">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <LoadingState />;
   }
 
   const savedInfo = gridConfig
@@ -182,160 +476,27 @@ export function OptimizationGridEditor({ strategyName }: OptimizationGridEditorP
 
   const lastSaveInfo =
     saveGrid.data && saveGrid.data.strategy_name === basename
-    ? `${saveGrid.data.param_count} params, ${saveGrid.data.combinations} combinations`
-    : null;
-
-  const canDelete = hasPersistedConfig;
+      ? `${saveGrid.data.param_count} params, ${saveGrid.data.combinations} combinations`
+      : null;
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div className="space-y-1">
-          <h4 className="text-sm font-semibold">Optimization Grid Editor</h4>
-          <p className="text-xs text-muted-foreground">
-            Edit optimization parameter ranges and validate combinations before running jobs.
-          </p>
-          <p className="text-xs font-mono text-muted-foreground">strategy: {basename}</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleReset}
-            disabled={!isDirty || saveGrid.isPending || deleteGrid.isPending}
-          >
-            <RotateCcw className="h-4 w-4 mr-1" />
-            Reset
-          </Button>
-          {canDelete && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleDelete}
-              disabled={deleteGrid.isPending || saveGrid.isPending}
-              className="text-destructive hover:text-destructive"
-            >
-              <Trash2 className="h-4 w-4 mr-1" />
-              Delete
-            </Button>
-          )}
-          <Button
-            size="sm"
-            onClick={handleSave}
-            disabled={!isDirty || !!analysis.parseError || saveGrid.isPending || deleteGrid.isPending}
-          >
-            {saveGrid.isPending ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Save className="h-4 w-4 mr-1" />}
-            Save
-          </Button>
-        </div>
-      </div>
-
-      <div className="grid gap-2 md:grid-cols-3">
-        <div className="rounded-md border bg-muted/20 p-2">
-          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Current</p>
-          <p className="text-sm font-medium">
-            {analysis.paramCount} params / {analysis.combinations} combos
-          </p>
-        </div>
-        <div className="rounded-md border bg-muted/20 p-2">
-          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Saved</p>
-          <p className="text-sm font-medium">{lastSaveInfo || savedInfo}</p>
-        </div>
-        <div className="rounded-md border bg-muted/20 p-2">
-          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">State</p>
-          <p className={cn('text-sm font-medium', isDirty ? 'text-amber-600' : 'text-muted-foreground')}>
-            {isDirty ? 'Unsaved changes' : 'Synced'}
-          </p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 min-h-[460px]">
-        <div className="xl:col-span-2 flex flex-col min-h-0">
-          <div className="flex-1 min-h-0">
-            <MonacoYamlEditor value={content} onChange={handleContentChange} height="380px" />
-          </div>
-
-          <div className="mt-3 space-y-2">
-            <div
-              className={cn(
-                'flex items-start gap-2 rounded-md p-3 text-sm',
-                validationState.tone === 'error'
-                  ? 'bg-destructive/10 text-destructive'
-                  : validationState.tone === 'warning'
-                    ? 'bg-yellow-500/10 text-yellow-700'
-                    : 'bg-green-500/10 text-green-700'
-              )}
-            >
-              {validationState.tone === 'error' ? (
-                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-              ) : validationState.tone === 'warning' ? (
-                <Info className="h-4 w-4 mt-0.5 shrink-0" />
-              ) : (
-                <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
-              )}
-              <span>{validationState.message}</span>
-            </div>
-
-            {saveGrid.isError && (
-              <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-                <span>{saveGrid.error.message}</span>
-              </div>
-            )}
-
-            {deleteGrid.isError && (
-              <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-                <span>{deleteGrid.error.message}</span>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="border rounded-md overflow-hidden min-h-0 flex flex-col">
-          <div className="border-b p-3">
-            <h5 className="text-sm font-medium">Grid Helper</h5>
-            <p className="text-xs text-muted-foreground mt-1">Apply presets and inspect detected parameter paths.</p>
-          </div>
-          <div className="flex-1 overflow-y-auto p-3 space-y-4">
-            <section className="space-y-2">
-              <p className="text-xs font-medium text-muted-foreground">Presets</p>
-              {PRESET_TEMPLATES.map((preset) => (
-                <button
-                  key={preset.id}
-                  type="button"
-                  className="w-full rounded-md border p-2 text-left hover:bg-muted/30 transition-colors"
-                  onClick={() => handleApplyPreset(preset.content)}
-                  disabled={saveGrid.isPending || deleteGrid.isPending}
-                >
-                  <p className="text-sm font-medium">{preset.label}</p>
-                  <p className="text-xs text-muted-foreground">{preset.description}</p>
-                </button>
-              ))}
-            </section>
-
-            <section className="space-y-2">
-              <p className="text-xs font-medium text-muted-foreground">Detected Parameters ({analysis.paramCount})</p>
-              {analysis.entries.length > 0 ? (
-                <ul className="space-y-1">
-                  {analysis.entries.map((entry) => (
-                    <li key={entry.path} className="rounded bg-muted/30 px-2 py-1 text-xs">
-                      <p className="font-mono break-all">{entry.path}</p>
-                      <p className="text-muted-foreground break-all">
-                        [{entry.values.map((value) => formatGridParameterValue(value)).join(', ')}]
-                      </p>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Parameter lists are not detected yet. Add arrays under <code>parameter_ranges</code>.
-                </p>
-              )}
-            </section>
-          </div>
-        </div>
-      </div>
-    </div>
+    <OptimizationGridEditorView
+      basename={basename}
+      content={content}
+      analysis={analysis}
+      validationState={validationState}
+      savedInfo={lastSaveInfo || savedInfo}
+      isDirty={isDirty}
+      canDelete={hasPersistedConfig}
+      isSavePending={saveGrid.isPending}
+      isDeletePending={deleteGrid.isPending}
+      saveErrorMessage={saveGrid.isError ? saveGrid.error.message : null}
+      deleteErrorMessage={deleteGrid.isError ? deleteGrid.error.message : null}
+      onContentChange={handleContentChange}
+      onReset={handleReset}
+      onDelete={handleDelete}
+      onSave={handleSave}
+      onApplyPreset={handleApplyPreset}
+    />
   );
 }

--- a/apps/ts/packages/web/src/components/Backtest/optimizationGridParams.test.ts
+++ b/apps/ts/packages/web/src/components/Backtest/optimizationGridParams.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractGridParameterEntries, formatGridParameterValue } from './optimizationGridParams';
+import { analyzeGridParameters, extractGridParameterEntries, formatGridParameterValue } from './optimizationGridParams';
 
 describe('optimizationGridParams', () => {
   it('extracts nested parameter ranges from grid yaml', () => {
@@ -27,6 +27,31 @@ parameter_ranges:
 
   it('returns empty array for invalid yaml', () => {
     expect(extractGridParameterEntries('invalid: [yaml')).toEqual([]);
+  });
+
+  it('returns parse error details for invalid yaml', () => {
+    const analysis = analyzeGridParameters('invalid: [yaml');
+    expect(analysis.parseError).toContain('YAML parse error:');
+    expect(analysis.hasParameterRanges).toBe(false);
+    expect(analysis.paramCount).toBe(0);
+    expect(analysis.combinations).toBe(0);
+  });
+
+  it('returns warning-shaped analysis when parameter_ranges is missing', () => {
+    const analysis = analyzeGridParameters('foo: 1');
+    expect(analysis.parseError).toBeNull();
+    expect(analysis.hasParameterRanges).toBe(false);
+    expect(analysis.entries).toEqual([]);
+    expect(analysis.paramCount).toBe(0);
+    expect(analysis.combinations).toBe(0);
+  });
+
+  it('does not treat non-object root as parse error', () => {
+    const analysis = analyzeGridParameters('- 1\n- 2');
+    expect(analysis.parseError).toBeNull();
+    expect(analysis.hasParameterRanges).toBe(false);
+    expect(analysis.paramCount).toBe(0);
+    expect(analysis.combinations).toBe(0);
   });
 
   it('formats parameter values for display', () => {


### PR DESCRIPTION
## Summary
- redesign Backtest Strategies > Optimize grid editor into a richer Monaco-based editing workspace
- add live YAML analysis feedback (syntax error / warning / success) with param-count and combination summary
- add helper panel with presets and detected parameter path previews
- keep frontend behavior aligned with backend by blocking save only on YAML syntax errors
- add/expand unit tests for optimization grid editor and parameter analysis helpers
- update AGENTS.md with the new optimization editor behavior

## Testing
- bun run --filter @trading25/web test src/components/Backtest/optimizationGridParams.test.ts src/components/Backtest/OptimizationGridEditor.test.tsx src/components/Backtest/BacktestStrategies.test.tsx
- bun run --filter @trading25/web typecheck
- bun run test:coverage -- src/components/Backtest/optimizationGridParams.test.ts src/components/Backtest/OptimizationGridEditor.test.tsx --coverage.include=src/components/Backtest/optimizationGridParams.ts --coverage.include=src/components/Backtest/OptimizationGridEditor.tsx --coverage.reporter=text