### PR TITLE
feat(web): restore optimization popup editor and add smoke coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ bun run cli backtest attribution run <strategy> --wait
 
 - Backtest UI は `Attribution` サブタブ内に `Run` / `History` を持ち、進捗取得は 2 秒ポーリング
 - Backtest `Strategies` 画面の YAML Editor は `production` / `experimental` の編集を許可し、`Rename` / `Delete` は `experimental` のみ許可
-- Backtest `Strategies > Optimize` の Grid Editor は Monaco + helper panel（preset 適用 / 検出 parameter path プレビュー / live YAML フィードバック）を提供し、保存ブロックは YAML 構文エラー時のみとする
+- Backtest `Strategies > Optimize` は `Open Editor` ポップアップで Monaco + Signal Reference を表示し、`Current` / `Saved` / `State` 要約を維持する。保存ブロックは YAML 構文エラー時のみとする
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 - `analysis screening`（web/cli）は production 戦略を動的選択し、非同期ジョブ（2秒ポーリング）で実行する。`sortBy` 既定は `matchedDate`、`order` 既定は `desc`。`backtestMetric` は廃止
 

--- a/apps/ts/packages/web/e2e/backtest-optimize-popup.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/backtest-optimize-popup.smoke.spec.ts
@@ -165,7 +165,7 @@ test.describe('backtest optimize popup smoke', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText(`Optimization Grid Editor: ${STRATEGY_BASENAME}`)).toBeVisible();
-    await expect(dialog.getByText('Signal Reference')).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Signal Reference' })).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Save' })).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Close' })).toBeVisible();
   });

--- a/apps/ts/packages/web/e2e/backtest-optimize-popup.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/backtest-optimize-popup.smoke.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test } from '@playwright/test';
+
+const STRATEGY_NAME = 'production/smoke_strategy';
+const STRATEGY_BASENAME = 'smoke_strategy';
+const STRATEGY_DISPLAY_NAME = 'Smoke Strategy';
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  };
+}
+
+test.describe('backtest optimize popup smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/strategies**', async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const path = url.pathname;
+
+      if (request.method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+
+      if (path === '/api/strategies') {
+        await route.fulfill(
+          jsonResponse({
+            strategies: [
+              {
+                name: STRATEGY_NAME,
+                category: 'production',
+                display_name: STRATEGY_DISPLAY_NAME,
+                description: 'Smoke strategy for optimize popup flow',
+                last_modified: '2026-02-19T00:00:00Z',
+              },
+            ],
+            total: 1,
+          })
+        );
+        return;
+      }
+
+      if (path.startsWith('/api/strategies/')) {
+        const encodedName = path.slice('/api/strategies/'.length);
+        const strategyName = decodeURIComponent(encodedName);
+        if (strategyName === STRATEGY_NAME) {
+          await route.fulfill(
+            jsonResponse({
+              name: STRATEGY_NAME,
+              category: 'production',
+              display_name: STRATEGY_DISPLAY_NAME,
+              description: 'Smoke strategy for optimize popup flow',
+              config: {
+                entry_filter_params: {
+                  period_breakout: {
+                    period: 20,
+                  },
+                },
+              },
+              execution_info: {},
+            })
+          );
+          return;
+        }
+      }
+
+      await route.continue();
+    });
+
+    await page.route('**/api/optimize/grid-configs**', async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const path = url.pathname;
+
+      if (request.method() === 'GET' && path === `/api/optimize/grid-configs/${STRATEGY_BASENAME}`) {
+        await route.fulfill(
+          jsonResponse({
+            strategy_name: STRATEGY_BASENAME,
+            content: `parameter_ranges:
+  entry_filter_params:
+    period_breakout:
+      period: [10, 20]
+  exit_trigger_params:
+    atr_stop:
+      atr_multiplier: [1.5, 2.0]
+`,
+            param_count: 2,
+            combinations: 4,
+          })
+        );
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.route('**/api/signals/reference', async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const path = url.pathname;
+
+      if (request.method() === 'GET' && path === '/api/signals/reference') {
+        await route.fulfill(
+          jsonResponse({
+            categories: [
+              {
+                key: 'breakout',
+                label: 'Breakout',
+              },
+            ],
+            signals: [
+              {
+                key: 'period_breakout',
+                name: 'Period Breakout',
+                category: 'breakout',
+                description: 'Breakout signal for smoke flow',
+                usage_hint: 'Use for trend following entries.',
+                fields: [
+                  {
+                    name: 'period',
+                    type: 'number',
+                    description: 'Lookback period',
+                    default: 20,
+                    options: null,
+                    constraints: {
+                      ge: 1,
+                    },
+                  },
+                ],
+                yaml_snippet: `entry_filter_params:
+  period_breakout:
+    period: 20`,
+                exit_disabled: false,
+                data_requirements: ['stock_data'],
+              },
+            ],
+            total: 1,
+          })
+        );
+        return;
+      }
+
+      await route.continue();
+    });
+  });
+
+  test('@smoke opens optimization popup editor from strategies tab', async ({ page }) => {
+    await page.goto('/backtest');
+
+    await page.getByRole('button', { name: 'Strategies' }).click();
+    await expect(page.getByRole('heading', { name: STRATEGY_DISPLAY_NAME })).toBeVisible();
+
+    await page.getByRole('heading', { name: STRATEGY_DISPLAY_NAME }).click();
+    await page.getByRole('button', { name: 'Optimize' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Optimization Grid' })).toBeVisible();
+    await expect(page.getByText('Current')).toBeVisible();
+    await expect(page.getByText('Saved')).toBeVisible();
+    await expect(page.getByText('State')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open Editor' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(`Optimization Grid Editor: ${STRATEGY_BASENAME}`)).toBeVisible();
+    await expect(dialog.getByText('Signal Reference')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Save' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Close' })).toBeVisible();
+  });
+});

--- a/apps/ts/packages/web/e2e/backtest-optimize-popup.smoke.spec.ts
+++ b/apps/ts/packages/web/e2e/backtest-optimize-popup.smoke.spec.ts
@@ -167,6 +167,6 @@ test.describe('backtest optimize popup smoke', () => {
     await expect(dialog.getByText(`Optimization Grid Editor: ${STRATEGY_BASENAME}`)).toBeVisible();
     await expect(dialog.getByRole('heading', { name: 'Signal Reference' })).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Save' })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: 'Close' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Close' }).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- switch Backtest Strategies > Optimize from helper panel layout to an Open Editor popup flow
- keep Current/Saved/State summary behavior while showing Signal Reference in the popup editor
- add and expand unit tests for optimize editor branches and error handling
- add a new Playwright smoke spec for the optimize popup flow under e2e
- update AGENTS.md to reflect the popup-based optimize editor behavior

## Validation
- bun run --filter @trading25/web test src/components/Backtest/OptimizationGridEditor.test.tsx
- bun run --filter @trading25/web typecheck
- bunx vitest run src/components/Backtest/OptimizationGridEditor.test.tsx --coverage --coverage.include=src/components/Backtest/OptimizationGridEditor.tsx --coverage.reporter=text
- PLAYWRIGHT_SKIP_WEBSERVER=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:1 bun run --filter @trading25/web e2e --list