### PR TITLE
fix(bt): allow nested experimental strategy delete and rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - Screening 実行時のデータ SoT は `market.db`（`stock_data` / `topix_data` / `indices_data` / `stocks`）とし、dataset へのフォールバックを禁止する
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - Strategy YAML更新の SoT は `/api/strategies/{name}` で、`production` / `experimental` を更新可能（`production` は既存ファイルの編集のみ許可）。`rename` / `delete` は引き続き `experimental` 限定
+- Strategy `rename` / `delete` の権限判定はトップレベルカテゴリ基準で行い、`experimental/**`（例: `experimental/optuna/foo`）は許可する
 - 市場コードフィルタは legacy (`prime/standard/growth`) と current (`0111/0112/0113`) を同義として扱う
 - **ts/web** は `/api` パスを FastAPI (:3002) にプロキシ
 - **Hono サーバー** (:3001) は廃止済み（`apps/ts/packages/api` は削除済み）


### PR DESCRIPTION
## Summary
- fix strategy permission/category resolution to use top-level category roots instead of parent directory names
- allow delete/rename for nested paths under experimental (e.g. experimental/optuna/foo)
- clean up empty source directories after delete/rename while preserving non-empty sibling directories
- add regression tests for nested experimental delete/rename and category checks
- update AGENTS.md to document that experimental/** is allowed for rename/delete

## Testing
- uv run --project /Users/shinjiroaso/.codex/worktrees/c81d/trading25/apps/bt pytest tests/unit/strategy_config/test_loader.py
- uv run --project /Users/shinjiroaso/.codex/worktrees/c81d/trading25/apps/bt python -m coverage run --branch -m pytest tests/unit/strategy_config/test_loader.py
- uv run --project /Users/shinjiroaso/.codex/worktrees/c81d/trading25/apps/bt python -m coverage report --show-missing --include='src/lib/strategy_runtime/loader.py'