### PR TITLE
fix(bt): normalize lab strategy output paths

### DIFF
--- a/apps/bt/src/agent/yaml_updater.py
+++ b/apps/bt/src/agent/yaml_updater.py
@@ -117,7 +117,8 @@ class YamlUpdater:
         # 出力パス決定
         if output_path is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"{strategy_name}_improved_{timestamp}.yaml"
+            strategy_basename = self._resolve_strategy_basename(strategy_name)
+            filename = f"{strategy_basename}_improved_{timestamp}.yaml"
 
             # experimentalは外部ディレクトリに保存
             if self.use_external:
@@ -238,6 +239,18 @@ class YamlUpdater:
 
         return "\n".join(lines)
 
+    def _resolve_strategy_basename(self, strategy_name: str) -> str:
+        """
+        戦略名からファイル名用のベース名を解決
+
+        category付き戦略名（例: production/range_break_v15）でも
+        不要なディレクトリを作らないよう basename のみを返す。
+        """
+        normalized = strategy_name.replace("\\", "/").strip("/")
+        if not normalized:
+            return "strategy"
+        return normalized.rsplit("/", 1)[-1]
+
     def save_evolution_result(
         self,
         best_candidate: StrategyCandidate,
@@ -258,6 +271,7 @@ class YamlUpdater:
             (戦略YAMLパス, 履歴YAMLパス)
         """
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        strategy_basename = self._resolve_strategy_basename(base_strategy_name)
 
         if output_dir is None:
             # experimentalは外部ディレクトリに保存
@@ -270,11 +284,13 @@ class YamlUpdater:
         os.makedirs(output_dir, exist_ok=True)
 
         # 戦略YAML保存
-        strategy_path = os.path.join(output_dir, f"{base_strategy_name}_{timestamp}.yaml")
+        strategy_path = os.path.join(output_dir, f"{strategy_basename}_{timestamp}.yaml")
         self.save_candidate(best_candidate, strategy_path)
 
         # 履歴YAML保存
-        history_path = os.path.join(output_dir, f"{base_strategy_name}_{timestamp}_history.yaml")
+        history_path = os.path.join(
+            output_dir, f"{strategy_basename}_{timestamp}_history.yaml"
+        )
         ruamel_yaml = YAML()
         ruamel_yaml.default_flow_style = False
         ruamel_yaml.allow_unicode = True
@@ -313,6 +329,7 @@ class YamlUpdater:
             (戦略YAMLパス, 履歴YAMLパス)
         """
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        strategy_basename = self._resolve_strategy_basename(base_strategy_name)
 
         if output_dir is None:
             # experimentalは外部ディレクトリに保存
@@ -325,11 +342,13 @@ class YamlUpdater:
         os.makedirs(output_dir, exist_ok=True)
 
         # 戦略YAML保存
-        strategy_path = os.path.join(output_dir, f"{base_strategy_name}_{timestamp}.yaml")
+        strategy_path = os.path.join(output_dir, f"{strategy_basename}_{timestamp}.yaml")
         self.save_candidate(best_candidate, strategy_path)
 
         # 履歴YAML保存
-        history_path = os.path.join(output_dir, f"{base_strategy_name}_{timestamp}_history.yaml")
+        history_path = os.path.join(
+            output_dir, f"{strategy_basename}_{timestamp}_history.yaml"
+        )
         ruamel_yaml = YAML()
         ruamel_yaml.default_flow_style = False
         ruamel_yaml.allow_unicode = True


### PR DESCRIPTION
## Summary
- normalize strategy names to basename when saving lab outputs in YamlUpdater
- fix optuna/evolve saved paths so category-prefixed strategies (e.g. production/foo) do not create nested production/ dirs
- apply the same basename rule to apply_improvements default output naming
- add regression tests for basename resolution and external/non-external output-dir branches

## Testing
- uv run pytest tests/unit/agent/test_yaml_updater.py -q
- uv run coverage run --branch -m pytest tests/unit/agent/test_yaml_updater.py -q
- uv run coverage report -m src/agent/yaml_updater.py
- uv run ruff check src/agent/yaml_updater.py tests/unit/agent/test_yaml_updater.py