### PR TITLE
fix(bt): remove /indices dependency in index sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
   - **market.db**: 読み書き（SQLAlchemy Core）
   - **portfolio.db**: CRUD（SQLAlchemy Core）
   - **dataset.db**: 読み書き（SQLAlchemy Core）
-- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新し、`/indices` 取得失敗時は日付指定フォールバックで継続する（`indices-only` は指数再同期専用モード）。フォールバック時は不足 `index_master` をプレースホルダ補完して、FK 制約付きの既存DBでも継続可能にする
+- `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Screening API は非同期ジョブ方式（`POST /api/analytics/screening/jobs` / `GET /api/analytics/screening/jobs/{id}` / `POST /api/analytics/screening/jobs/{id}/cancel` / `GET /api/analytics/screening/result/{id}`）を SoT とする。旧 `GET /api/analytics/screening` は 410

--- a/apps/bt/src/lib/market_db/market_db.py
+++ b/apps/bt/src/lib/market_db/market_db.py
@@ -322,7 +322,10 @@ class MarketDb(BaseDbAccess):
                             "name": stmt.excluded.name,
                             "name_english": stmt.excluded.name_english,
                             "category": stmt.excluded.category,
-                            "data_start_date": stmt.excluded.data_start_date,
+                            "data_start_date": func.coalesce(
+                                stmt.excluded.data_start_date,
+                                index_master.c.data_start_date,
+                            ),
                             "updated_at": stmt.excluded.updated_at,
                         },
                     )

--- a/apps/bt/src/server/services/index_master_catalog.py
+++ b/apps/bt/src/server/services/index_master_catalog.py
@@ -1,0 +1,164 @@
+"""
+Index master seed catalog.
+
+J-Quants v2 には index master 専用エンドポイントが見当たらないため、
+index_master はローカル参照データを SoT として補完する。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+_INDEX_CODE_NAME_PAIRS: tuple[tuple[str, str], ...] = (
+    ("0000", "TOPIX"),
+    ("0001", "東証二部総合指数"),
+    ("0028", "TOPIX Core30"),
+    ("0029", "TOPIX Large 70"),
+    ("002A", "TOPIX 100"),
+    ("002B", "TOPIX Mid400"),
+    ("002C", "TOPIX 500"),
+    ("002D", "TOPIX Small"),
+    ("002E", "TOPIX 1000"),
+    ("002F", "TOPIX Small500"),
+    ("0040", "東証業種別 水産・農林業"),
+    ("0041", "東証業種別 鉱業"),
+    ("0042", "東証業種別 建設業"),
+    ("0043", "東証業種別 食料品"),
+    ("0044", "東証業種別 繊維製品"),
+    ("0045", "東証業種別 パルプ・紙"),
+    ("0046", "東証業種別 化学"),
+    ("0047", "東証業種別 医薬品"),
+    ("0048", "東証業種別 石油・石炭製品"),
+    ("0049", "東証業種別 ゴム製品"),
+    ("004A", "東証業種別 ガラス・土石製品"),
+    ("004B", "東証業種別 鉄鋼"),
+    ("004C", "東証業種別 非鉄金属"),
+    ("004D", "東証業種別 金属製品"),
+    ("004E", "東証業種別 機械"),
+    ("004F", "東証業種別 電気機器"),
+    ("0050", "東証業種別 輸送用機器"),
+    ("0051", "東証業種別 精密機器"),
+    ("0052", "東証業種別 その他製品"),
+    ("0053", "東証業種別 電気・ガス業"),
+    ("0054", "東証業種別 陸運業"),
+    ("0055", "東証業種別 海運業"),
+    ("0056", "東証業種別 空運業"),
+    ("0057", "東証業種別 倉庫・運輸関連業"),
+    ("0058", "東証業種別 情報・通信業"),
+    ("0059", "東証業種別 卸売業"),
+    ("005A", "東証業種別 小売業"),
+    ("005B", "東証業種別 銀行業"),
+    ("005C", "東証業種別 証券・商品先物取引業"),
+    ("005D", "東証業種別 保険業"),
+    ("005E", "東証業種別 その他金融業"),
+    ("005F", "東証業種別 不動産業"),
+    ("0060", "東証業種別 サービス業"),
+    ("0070", "東証グロース市場250指数"),
+    ("0075", "REIT"),
+    ("0080", "TOPIX-17 食品"),
+    ("0081", "TOPIX-17 エネルギー資源"),
+    ("0082", "TOPIX-17 建設・資材"),
+    ("0083", "TOPIX-17 素材・化学"),
+    ("0084", "TOPIX-17 医薬品"),
+    ("0085", "TOPIX-17 自動車・輸送機"),
+    ("0086", "TOPIX-17 鉄鋼・非鉄"),
+    ("0087", "TOPIX-17 機械"),
+    ("0088", "TOPIX-17 電機・精密"),
+    ("0089", "TOPIX-17 情報通信・サービスその他"),
+    ("008A", "TOPIX-17 電力・ガス"),
+    ("008B", "TOPIX-17 運輸・物流"),
+    ("008C", "TOPIX-17 商社・卸売"),
+    ("008D", "TOPIX-17 小売"),
+    ("008E", "TOPIX-17 銀行"),
+    ("008F", "TOPIX-17 金融（除く銀行）"),
+    ("0090", "TOPIX-17 不動産"),
+    ("0091", "JASDAQ INDEX"),
+    ("0500", "東証プライム市場指数"),
+    ("0501", "東証スタンダード市場指数"),
+    ("0502", "東証グロース市場指数"),
+    ("0503", "JPXプライム150指数"),
+    ("8100", "TOPIX バリュー"),
+    ("812C", "TOPIX500 バリュー"),
+    ("812D", "TOPIXSmall バリュー"),
+    ("8200", "TOPIX グロース"),
+    ("822C", "TOPIX500 グロース"),
+    ("822D", "TOPIXSmall グロース"),
+    ("8501", "東証REIT オフィス指数"),
+    ("8502", "東証REIT 住宅指数"),
+    ("8503", "東証REIT 商業・物流等指数"),
+)
+
+_TOPIX_CODES = {
+    "0000",
+    "0001",
+    "0028",
+    "0029",
+    "002A",
+    "002B",
+    "002C",
+    "002D",
+    "002E",
+    "002F",
+}
+_MARKET_CODES = {
+    "0070",
+    "0075",
+    "0091",
+    "0500",
+    "0501",
+    "0502",
+    "0503",
+    "8501",
+    "8502",
+    "8503",
+}
+_STYLE_CODES = {"8100", "812C", "812D", "8200", "822C", "822D"}
+
+
+def _in_hex_range(code: str, start_hex: str, end_hex: str) -> bool:
+    try:
+        value = int(code, 16)
+    except ValueError:
+        return False
+    return int(start_hex, 16) <= value <= int(end_hex, 16)
+
+
+def _resolve_category(code: str) -> str:
+    if code in _TOPIX_CODES:
+        return "topix"
+    if code in _MARKET_CODES:
+        return "market"
+    if code in _STYLE_CODES:
+        return "style"
+    if _in_hex_range(code, "0040", "0060"):
+        return "sector33"
+    if _in_hex_range(code, "0080", "0090"):
+        return "sector17"
+    return "unknown"
+
+
+def get_index_catalog_codes() -> set[str]:
+    return {code for code, _name in _INDEX_CODE_NAME_PAIRS}
+
+
+def build_index_master_seed_rows(
+    *,
+    existing_codes: set[str] | None = None,
+) -> list[dict[str, str | None]]:
+    created_at = datetime.now(UTC).isoformat()
+    existing = existing_codes or set()
+    rows: list[dict[str, str | None]] = []
+
+    for code, name in _INDEX_CODE_NAME_PAIRS:
+        if code in existing:
+            continue
+        rows.append({
+            "code": code,
+            "name": name,
+            "name_english": None,
+            "category": _resolve_category(code),
+            "data_start_date": None,
+            "created_at": created_at,
+        })
+
+    return rows

--- a/apps/bt/src/server/services/sync_strategies.py
+++ b/apps/bt/src/server/services/sync_strategies.py
@@ -25,6 +25,10 @@ from src.lib.market_db.query_helpers import (
 )
 from src.server.schemas.db import SyncResult
 from src.server.services.fins_summary_mapper import convert_fins_summary_rows
+from src.server.services.index_master_catalog import (
+    build_index_master_seed_rows,
+    get_index_catalog_codes,
+)
 from src.server.services.stock_data_row_builder import build_stock_data_row
 
 
@@ -57,34 +61,29 @@ class IndicesOnlySyncStrategy:
         errors: list[str] = []
 
         try:
-            # 1. 指数マスタ取得
-            ctx.on_progress("indices_master", 0, 2, "Fetching index master data...")
+            # 1. 指数マスタ（ローカルカタログ）を補完
+            ctx.on_progress("indices_master", 0, 2, "Syncing index master catalog...")
             if ctx.cancelled.is_set():
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
-            body = await ctx.client.get("/indices")
-            total_calls += 1
-            indices_list = _extract_list_items(body, preferred_keys=("data", "indices"))
-
-            # index_master に保存
-            master_rows = _convert_index_master_rows(indices_list)
-            if master_rows:
-                await asyncio.to_thread(ctx.market_db.upsert_index_master, master_rows)
+            known_master_codes = await _seed_index_master_from_catalog(ctx)
+            target_codes = sorted(get_index_catalog_codes() | known_master_codes)
 
             # 2. 各指数のデータ取得
-            ctx.on_progress("indices_data", 1, 2, f"Fetching data for {len(indices_list)} indices...")
-            for idx in indices_list:
+            ctx.on_progress("indices_data", 1, 2, f"Fetching data for {len(target_codes)} indices...")
+            for code in target_codes:
                 if ctx.cancelled.is_set():
                     return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
-                code = _extract_index_code(idx)
-                if not code:
-                    continue
                 try:
                     data = await ctx.client.get_paginated("/indices/bars/daily", params={"code": code})
                     total_calls += 1
                     rows = _convert_indices_data_rows(data, code)
                     if rows:
-                        await asyncio.to_thread(ctx.market_db.upsert_indices_data, rows)
+                        await _upsert_indices_rows_with_master_backfill(
+                            ctx,
+                            rows,
+                            known_master_codes,
+                        )
                 except Exception as e:
                     errors.append(f"Index {code}: {e}")
                     logger.warning(f"Index {code} sync error: {e}")
@@ -315,108 +314,94 @@ class IncrementalSyncStrategy:
             if ctx.cancelled.is_set():
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
-            indices_list: list[dict[str, Any]] = []
-            try:
-                indices_body = await ctx.client.get("/indices")
-                total_calls += 1
-                indices_list = _extract_list_items(indices_body, preferred_keys=("data", "indices"))
-            except Exception as e:
-                # /indices が取得できない環境でも、日付指定で indices_data の増分だけは継続する。
-                logger.warning("Index master fetch failed. Falling back to date-based index sync: {}", e)
-
-            if indices_list:
-                master_rows = _convert_index_master_rows(indices_list)
-                if master_rows:
-                    await asyncio.to_thread(ctx.market_db.upsert_index_master, master_rows)
-
+            known_master_codes = await _seed_index_master_from_catalog(ctx)
             latest_index_dates = ctx.market_db.get_latest_indices_data_dates()
-            if indices_list:
-                for idx in indices_list:
-                    if ctx.cancelled.is_set():
-                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+            target_codes = sorted(
+                get_index_catalog_codes()
+                | set(latest_index_dates.keys())
+                | known_master_codes
+            )
 
-                    code = _extract_index_code(idx)
-                    if not code:
-                        continue
+            for code in target_codes:
+                if ctx.cancelled.is_set():
+                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
-                    params: dict[str, Any] = {"code": code}
-                    last_index_date = latest_index_dates.get(code)
+                params: dict[str, Any] = {"code": code}
+                last_index_date = latest_index_dates.get(code)
+                if last_index_date:
+                    params["from"] = _to_jquants_date_param(last_index_date)
+
+                try:
+                    data = await ctx.client.get_paginated("/indices/bars/daily", params=params)
+                    total_calls += 1
+
+                    rows = _convert_indices_data_rows(data, code)
                     if last_index_date:
-                        params["from"] = _to_jquants_date_param(last_index_date)
+                        rows = [r for r in rows if _is_date_after(r["date"], last_index_date)]
 
-                    try:
-                        data = await ctx.client.get_paginated("/indices/bars/daily", params=params)
-                        total_calls += 1
+                    if rows:
+                        await _upsert_indices_rows_with_master_backfill(
+                            ctx,
+                            rows,
+                            known_master_codes,
+                            discovery_log="Inserted {} discovered index master rows while syncing by code.",
+                        )
+                except Exception as e:
+                    errors.append(f"Index {code}: {e}")
+                    logger.warning(f"Index {code} incremental sync error: {e}")
 
-                        rows = _convert_indices_data_rows(data, code)
-                        if last_index_date:
-                            rows = [r for r in rows if _is_date_after(r["date"], last_index_date)]
+            # code 指定同期の補完として、日付指定で新規コードを探索する。
+            latest_index_date = _latest_date(list(latest_index_dates.values()))
+            fallback_dates = _extract_dates_after(
+                topix_rows,
+                latest_index_date,
+                include_anchor=True,
+            )
 
-                        if rows:
-                            await asyncio.to_thread(ctx.market_db.upsert_indices_data, rows)
-                    except Exception as e:
-                        errors.append(f"Index {code}: {e}")
-                        logger.warning(f"Index {code} incremental sync error: {e}")
-            else:
-                known_master_codes = ctx.market_db.get_index_master_codes()
-                latest_index_date = _latest_date(list(latest_index_dates.values()))
-                fallback_dates = _extract_dates_after(
-                    topix_rows,
-                    latest_index_date,
-                    include_anchor=True,
+            # indices_data が遅れている場合、topix を indices 側アンカーで再取得して候補日を補完する。
+            if (
+                latest_index_date
+                and last_date
+                and _is_date_after(last_date, latest_index_date)
+            ):
+                topix_for_indices = await ctx.client.get_paginated(
+                    "/indices/bars/daily/topix",
+                    params={"from": _to_jquants_date_param(latest_index_date)},
+                )
+                total_calls += 1
+                topix_dates = [
+                    {"date": d.get("Date", "")}
+                    for d in topix_for_indices
+                    if d.get("Date")
+                ]
+                fallback_dates = sorted(
+                    set(fallback_dates) | set(
+                        _extract_dates_after(topix_dates, latest_index_date, include_anchor=True)
+                    ),
+                    key=_date_sort_key,
                 )
 
-                # indices_data が遅れている場合、topix を indices 側アンカーで再取得して候補日を補完する。
-                if (
-                    latest_index_date
-                    and last_date
-                    and _is_date_after(last_date, latest_index_date)
-                ):
-                    topix_for_indices = await ctx.client.get_paginated(
-                        "/indices/bars/daily/topix",
-                        params={"from": _to_jquants_date_param(latest_index_date)},
+            for index_date in fallback_dates:
+                if ctx.cancelled.is_set():
+                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+
+                try:
+                    data = await ctx.client.get_paginated(
+                        "/indices/bars/daily",
+                        params={"date": _to_jquants_date_param(index_date)},
                     )
                     total_calls += 1
-                    topix_dates = [
-                        {"date": d.get("Date", "")}
-                        for d in topix_for_indices
-                        if d.get("Date")
-                    ]
-                    fallback_dates = sorted(
-                        set(fallback_dates) | set(
-                            _extract_dates_after(topix_dates, latest_index_date, include_anchor=True)
-                        ),
-                        key=_date_sort_key,
-                    )
-
-                for index_date in fallback_dates:
-                    if ctx.cancelled.is_set():
-                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
-
-                    try:
-                        data = await ctx.client.get_paginated(
-                            "/indices/bars/daily",
-                            params={"date": _to_jquants_date_param(index_date)},
+                    rows = _convert_indices_data_rows(data, None)
+                    if rows:
+                        await _upsert_indices_rows_with_master_backfill(
+                            ctx,
+                            rows,
+                            known_master_codes,
+                            discovery_log="Inserted {} discovered index master rows while syncing by date.",
                         )
-                        total_calls += 1
-                        rows = _convert_indices_data_rows(data, None)
-                        if rows:
-                            missing_master_rows = _build_fallback_index_master_rows(rows, known_master_codes)
-                            if missing_master_rows:
-                                await asyncio.to_thread(ctx.market_db.upsert_index_master, missing_master_rows)
-                                known_master_codes.update(
-                                    str(row["code"])
-                                    for row in missing_master_rows
-                                    if row.get("code")
-                                )
-                                logger.warning(
-                                    "Index master unavailable. Inserted {} fallback master rows for FK compatibility.",
-                                    len(missing_master_rows),
-                                )
-                            await asyncio.to_thread(ctx.market_db.upsert_indices_data, rows)
-                    except Exception as e:
-                        errors.append(f"Index date {index_date}: {e}")
-                        logger.warning("Index date {} incremental sync error: {}", index_date, e)
+                except Exception as e:
+                    errors.append(f"Index date {index_date}: {e}")
+                    logger.warning("Index date {} incremental sync error: {}", index_date, e)
 
             # Step 5: Prime fundamentals（増分: date 指定 + 欠損補完）
             ctx.on_progress("fundamentals", 4, 5, "Fetching incremental Prime fundamentals...")
@@ -825,6 +810,34 @@ def get_strategy(resolved_mode: str) -> SyncStrategy:
     return InitialSyncStrategy()
 
 
+async def _seed_index_master_from_catalog(ctx: SyncContext) -> set[str]:
+    seed_rows = build_index_master_seed_rows()
+    if seed_rows:
+        await asyncio.to_thread(ctx.market_db.upsert_index_master, seed_rows)
+    return ctx.market_db.get_index_master_codes()
+
+
+async def _upsert_indices_rows_with_master_backfill(
+    ctx: SyncContext,
+    rows: list[dict[str, Any]],
+    known_master_codes: set[str],
+    *,
+    discovery_log: str | None = None,
+) -> None:
+    missing_master_rows = _build_fallback_index_master_rows(rows, known_master_codes)
+    if missing_master_rows:
+        await asyncio.to_thread(ctx.market_db.upsert_index_master, missing_master_rows)
+        known_master_codes.update(
+            str(row["code"])
+            for row in missing_master_rows
+            if row.get("code")
+        )
+        if discovery_log:
+            logger.warning(discovery_log, len(missing_master_rows))
+
+    await asyncio.to_thread(ctx.market_db.upsert_indices_data, rows)
+
+
 def _convert_stock_rows(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """JQuants 銘柄マスタ → DB 行"""
     rows = []
@@ -1010,7 +1023,7 @@ def _normalize_index_code(value: Any) -> str:
         return ""
     if text.isdigit() and len(text) < 4:
         return text.zfill(4)
-    return text
+    return text.upper()
 
 
 def _latest_date(values: list[str]) -> str | None:

--- a/apps/bt/src/server/services/sync_strategies.py
+++ b/apps/bt/src/server/services/sync_strategies.py
@@ -984,8 +984,7 @@ def _build_fallback_index_master_rows(
     known_codes: set[str],
 ) -> list[dict[str, Any]]:
     """index_master 欠損コード向けに最小プレースホルダ行を作る。"""
-    created_at = datetime.now(UTC).isoformat()
-    missing_rows_by_code: dict[str, dict[str, Any]] = {}
+    missing_master_items_by_code: dict[str, dict[str, Any]] = {}
 
     for row in rows:
         code = _normalize_index_code(row.get("code"))
@@ -996,15 +995,13 @@ def _build_fallback_index_master_rows(
         placeholder_name = row_name or code
         row_date = str(row.get("date") or "").strip() or None
 
-        existing = missing_rows_by_code.get(code)
+        existing = missing_master_items_by_code.get(code)
         if existing is None:
-            missing_rows_by_code[code] = {
+            missing_master_items_by_code[code] = {
                 "code": code,
                 "name": placeholder_name,
-                "name_english": None,
                 "category": "unknown",
                 "data_start_date": row_date,
-                "created_at": created_at,
             }
             continue
 
@@ -1013,7 +1010,7 @@ def _build_fallback_index_master_rows(
         if existing["data_start_date"] is None and row_date:
             existing["data_start_date"] = row_date
 
-    return list(missing_rows_by_code.values())
+    return _convert_index_master_rows(list(missing_master_items_by_code.values()))
 
 
 def _normalize_index_code(value: Any) -> str:

--- a/apps/bt/tests/unit/server/services/test_index_master_catalog.py
+++ b/apps/bt/tests/unit/server/services/test_index_master_catalog.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from src.server.services.index_master_catalog import (
+    _in_hex_range,
+    _resolve_category,
+    build_index_master_seed_rows,
+    get_index_catalog_codes,
+)
+
+
+def test_in_hex_range_handles_true_false_and_invalid() -> None:
+    assert _in_hex_range("004A", "0040", "0060")
+    assert not _in_hex_range("003F", "0040", "0060")
+    assert not _in_hex_range("not-hex", "0040", "0060")
+
+
+def test_resolve_category_covers_all_known_buckets() -> None:
+    assert _resolve_category("0000") == "topix"
+    assert _resolve_category("0500") == "market"
+    assert _resolve_category("8100") == "style"
+    assert _resolve_category("004A") == "sector33"
+    assert _resolve_category("008B") == "sector17"
+    assert _resolve_category("0999") == "unknown"
+
+
+def test_get_index_catalog_codes_contains_known_codes() -> None:
+    codes = get_index_catalog_codes()
+    assert "0000" in codes
+    assert "0040" in codes
+    assert "8503" in codes
+    assert len(codes) > 60
+
+
+def test_build_index_master_seed_rows_respects_existing_codes() -> None:
+    rows = build_index_master_seed_rows(existing_codes={"0000", "0040"})
+
+    codes = {str(row["code"]) for row in rows}
+    assert "0000" not in codes
+    assert "0040" not in codes
+    assert "0500" in codes
+
+    sample = next(row for row in rows if row["code"] == "0500")
+    assert sample["name"] == "東証プライム市場指数"
+    assert sample["category"] == "market"
+    assert sample["data_start_date"] is None
+    assert sample["created_at"]
+
+
+def test_build_index_master_seed_rows_returns_all_when_existing_empty() -> None:
+    rows = build_index_master_seed_rows()
+    codes = {str(row["code"]) for row in rows}
+    assert "0000" in codes
+    assert "0080" in codes
+    assert "812C" in codes


### PR DESCRIPTION
## Summary
- replace /indices master fetch dependency with local index_master catalog seed
- sync indices by code using catalog plus existing DB codes, and keep date-based discovery for new codes
- preserve existing index_master.data_start_date on upsert when incoming value is null
- add and update unit tests for index catalog and sync strategy behavior

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/services/test_index_master_catalog.py apps/bt/tests/unit/server/db/test_market_db.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_index_master_catalog.py apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/db/test_market_db.py

## Notes
- no related open issue was selected to close in this change set