### PR TITLE
test(web): add Backtest component coverage suite

### DIFF
--- a/apps/ts/packages/web/src/components/Backtest/BacktestResults.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/BacktestResults.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { BacktestResults } from './BacktestResults';
+
+vi.mock('./HtmlFileBrowser', () => ({
+  HtmlFileBrowser: () => <div>Backtest Browser Content</div>,
+}));
+
+vi.mock('./OptimizationHtmlFileBrowser', () => ({
+  OptimizationHtmlFileBrowser: () => <div>Optimization Browser Content</div>,
+}));
+
+describe('BacktestResults', () => {
+  it('renders backtest tab content by default', () => {
+    render(<BacktestResults />);
+
+    expect(screen.getByRole('button', { name: 'Backtest' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Optimization' })).toBeInTheDocument();
+    expect(screen.getByText('Backtest Browser Content')).toBeInTheDocument();
+    expect(screen.queryByText('Optimization Browser Content')).not.toBeInTheDocument();
+  });
+
+  it('switches between backtest and optimization tabs', async () => {
+    const user = userEvent.setup();
+    render(<BacktestResults />);
+
+    await user.click(screen.getByRole('button', { name: 'Optimization' }));
+    expect(screen.getByText('Optimization Browser Content')).toBeInTheDocument();
+    expect(screen.queryByText('Backtest Browser Content')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Backtest' }));
+    expect(screen.getByText('Backtest Browser Content')).toBeInTheDocument();
+    expect(screen.queryByText('Optimization Browser Content')).not.toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/BacktestRunner.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/BacktestRunner.test.tsx
@@ -1,0 +1,333 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BacktestRunner } from './BacktestRunner';
+
+const mockInvalidateQueries = vi.fn();
+const mockSetSelectedStrategy = vi.fn();
+const mockSetActiveJobId = vi.fn();
+const mockSetActiveOptimizationJobId = vi.fn();
+const mockRunBacktestMutateAsync = vi.fn();
+const mockCancelBacktestMutate = vi.fn();
+const mockRunOptimizationMutateAsync = vi.fn();
+
+const mockStore = {
+  selectedStrategy: 'production/alpha' as string | null,
+  setSelectedStrategy: mockSetSelectedStrategy,
+  activeJobId: null as string | null,
+  setActiveJobId: mockSetActiveJobId,
+  activeOptimizationJobId: null as string | null,
+  setActiveOptimizationJobId: mockSetActiveOptimizationJobId,
+};
+
+const mockHookState = {
+  strategiesData: {
+    data: {
+      strategies: [{ name: 'production/alpha', category: 'production', display_name: null }],
+    },
+    isLoading: false,
+  },
+  strategyDetail: null as
+    | {
+        name: string;
+        display_name: string | null;
+        category: string;
+        description: string | null;
+      }
+    | null,
+  jobStatus: {
+    data: null as { status?: string } | null,
+    isLoading: false,
+  },
+  runBacktest: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+  cancelBacktest: {
+    isPending: false,
+  },
+  optimizationJobStatus: {
+    data: null as { status?: string } | null,
+    isLoading: false,
+  },
+  runOptimization: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+  gridConfig: null as { content: string; param_count: number; combinations: number } | null,
+  gridEntries: [] as Array<{ path: string; values: unknown[] }>,
+};
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  };
+});
+
+vi.mock('@/stores/backtestStore', () => ({
+  useBacktestStore: () => mockStore,
+}));
+
+vi.mock('@/hooks/useBacktest', () => ({
+  backtestKeys: {
+    htmlFiles: () => ['backtest', 'html-files'],
+  },
+  useStrategies: () => ({
+    data: mockHookState.strategiesData.data,
+    isLoading: mockHookState.strategiesData.isLoading,
+  }),
+  useStrategy: () => ({
+    data: mockHookState.strategyDetail,
+  }),
+  useJobStatus: () => ({
+    data: mockHookState.jobStatus.data,
+    isLoading: mockHookState.jobStatus.isLoading,
+  }),
+  useRunBacktest: () => ({
+    mutateAsync: mockRunBacktestMutateAsync,
+    isPending: mockHookState.runBacktest.isPending,
+    isError: mockHookState.runBacktest.isError,
+    error: mockHookState.runBacktest.error,
+  }),
+  useCancelBacktest: () => ({
+    mutate: mockCancelBacktestMutate,
+    isPending: mockHookState.cancelBacktest.isPending,
+  }),
+}));
+
+vi.mock('@/hooks/useOptimization', () => ({
+  optimizationKeys: {
+    htmlFiles: () => ['optimization', 'html-files'],
+  },
+  useOptimizationJobStatus: () => ({
+    data: mockHookState.optimizationJobStatus.data,
+    isLoading: mockHookState.optimizationJobStatus.isLoading,
+  }),
+  useRunOptimization: () => ({
+    mutateAsync: mockRunOptimizationMutateAsync,
+    isPending: mockHookState.runOptimization.isPending,
+    isError: mockHookState.runOptimization.isError,
+    error: mockHookState.runOptimization.error,
+  }),
+  useOptimizationGridConfig: () => ({
+    data: mockHookState.gridConfig,
+  }),
+}));
+
+vi.mock('./optimizationGridParams', () => ({
+  extractGridParameterEntries: () => mockHookState.gridEntries,
+  formatGridParameterValue: (value: unknown) => String(value),
+}));
+
+vi.mock('./StrategySelector', () => ({
+  StrategySelector: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    value: string | null;
+    onChange: (next: string | null) => void;
+    disabled: boolean;
+  }) => (
+    <div>
+      <div>strategy-value:{value ?? 'none'}</div>
+      <div>strategy-disabled:{String(disabled)}</div>
+      <button type="button" onClick={() => onChange('experimental/next')}>
+        Select Strategy
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./DefaultConfigEditor', () => ({
+  DefaultConfigEditor: ({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onOpenChange: (next: boolean) => void;
+  }) => (
+    <div>
+      <div>default-config-open:{String(open)}</div>
+      <button type="button" onClick={() => onOpenChange(false)}>
+        Close Default Config
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./JobProgressCard', () => ({
+  JobProgressCard: ({
+    isLoading,
+    isCancelling,
+    onCancel,
+  }: {
+    isLoading: boolean;
+    isCancelling: boolean;
+    onCancel?: () => void;
+  }) => (
+    <div>
+      <div>job-loading:{String(isLoading)}</div>
+      <div>job-cancelling:{String(isCancelling)}</div>
+      {onCancel ? (
+        <button type="button" onClick={onCancel}>
+          Cancel Active Job
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+vi.mock('./OptimizationJobProgressCard', () => ({
+  OptimizationJobProgressCard: ({ isLoading }: { isLoading: boolean }) => (
+    <div>optimization-job-loading:{String(isLoading)}</div>
+  ),
+}));
+
+describe('BacktestRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore.selectedStrategy = 'production/alpha';
+    mockStore.activeJobId = null;
+    mockStore.activeOptimizationJobId = null;
+
+    mockHookState.strategyDetail = null;
+    mockHookState.jobStatus.data = null;
+    mockHookState.jobStatus.isLoading = false;
+    mockHookState.runBacktest.isPending = false;
+    mockHookState.runBacktest.isError = false;
+    mockHookState.runBacktest.error = null;
+    mockHookState.cancelBacktest.isPending = false;
+    mockHookState.optimizationJobStatus.data = null;
+    mockHookState.optimizationJobStatus.isLoading = false;
+    mockHookState.runOptimization.isPending = false;
+    mockHookState.runOptimization.isError = false;
+    mockHookState.runOptimization.error = null;
+    mockHookState.gridConfig = null;
+    mockHookState.gridEntries = [];
+
+    mockRunBacktestMutateAsync.mockResolvedValue({ job_id: 'job-1' });
+    mockRunOptimizationMutateAsync.mockResolvedValue({ job_id: 'opt-1' });
+  });
+
+  it('renders strategy detail and fallback text when grid config is missing', () => {
+    mockHookState.strategyDetail = {
+      name: 'production/alpha',
+      display_name: 'Alpha Strategy',
+      category: 'production',
+      description: 'Alpha description',
+    };
+
+    render(<BacktestRunner />);
+
+    expect(screen.getByText('strategy-value:production/alpha')).toBeInTheDocument();
+    expect(screen.getByText('Alpha Strategy')).toBeInTheDocument();
+    expect(screen.getByText('Category: production')).toBeInTheDocument();
+    expect(screen.getByText('Alpha description')).toBeInTheDocument();
+    expect(screen.getByText('No grid config found. Configure in Strategies > Optimize tab.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run Optimization' })).toBeDisabled();
+  });
+
+  it('opens default config editor when button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<BacktestRunner />);
+
+    expect(screen.getByText('default-config-open:false')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Default Config' }));
+
+    expect(screen.getByText('default-config-open:true')).toBeInTheDocument();
+  });
+
+  it('runs backtest and stores active job id', async () => {
+    const user = userEvent.setup();
+    render(<BacktestRunner />);
+
+    await user.click(screen.getByRole('button', { name: 'Run Backtest' }));
+
+    expect(mockRunBacktestMutateAsync).toHaveBeenCalledWith({ strategy_name: 'production/alpha' });
+    await waitFor(() => {
+      expect(mockSetActiveJobId).toHaveBeenCalledWith('job-1');
+    });
+  });
+
+  it('disables backtest run when strategy is not selected', () => {
+    mockStore.selectedStrategy = null;
+    render(<BacktestRunner />);
+
+    expect(screen.getByRole('button', { name: 'Run Backtest' })).toBeDisabled();
+  });
+
+  it('shows running state, disables selector, and supports cancellation', async () => {
+    const user = userEvent.setup();
+    mockStore.activeJobId = 'job-running';
+    mockHookState.jobStatus.data = { status: 'running' };
+
+    render(<BacktestRunner />);
+
+    expect(screen.getByRole('button', { name: 'Running...' })).toBeDisabled();
+    expect(screen.getByText('strategy-disabled:true')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel Active Job' }));
+    expect(mockCancelBacktestMutate).toHaveBeenCalledWith('job-running');
+  });
+
+  it('shows backtest error and invalidates result html list on completion', () => {
+    mockHookState.runBacktest.isError = true;
+    mockHookState.runBacktest.error = new Error('backtest failed');
+    mockHookState.jobStatus.data = { status: 'completed' };
+
+    render(<BacktestRunner />);
+
+    expect(screen.getByText('backtest failed')).toBeInTheDocument();
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['backtest', 'html-files'] });
+  });
+
+  it('runs optimization with grid config and displays grid entry details', async () => {
+    const user = userEvent.setup();
+    mockHookState.gridConfig = {
+      content: 'dummy',
+      param_count: 2,
+      combinations: 12,
+    };
+    mockHookState.gridEntries = [
+      { path: 'entry_filter_params.signal_a', values: [1, 2] },
+      { path: 'exit_trigger_params.signal_b', values: ['x', 'y'] },
+    ];
+
+    render(<BacktestRunner />);
+
+    expect(screen.getByText('Grid config: 2 params, 12 combinations')).toBeInTheDocument();
+    expect(screen.getByText('entry_filter_params.signal_a: [1, 2]')).toBeInTheDocument();
+    expect(screen.getByText('exit_trigger_params.signal_b: [x, y]')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Run Optimization' }));
+    expect(mockRunOptimizationMutateAsync).toHaveBeenCalledWith({ strategy_name: 'production/alpha' });
+    await waitFor(() => {
+      expect(mockSetActiveOptimizationJobId).toHaveBeenCalledWith('opt-1');
+    });
+  });
+
+  it('shows optimization running and error states, then invalidates html list on completion', () => {
+    mockHookState.gridConfig = {
+      content: 'dummy',
+      param_count: 1,
+      combinations: 1,
+    };
+    mockHookState.runOptimization.isPending = true;
+    mockHookState.runOptimization.isError = true;
+    mockHookState.runOptimization.error = new Error('optimization failed');
+    mockHookState.optimizationJobStatus.data = { status: 'failed' };
+
+    render(<BacktestRunner />);
+
+    expect(screen.getByRole('button', { name: 'Optimizing...' })).toBeDisabled();
+    expect(screen.getByText('strategy-disabled:true')).toBeInTheDocument();
+    expect(screen.getByText('optimization failed')).toBeInTheDocument();
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['optimization', 'html-files'] });
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/BacktestStatus.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/BacktestStatus.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BacktestJobResponse, HealthResponse } from '@/types/backtest';
+import { BacktestStatus } from './BacktestStatus';
+
+const mockSetActiveSubTab = vi.fn();
+const mockSetSelectedResultJobId = vi.fn();
+const mockRefetchHealth = vi.fn();
+const mockRefetchJobs = vi.fn();
+
+const mockQueryState = {
+  health: null as HealthResponse | null,
+  isLoadingHealth: false,
+  jobs: undefined as BacktestJobResponse[] | undefined,
+  isLoadingJobs: false,
+};
+
+const mockUseBacktestHealth = vi.fn(() => ({
+  data: mockQueryState.health,
+  isLoading: mockQueryState.isLoadingHealth,
+  refetch: mockRefetchHealth,
+}));
+
+const mockUseJobs = vi.fn((_limit?: number) => ({
+  data: mockQueryState.jobs,
+  isLoading: mockQueryState.isLoadingJobs,
+  refetch: mockRefetchJobs,
+}));
+
+vi.mock('@/stores/backtestStore', () => ({
+  useBacktestStore: () => ({
+    setActiveSubTab: mockSetActiveSubTab,
+    setSelectedResultJobId: mockSetSelectedResultJobId,
+  }),
+}));
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useBacktestHealth: () => mockUseBacktestHealth(),
+  useJobs: (limit?: number) => mockUseJobs(limit),
+}));
+
+vi.mock('./JobsTable', () => ({
+  JobsTable: ({
+    jobs,
+    isLoading,
+    onSelectJob,
+  }: {
+    jobs: BacktestJobResponse[] | undefined;
+    isLoading: boolean;
+    onSelectJob: (jobId: string) => void;
+  }) => (
+    <div>
+      <div>jobs-count:{jobs?.length ?? 0}</div>
+      <div>jobs-loading:{String(isLoading)}</div>
+      <button type="button" onClick={() => onSelectJob('selected-job-id')}>
+        Select Job
+      </button>
+    </div>
+  ),
+}));
+
+describe('BacktestStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryState.health = null;
+    mockQueryState.isLoadingHealth = false;
+    mockQueryState.jobs = undefined;
+    mockQueryState.isLoadingJobs = false;
+  });
+
+  it('renders loading state while health check is in progress', () => {
+    mockQueryState.isLoadingHealth = true;
+
+    render(<BacktestStatus />);
+
+    expect(screen.getByText('Checking...')).toBeInTheDocument();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disconnected')).not.toBeInTheDocument();
+  });
+
+  it('renders connected state with service metadata', () => {
+    mockQueryState.health = {
+      service: 'trading25-bt',
+      version: '1.2.3',
+      status: 'ok',
+    } as HealthResponse;
+
+    render(<BacktestStatus />);
+
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getByText('trading25-bt')).toBeInTheDocument();
+    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+
+  it('renders disconnected state when health is unavailable', () => {
+    render(<BacktestStatus />);
+
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+    expect(screen.getByText('Make sure bt server is running on port 3002')).toBeInTheDocument();
+  });
+
+  it('refreshes health and jobs when Refresh is clicked', async () => {
+    const user = userEvent.setup();
+    render(<BacktestStatus />);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(mockRefetchHealth).toHaveBeenCalledTimes(1);
+    expect(mockRefetchJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes jobs query state to JobsTable and requests last 20 jobs', () => {
+    mockQueryState.jobs = [
+      {
+        job_id: 'job-1',
+        status: 'completed',
+      } as BacktestJobResponse,
+      {
+        job_id: 'job-2',
+        status: 'running',
+      } as BacktestJobResponse,
+    ];
+    mockQueryState.isLoadingJobs = true;
+
+    render(<BacktestStatus />);
+
+    expect(mockUseJobs).toHaveBeenCalledWith(20);
+    expect(screen.getByText('jobs-count:2')).toBeInTheDocument();
+    expect(screen.getByText('jobs-loading:true')).toBeInTheDocument();
+  });
+
+  it('moves to results tab when selecting a job from JobsTable', async () => {
+    const user = userEvent.setup();
+    render(<BacktestStatus />);
+
+    await user.click(screen.getByRole('button', { name: 'Select Job' }));
+
+    expect(mockSetSelectedResultJobId).toHaveBeenCalledWith('selected-job-id');
+    expect(mockSetActiveSubTab).toHaveBeenCalledWith('results');
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DatasetCreateForm.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetCreateForm.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent, ReactNode } from 'react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DatasetCreateForm } from './DatasetCreateForm';
+
+const mockCreateMutate = vi.fn();
+const mockResumeMutate = vi.fn();
+const mockSetActiveDatasetJobId = vi.fn();
+
+const mockStore = {
+  activeDatasetJobId: null as string | null,
+};
+
+const mockState = {
+  create: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+  resume: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+};
+
+vi.mock('@/stores/backtestStore', () => ({
+  useBacktestStore: () => ({
+    activeDatasetJobId: mockStore.activeDatasetJobId,
+    setActiveDatasetJobId: mockSetActiveDatasetJobId,
+  }),
+}));
+
+vi.mock('@/hooks/useDataset', () => ({
+  useCreateDataset: () => ({
+    mutate: mockCreateMutate,
+    isPending: mockState.create.isPending,
+    isError: mockState.create.isError,
+    error: mockState.create.error,
+  }),
+  useResumeDataset: () => ({
+    mutate: mockResumeMutate,
+    isPending: mockState.resume.isPending,
+    isError: mockState.resume.isError,
+    error: mockState.resume.error,
+  }),
+}));
+
+vi.mock('./DatasetJobProgress', () => ({
+  DatasetJobProgress: () => <div>Dataset Job Progress</div>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: ({
+    id,
+    value,
+    onChange,
+    placeholder,
+    type = 'text',
+  }: {
+    id?: string;
+    value?: string | number;
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    type?: string;
+  }) => <input id={id} type={type} value={value} onChange={onChange} placeholder={placeholder} />,
+}));
+
+vi.mock('@/components/ui/select', () => {
+  const SelectContext = React.createContext<(value: string) => void>(() => {});
+
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => <SelectContext.Provider value={onValueChange ?? (() => {})}>{children}</SelectContext.Provider>,
+    SelectTrigger: ({ children, id }: { children: ReactNode; id?: string }) => (
+      <div data-testid={id ?? 'select-trigger'}>{children}</div>
+    ),
+    SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+    SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) => {
+      const setValue = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => setValue(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+describe('DatasetCreateForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore.activeDatasetJobId = null;
+    mockState.create.isPending = false;
+    mockState.create.isError = false;
+    mockState.create.error = null;
+    mockState.resume.isPending = false;
+    mockState.resume.isError = false;
+    mockState.resume.error = null;
+  });
+
+  it('renders default values and preset information', () => {
+    render(<DatasetCreateForm />);
+
+    expect(screen.getByDisplayValue('quickTesting.db')).toBeInTheDocument();
+    expect(screen.getByText(/テスト用小規模データセット/)).toBeInTheDocument();
+    expect(screen.getByText('Dataset Job Progress')).toBeInTheDocument();
+  });
+
+  it('updates filename when preset changes', async () => {
+    const user = userEvent.setup();
+    render(<DatasetCreateForm />);
+
+    await user.click(screen.getByRole('button', { name: 'TOPIX 100' }));
+    expect(screen.getByDisplayValue('topix100.db')).toBeInTheDocument();
+  });
+
+  it('creates dataset and stores active job id on success', async () => {
+    const user = userEvent.setup();
+    mockCreateMutate.mockImplementation((_payload, options) => {
+      options?.onSuccess?.({ jobId: 'dataset-job-1' });
+    });
+
+    render(<DatasetCreateForm />);
+
+    await user.click(screen.getByRole('button', { name: '作成' }));
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      {
+        name: 'quickTesting.db',
+        preset: 'quickTesting',
+        overwrite: false,
+        timeoutMinutes: 30,
+      },
+      expect.any(Object)
+    );
+    expect(mockSetActiveDatasetJobId).toHaveBeenCalledWith('dataset-job-1');
+  });
+
+  it('resumes dataset and stores active job id on success', async () => {
+    const user = userEvent.setup();
+    mockResumeMutate.mockImplementation((_payload, options) => {
+      options?.onSuccess?.({ jobId: 'dataset-job-2' });
+    });
+
+    render(<DatasetCreateForm />);
+
+    await user.click(screen.getByRole('button', { name: 'レジューム' }));
+
+    expect(mockResumeMutate).toHaveBeenCalledWith(
+      {
+        name: 'quickTesting.db',
+        preset: 'quickTesting',
+        timeoutMinutes: 30,
+      },
+      expect.any(Object)
+    );
+    expect(mockSetActiveDatasetJobId).toHaveBeenCalledWith('dataset-job-2');
+  });
+
+  it('disables actions when a dataset job is active', () => {
+    mockStore.activeDatasetJobId = 'running-job';
+
+    render(<DatasetCreateForm />);
+
+    expect(screen.getByRole('button', { name: '作成' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'レジューム' })).toBeDisabled();
+  });
+
+  it('shows create and resume errors', () => {
+    mockState.create.isError = true;
+    mockState.create.error = new Error('create failed');
+    mockState.resume.isError = true;
+    mockState.resume.error = new Error('resume failed');
+
+    render(<DatasetCreateForm />);
+
+    expect(screen.getByText('Error: create failed')).toBeInTheDocument();
+    expect(screen.getByText('Error: resume failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DatasetDeleteDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetDeleteDialog.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DatasetDeleteDialog } from './DatasetDeleteDialog';
+
+const mockMutate = vi.fn();
+const mockDeleteState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+};
+
+vi.mock('@/hooks/useDataset', () => ({
+  useDeleteDataset: () => ({
+    mutate: mockMutate,
+    isPending: mockDeleteState.isPending,
+    isError: mockDeleteState.isError,
+    error: mockDeleteState.error,
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('DatasetDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteState.isPending = false;
+    mockDeleteState.isError = false;
+    mockDeleteState.error = null;
+  });
+
+  it('deletes dataset and closes dialog on success', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    mockMutate.mockImplementation((_name, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(<DatasetDeleteDialog open={true} onOpenChange={onOpenChange} datasetName="quickTesting.db" />);
+
+    expect(screen.getByText('quickTesting.db')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '削除' }));
+
+    expect(mockMutate).toHaveBeenCalledWith('quickTesting.db', expect.any(Object));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes dialog when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(<DatasetDeleteDialog open={true} onOpenChange={onOpenChange} datasetName="quickTesting.db" />);
+
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows pending and error states', () => {
+    mockDeleteState.isPending = true;
+    mockDeleteState.isError = true;
+    mockDeleteState.error = new Error('delete failed');
+
+    render(<DatasetDeleteDialog open={true} onOpenChange={vi.fn()} datasetName="quickTesting.db" />);
+
+    expect(screen.getByRole('button', { name: '削除中...' })).toBeDisabled();
+    expect(screen.getByText('Error: delete failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DatasetInfoDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetInfoDialog.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DatasetInfoDialog } from './DatasetInfoDialog';
+
+const mockUseDatasetInfo = vi.fn();
+
+const mockState = {
+  data: null as Record<string, unknown> | null,
+  isLoading: false,
+  isError: false,
+  error: null as Error | null,
+};
+
+vi.mock('@/hooks/useDataset', () => ({
+  useDatasetInfo: (name: string | null) => {
+    mockUseDatasetInfo(name);
+    return {
+      data: mockState.data,
+      isLoading: mockState.isLoading,
+      isError: mockState.isError,
+      error: mockState.error,
+    };
+  },
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('DatasetInfoDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.data = null;
+    mockState.isLoading = false;
+    mockState.isError = false;
+    mockState.error = null;
+  });
+
+  it('renders loading state', () => {
+    mockState.isLoading = true;
+
+    render(<DatasetInfoDialog open={true} onOpenChange={vi.fn()} datasetName="quickTesting.db" />);
+
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(mockUseDatasetInfo).toHaveBeenCalledWith('quickTesting.db');
+  });
+
+  it('renders error state', () => {
+    mockState.isError = true;
+    mockState.error = new Error('failed to load');
+
+    render(<DatasetInfoDialog open={true} onOpenChange={vi.fn()} datasetName="quickTesting.db" />);
+
+    expect(screen.getByText('Error: failed to load')).toBeInTheDocument();
+  });
+
+  it('renders detailed dataset info and closes dialog', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    mockState.data = {
+      snapshot: {
+        preset: 'quickTesting',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+      fileSize: 1024 * 1024,
+      lastModified: '2026-01-02T00:00:00Z',
+      stats: {
+        totalStocks: 100,
+        totalQuotes: 2000,
+        dateRange: { from: '2025-01-01', to: '2025-12-31' },
+        hasMarginData: true,
+        hasTOPIXData: true,
+        hasSectorData: false,
+        hasStatementsData: true,
+        statementsFieldCoverage: {
+          hasExtendedFields: true,
+          hasCashFlowFields: false,
+        },
+      },
+      validation: {
+        isValid: true,
+        errors: [],
+        warnings: [],
+        details: {
+          dataCoverage: {
+            stocksWithQuotes: 90,
+            stocksWithStatements: 80,
+            stocksWithMargin: 70,
+            totalStocks: 100,
+          },
+        },
+      },
+    };
+
+    render(<DatasetInfoDialog open={true} onOpenChange={onOpenChange} datasetName="quickTesting.db" />);
+
+    expect(screen.getByText('quickTesting')).toBeInTheDocument();
+    expect(screen.getByText('Quotes')).toBeInTheDocument();
+    expect(screen.getByText('90 / 100')).toBeInTheDocument();
+    expect(screen.getAllByText('Statements').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('80 / 100')).toBeInTheDocument();
+    expect(screen.getAllByText('Margin').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('70 / 100')).toBeInTheDocument();
+    expect(screen.getByText('CF: N/A (v1)')).toBeInTheDocument();
+    expect(screen.getByText('問題なし')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '閉じる' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders validation errors and warnings', () => {
+    mockState.data = {
+      snapshot: {
+        preset: null,
+        createdAt: null,
+      },
+      fileSize: 1234,
+      lastModified: '2026-01-02T00:00:00Z',
+      stats: {
+        totalStocks: 10,
+        totalQuotes: 20,
+        dateRange: { from: '2025-01-01', to: '2025-01-02' },
+        hasMarginData: false,
+        hasTOPIXData: false,
+        hasSectorData: false,
+        hasStatementsData: false,
+        statementsFieldCoverage: null,
+      },
+      validation: {
+        isValid: false,
+        errors: ['missing quotes'],
+        warnings: ['partial update'],
+        details: {},
+      },
+    };
+
+    render(<DatasetInfoDialog open={true} onOpenChange={vi.fn()} datasetName="quickTesting.db" />);
+
+    expect(screen.getByText('missing quotes')).toBeInTheDocument();
+    expect(screen.getByText('partial update')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DatasetJobProgress.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetJobProgress.test.tsx
@@ -1,0 +1,185 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DatasetJobResponse } from '@/types/dataset';
+import { DatasetJobProgress } from './DatasetJobProgress';
+
+const mockInvalidateQueries = vi.fn();
+const mockCancelMutate = vi.fn();
+const mockSetActiveDatasetJobId = vi.fn();
+
+const mockStoreState = {
+  activeDatasetJobId: null as string | null,
+};
+
+const mockHookState = {
+  job: null as DatasetJobResponse | null,
+  cancelIsPending: false,
+};
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: (...args: unknown[]) => mockInvalidateQueries(...args),
+    }),
+  };
+});
+
+vi.mock('@/stores/backtestStore', () => ({
+  useBacktestStore: Object.assign(
+    () => ({
+      activeDatasetJobId: mockStoreState.activeDatasetJobId,
+      setActiveDatasetJobId: (...args: unknown[]) => mockSetActiveDatasetJobId(...args),
+    }),
+    {
+      getState: () => ({
+        activeDatasetJobId: mockStoreState.activeDatasetJobId,
+      }),
+    }
+  ),
+}));
+
+vi.mock('@/hooks/useDataset', () => ({
+  datasetKeys: {
+    list: () => ['dataset', 'list'],
+  },
+  useDatasetJobStatus: () => ({
+    data: mockHookState.job,
+  }),
+  useCancelDatasetJob: () => ({
+    mutate: (...args: unknown[]) => mockCancelMutate(...args),
+    isPending: mockHookState.cancelIsPending,
+  }),
+}));
+
+describe('DatasetJobProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    mockStoreState.activeDatasetJobId = null;
+    mockHookState.job = null;
+    mockHookState.cancelIsPending = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when no active job is selected', () => {
+    const { container } = render(<DatasetJobProgress />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders running state, elapsed time, and allows cancellation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-10T00:01:05Z'));
+
+    mockStoreState.activeDatasetJobId = 'job-running';
+    mockHookState.job = {
+      jobId: 'job-running',
+      status: 'running',
+      startedAt: '2026-02-10T00:00:00Z',
+      progress: null,
+    } as DatasetJobResponse;
+
+    render(<DatasetJobProgress />);
+
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText('1:05')).toBeInTheDocument();
+    expect(document.querySelector('.animate-progress-indeterminate')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(mockCancelMutate).toHaveBeenCalledWith('job-running', expect.any(Object));
+
+    const [, options] = mockCancelMutate.mock.calls[0] as [
+      string,
+      { onSuccess?: () => void } | undefined,
+    ];
+    options?.onSuccess?.();
+    expect(mockSetActiveDatasetJobId).toHaveBeenCalledWith(null);
+  });
+
+  it('renders progress content and caps progress bar width at 100%', () => {
+    mockStoreState.activeDatasetJobId = 'job-progress';
+    mockHookState.job = {
+      jobId: 'job-progress',
+      status: 'running',
+      startedAt: '2026-02-10T00:00:00Z',
+      progress: {
+        stage: 'sync',
+        percentage: 132.5,
+        message: 'processing...',
+      },
+    } as DatasetJobResponse;
+
+    const { container } = render(<DatasetJobProgress />);
+
+    expect(screen.getByText('sync')).toBeInTheDocument();
+    expect(screen.getByText('132.5%')).toBeInTheDocument();
+    expect(screen.getByText('processing...')).toBeInTheDocument();
+    expect(container.querySelector('[style="width: 100%;"]')).toBeInTheDocument();
+  });
+
+  it('invalidates dataset list and auto-clears active id after completion', () => {
+    vi.useFakeTimers();
+    mockStoreState.activeDatasetJobId = 'job-completed';
+    mockHookState.job = {
+      jobId: 'job-completed',
+      status: 'completed',
+      startedAt: '2026-02-10T00:00:00Z',
+      result: {
+        processedStocks: 8,
+        totalStocks: 10,
+        warnings: ['warn-1'],
+      },
+    } as DatasetJobResponse;
+
+    render(<DatasetJobProgress />);
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['dataset', 'list'] });
+    expect(screen.getByText('8/10 銘柄処理完了')).toBeInTheDocument();
+    expect(screen.getByText('1 warnings')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockSetActiveDatasetJobId).toHaveBeenCalledWith(null);
+  });
+
+  it('does not clear active id when a different job became active before timeout', () => {
+    vi.useFakeTimers();
+    mockStoreState.activeDatasetJobId = 'job-a';
+    mockHookState.job = {
+      jobId: 'job-a',
+      status: 'cancelled',
+      startedAt: '2026-02-10T00:00:00Z',
+    } as DatasetJobResponse;
+
+    render(<DatasetJobProgress />);
+
+    mockSetActiveDatasetJobId.mockClear();
+    mockStoreState.activeDatasetJobId = 'job-b';
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockSetActiveDatasetJobId).not.toHaveBeenCalled();
+  });
+
+  it('renders failed state error message', () => {
+    mockStoreState.activeDatasetJobId = 'job-failed';
+    mockHookState.job = {
+      jobId: 'job-failed',
+      status: 'failed',
+      startedAt: '2026-02-10T00:00:00Z',
+      error: 'dataset creation failed',
+    } as DatasetJobResponse;
+
+    render(<DatasetJobProgress />);
+
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('dataset creation failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DatasetManager.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetManager.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DatasetManager } from './DatasetManager';
+
+vi.mock('./DatasetCreateForm', () => ({
+  DatasetCreateForm: () => <div>Dataset Create Form</div>,
+}));
+
+vi.mock('./DatasetList', () => ({
+  DatasetList: () => <div>Dataset List</div>,
+}));
+
+describe('DatasetManager', () => {
+  it('renders dataset create form and dataset list', () => {
+    render(<DatasetManager />);
+
+    expect(screen.getByText('Dataset Create Form')).toBeInTheDocument();
+    expect(screen.getByText('Dataset List')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DefaultConfigEditor.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DefaultConfigEditor.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DefaultConfigEditor } from './DefaultConfigEditor';
+
+const mockMutate = vi.fn();
+const mockReset = vi.fn();
+
+const mockState = {
+  configData: null as { content: string } | null,
+  isLoading: false,
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+};
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useDefaultConfig: () => ({
+    data: mockState.configData,
+    isLoading: mockState.isLoading,
+  }),
+  useUpdateDefaultConfig: () => ({
+    mutate: mockMutate,
+    reset: mockReset,
+    isPending: mockState.isPending,
+    isError: mockState.isError,
+    error: mockState.error,
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/Editor/MonacoYamlEditor', () => ({
+  MonacoYamlEditor: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="yaml-editor"
+      value={value}
+      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+describe('DefaultConfigEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.configData = { content: 'filters:\n  min_price: 1000' };
+    mockState.isLoading = false;
+    mockState.isPending = false;
+    mockState.isError = false;
+    mockState.error = null;
+  });
+
+  it('renders loading state', () => {
+    mockState.isLoading = true;
+
+    render(<DefaultConfigEditor open={true} onOpenChange={vi.fn()} />);
+
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('saves valid yaml and closes dialog on success', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    mockMutate.mockImplementation((_payload, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(<DefaultConfigEditor open={true} onOpenChange={onOpenChange} />);
+
+    const editor = screen.getByLabelText('yaml-editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('min_price: 1000');
+
+    await user.clear(editor);
+    await user.type(editor, 'filters:\n  min_price: 1200');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockMutate).toHaveBeenCalledWith({ content: 'filters:\n  min_price: 1200' }, expect.any(Object));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows parse error and prevents save for invalid yaml', async () => {
+    const user = userEvent.setup();
+    render(<DefaultConfigEditor open={true} onOpenChange={vi.fn()} />);
+
+    const editor = screen.getByLabelText('yaml-editor');
+    fireEvent.change(editor, { target: { value: 'filters: [' } });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText(/YAML parse error:/)).toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('resets mutation state when cancel closes dialog', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(<DefaultConfigEditor open={true} onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows mutation error banner', () => {
+    mockState.isError = true;
+    mockState.error = new Error('update failed');
+
+    render(<DefaultConfigEditor open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('Error: update failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DeleteConfirmDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DeleteConfirmDialog.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+
+const mockMutate = vi.fn();
+const mockDeleteState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+};
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useDeleteStrategy: () => ({
+    mutate: mockMutate,
+    isPending: mockDeleteState.isPending,
+    isError: mockDeleteState.isError,
+    error: mockDeleteState.error,
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('DeleteConfirmDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteState.isPending = false;
+    mockDeleteState.isError = false;
+    mockDeleteState.error = null;
+  });
+
+  it('deletes strategy and invokes success callbacks', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn();
+
+    mockMutate.mockImplementation((_name, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(
+      <DeleteConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        strategyName="experimental/test_strategy"
+        onSuccess={onSuccess}
+      />
+    );
+
+    expect(screen.getByText('experimental/test_strategy')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockMutate).toHaveBeenCalledWith('experimental/test_strategy', expect.any(Object));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes dialog when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(<DeleteConfirmDialog open={true} onOpenChange={onOpenChange} strategyName="experimental/alpha" />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows pending and error states', () => {
+    mockDeleteState.isPending = true;
+    mockDeleteState.isError = true;
+    mockDeleteState.error = new Error('delete failed');
+
+    render(<DeleteConfirmDialog open={true} onOpenChange={vi.fn()} strategyName="experimental/alpha" />);
+
+    expect(screen.getByRole('button', { name: 'Deleting...' })).toBeDisabled();
+    expect(screen.getByText('Error: delete failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/DuplicateDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DuplicateDialog.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DuplicateDialog } from './DuplicateDialog';
+
+const mockMutate = vi.fn();
+const mockDuplicateState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+};
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useDuplicateStrategy: () => ({
+    mutate: mockMutate,
+    isPending: mockDuplicateState.isPending,
+    isError: mockDuplicateState.isError,
+    error: mockDuplicateState.error,
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: ({
+    id,
+    value,
+    onChange,
+    placeholder,
+  }: {
+    id?: string;
+    value?: string;
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+  }) => <input id={id} value={value} onChange={onChange} placeholder={placeholder} />,
+}));
+
+describe('DuplicateDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDuplicateState.isPending = false;
+    mockDuplicateState.isError = false;
+    mockDuplicateState.error = null;
+  });
+
+  it('duplicates strategy with trimmed name and invokes success callbacks', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn();
+
+    mockMutate.mockImplementation((_payload, options) => {
+      options?.onSuccess?.({ new_strategy_name: 'experimental/new_strategy' });
+    });
+
+    render(
+      <DuplicateDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        strategyName="experimental/original"
+        onSuccess={onSuccess}
+      />
+    );
+
+    const duplicateButton = screen.getByRole('button', { name: 'Duplicate' });
+    expect(duplicateButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText('New Strategy Name'), '  new_strategy  ');
+    expect(duplicateButton).toBeEnabled();
+    await user.click(duplicateButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        name: 'experimental/original',
+        request: { new_name: 'new_strategy' },
+      },
+      expect.any(Object)
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledWith('experimental/new_strategy');
+  });
+
+  it('resets input when canceled', async () => {
+    const user = userEvent.setup();
+
+    render(<DuplicateDialog open={true} onOpenChange={vi.fn()} strategyName="experimental/original" />);
+
+    const input = screen.getByLabelText('New Strategy Name') as HTMLInputElement;
+    await user.type(input, 'draft_name');
+    expect(input.value).toBe('draft_name');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(input.value).toBe('');
+  });
+
+  it('shows pending and error states', () => {
+    mockDuplicateState.isPending = true;
+    mockDuplicateState.isError = true;
+    mockDuplicateState.error = new Error('duplicate failed');
+
+    render(<DuplicateDialog open={true} onOpenChange={vi.fn()} strategyName="experimental/original" />);
+
+    expect(screen.getByRole('button', { name: 'Duplicating...' })).toBeDisabled();
+    expect(screen.getByText('Error: duplicate failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/HtmlFileBrowser.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/HtmlFileBrowser.test.tsx
@@ -244,7 +244,7 @@ describe('HtmlFileBrowser', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const setTimeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((handler) => {
       if (typeof handler === 'function') handler();
-      return 0 as unknown as number;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
     render(<HtmlFileBrowser />);

--- a/apps/ts/packages/web/src/components/Backtest/HtmlFileBrowser.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/HtmlFileBrowser.test.tsx
@@ -1,0 +1,382 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HtmlFileContentResponse, HtmlFileInfo, HtmlFileMetrics } from '@/types/backtest';
+import { HtmlFileBrowser } from './HtmlFileBrowser';
+
+const mockUseHtmlFiles = vi.fn();
+const mockUseHtmlFileContent = vi.fn();
+const mockRenameMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+
+const mockHookState = {
+  filesData: null as { files: HtmlFileInfo[]; total: number } | null,
+  filesLoading: false,
+  contentByKey: {} as Record<string, HtmlFileContentResponse>,
+  contentLoading: false,
+  rename: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+  delete: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+};
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useHtmlFiles: (...args: unknown[]) => mockUseHtmlFiles(...args),
+  useHtmlFileContent: (...args: unknown[]) => mockUseHtmlFileContent(...args),
+  useRenameHtmlFile: () => ({
+    mutate: mockRenameMutate,
+    isPending: mockHookState.rename.isPending,
+    isError: mockHookState.rename.isError,
+    error: mockHookState.rename.error,
+  }),
+  useDeleteHtmlFile: () => ({
+    mutate: mockDeleteMutate,
+    isPending: mockHookState.delete.isPending,
+    isError: mockHookState.delete.isError,
+    error: mockHookState.delete.error,
+  }),
+}));
+
+vi.mock('./ResultHtmlViewer', () => ({
+  ResultHtmlViewer: ({
+    htmlContent,
+    isLoading,
+  }: {
+    htmlContent: string | null;
+    isLoading: boolean;
+  }) => <div data-testid="result-viewer">{isLoading ? 'loading' : htmlContent ?? 'empty'}</div>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    className,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    className?: string;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: React.forwardRef(
+    (
+      {
+        value,
+        onChange,
+        onKeyDown,
+        placeholder,
+        className,
+        disabled,
+      }: {
+        value?: string;
+        onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+        onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
+        placeholder?: string;
+        className?: string;
+        disabled?: boolean;
+      },
+      ref: React.ForwardedRef<HTMLInputElement>
+    ) => (
+      <input
+        ref={ref}
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        className={className}
+        disabled={disabled}
+      />
+    )
+  ),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: ReactNode;
+  }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/components/ui/select', () => {
+  const SelectContext = React.createContext<(value: string) => void>(() => {});
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => <SelectContext.Provider value={onValueChange ?? (() => {})}>{children}</SelectContext.Provider>,
+    SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+    SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) => {
+      const onValueChange = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+function createFile(overrides: Partial<HtmlFileInfo>): HtmlFileInfo {
+  return {
+    strategy_name: 'production/alpha',
+    filename: 'report.html',
+    dataset_name: 'dataset-a',
+    created_at: '2026-02-10T12:00:00Z',
+    ...overrides,
+  } as HtmlFileInfo;
+}
+
+function createMetrics(overrides: Partial<HtmlFileMetrics> = {}): HtmlFileMetrics {
+  return {
+    total_return: 12.34,
+    max_drawdown: -6.2,
+    sharpe_ratio: 1.23,
+    sortino_ratio: 1.45,
+    win_rate: 55.2,
+    total_trades: 43,
+    ...overrides,
+  } as HtmlFileMetrics;
+}
+
+describe('HtmlFileBrowser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHookState.filesData = { files: [], total: 0 };
+    mockHookState.filesLoading = false;
+    mockHookState.contentByKey = {};
+    mockHookState.contentLoading = false;
+    mockHookState.rename.isPending = false;
+    mockHookState.rename.isError = false;
+    mockHookState.rename.error = null;
+    mockHookState.delete.isPending = false;
+    mockHookState.delete.isError = false;
+    mockHookState.delete.error = null;
+
+    mockUseHtmlFiles.mockImplementation((_strategy?: string) => ({
+      data: mockHookState.filesData,
+      isLoading: mockHookState.filesLoading,
+    }));
+    mockUseHtmlFileContent.mockImplementation((strategy: string | null, filename: string | null) => {
+      if (!strategy || !filename) {
+        return { data: null, isLoading: false };
+      }
+      return {
+        data: mockHookState.contentByKey[`${strategy}/${filename}`] ?? null,
+        isLoading: mockHookState.contentLoading,
+      };
+    });
+  });
+
+  it('renders loading and empty states', () => {
+    mockHookState.filesLoading = true;
+    const { container, rerender } = render(<HtmlFileBrowser />);
+
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+
+    mockHookState.filesLoading = false;
+    mockHookState.filesData = { files: [], total: 0 };
+    rerender(<HtmlFileBrowser />);
+
+    expect(screen.getByText('No HTML files found')).toBeInTheDocument();
+    expect(screen.getByText('Select a file to preview')).toBeInTheDocument();
+  });
+
+  it('filters files, loads selected content, and opens report in a new tab', async () => {
+    const user = userEvent.setup();
+    mockHookState.filesData = {
+      files: [
+        createFile({
+          strategy_name: 'production/alpha',
+          filename: 'alpha-report.html',
+          dataset_name: 'dataset-alpha',
+          created_at: '2026-02-10T08:00:00Z',
+        }),
+        createFile({
+          strategy_name: 'experimental/beta',
+          filename: 'beta-report.html',
+          dataset_name: 'dataset-beta',
+          created_at: '2026-02-11T08:00:00Z',
+        }),
+      ],
+      total: 3,
+    };
+    mockHookState.contentByKey['experimental/beta/beta-report.html'] = {
+      html_content: btoa('<html><body>beta</body></html>'),
+      metrics: createMetrics(),
+    } as HtmlFileContentResponse;
+
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:html-report');
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((handler) => {
+      if (typeof handler === 'function') handler();
+      return 0 as unknown as number;
+    });
+
+    render(<HtmlFileBrowser />);
+
+    expect(screen.getByText('2 files (3 total)')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('Search files...'), 'beta');
+
+    expect(screen.getByText('beta-report.html')).toBeInTheDocument();
+    expect(screen.queryByText('alpha-report.html')).not.toBeInTheDocument();
+
+    const betaFileButton = screen.getByText('beta-report.html').closest('button');
+    expect(betaFileButton).not.toBeNull();
+    await user.click(betaFileButton as HTMLButtonElement);
+
+    expect(mockUseHtmlFileContent).toHaveBeenLastCalledWith('experimental/beta', 'beta-report.html');
+    expect(screen.getByText('Total Return')).toBeInTheDocument();
+    expect(screen.getByText('12.34%')).toBeInTheDocument();
+    expect(screen.getByTestId('result-viewer')).toHaveTextContent('<html><body>beta</body></html>');
+
+    await user.click(screen.getByRole('button', { name: 'Open in new tab' }));
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('blob:html-report', '_blank');
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000);
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:html-report');
+  });
+
+  it('renames and deletes selected files', async () => {
+    const user = userEvent.setup();
+    mockHookState.filesData = {
+      files: [
+        createFile({
+          strategy_name: 'production/alpha',
+          filename: 'alpha-report.html',
+        }),
+      ],
+      total: 1,
+    };
+    mockHookState.contentByKey['production/alpha/alpha-report.html'] = {
+      html_content: btoa('<html><body>alpha</body></html>'),
+      metrics: createMetrics(),
+    } as HtmlFileContentResponse;
+
+    mockRenameMutate.mockImplementation(
+      (
+        _payload: unknown,
+        options?: {
+          onSuccess?: (data: { new_filename: string }) => void;
+        }
+      ) => {
+        options?.onSuccess?.({ new_filename: 'renamed-report.html' });
+      }
+    );
+    mockDeleteMutate.mockImplementation(
+      (
+        _payload: unknown,
+        options?: {
+          onSuccess?: () => void;
+        }
+      ) => {
+        options?.onSuccess?.();
+      }
+    );
+
+    const { container } = render(<HtmlFileBrowser />);
+    const alphaFileButton = screen.getByText('alpha-report.html').closest('button');
+    expect(alphaFileButton).not.toBeNull();
+    await user.click(alphaFileButton as HTMLButtonElement);
+
+    const renameButton = container.querySelector('svg.lucide-pencil')?.closest('button');
+    expect(renameButton).not.toBeNull();
+    await user.click(renameButton as HTMLButtonElement);
+
+    const renameInput = screen.getByDisplayValue('alpha-report.html');
+    await user.clear(renameInput);
+    await user.type(renameInput, 'renamed-report');
+    await user.keyboard('{Enter}');
+
+    expect(mockRenameMutate).toHaveBeenCalledWith(
+      {
+        strategy: 'production/alpha',
+        filename: 'alpha-report.html',
+        request: { new_filename: 'renamed-report.html' },
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByText('renamed-report.html')).toBeInTheDocument();
+
+    const deleteButton = container.querySelector('svg.lucide-trash2')?.closest('button');
+    expect(deleteButton).not.toBeNull();
+    await user.click(deleteButton as HTMLButtonElement);
+    expect(screen.getByText('Delete HTML File')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(mockDeleteMutate).toHaveBeenCalledWith(
+      {
+        strategy: 'production/alpha',
+        filename: 'renamed-report.html',
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByText('Select a file to preview')).toBeInTheDocument();
+  });
+
+  it('shows mutation errors and skips opening tab for invalid base64', async () => {
+    const user = userEvent.setup();
+    mockHookState.filesData = {
+      files: [createFile({ filename: 'bad.html' })],
+      total: 1,
+    };
+    mockHookState.contentByKey['production/alpha/bad.html'] = {
+      html_content: '***invalid***',
+      metrics: createMetrics(),
+    } as HtmlFileContentResponse;
+    mockHookState.rename.isError = true;
+    mockHookState.rename.error = new Error('rename failed');
+    mockHookState.delete.isError = true;
+    mockHookState.delete.error = new Error('delete failed');
+
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(<HtmlFileBrowser />);
+    const badFileButton = screen.getByText('bad.html').closest('button');
+    expect(badFileButton).not.toBeNull();
+    await user.click(badFileButton as HTMLButtonElement);
+    expect(screen.getByText('rename failed')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Open in new tab' }));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to decode base64 HTML content');
+    expect(openSpy).not.toHaveBeenCalled();
+
+    const deleteButton = container.querySelector('svg.lucide-trash2')?.closest('button');
+    await user.click(deleteButton as HTMLButtonElement);
+    expect(screen.getByText('Error: delete failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationHtmlFileBrowser.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationHtmlFileBrowser.test.tsx
@@ -230,7 +230,7 @@ describe('OptimizationHtmlFileBrowser', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const setTimeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((handler) => {
       if (typeof handler === 'function') handler();
-      return 0 as unknown as number;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
     render(<OptimizationHtmlFileBrowser />);

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationHtmlFileBrowser.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationHtmlFileBrowser.test.tsx
@@ -1,0 +1,357 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OptimizationHtmlFileContentResponse, OptimizationHtmlFileInfo } from '@/types/backtest';
+import { OptimizationHtmlFileBrowser } from './OptimizationHtmlFileBrowser';
+
+const mockUseOptimizationHtmlFiles = vi.fn();
+const mockUseOptimizationHtmlFileContent = vi.fn();
+const mockRenameMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+
+const mockHookState = {
+  filesData: null as { files: OptimizationHtmlFileInfo[]; total: number } | null,
+  filesLoading: false,
+  contentByKey: {} as Record<string, OptimizationHtmlFileContentResponse>,
+  contentLoading: false,
+  rename: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+  delete: {
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+};
+
+vi.mock('@/hooks/useOptimization', () => ({
+  useOptimizationHtmlFiles: (...args: unknown[]) => mockUseOptimizationHtmlFiles(...args),
+  useOptimizationHtmlFileContent: (...args: unknown[]) => mockUseOptimizationHtmlFileContent(...args),
+  useRenameOptimizationHtmlFile: () => ({
+    mutate: mockRenameMutate,
+    isPending: mockHookState.rename.isPending,
+    isError: mockHookState.rename.isError,
+    error: mockHookState.rename.error,
+  }),
+  useDeleteOptimizationHtmlFile: () => ({
+    mutate: mockDeleteMutate,
+    isPending: mockHookState.delete.isPending,
+    isError: mockHookState.delete.isError,
+    error: mockHookState.delete.error,
+  }),
+}));
+
+vi.mock('./ResultHtmlViewer', () => ({
+  ResultHtmlViewer: ({
+    htmlContent,
+    isLoading,
+  }: {
+    htmlContent: string | null;
+    isLoading: boolean;
+  }) => <div data-testid="opt-viewer">{isLoading ? 'loading' : htmlContent ?? 'empty'}</div>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    className,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    className?: string;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: React.forwardRef(
+    (
+      {
+        value,
+        onChange,
+        onKeyDown,
+        placeholder,
+        className,
+        disabled,
+      }: {
+        value?: string;
+        onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+        onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
+        placeholder?: string;
+        className?: string;
+        disabled?: boolean;
+      },
+      ref: React.ForwardedRef<HTMLInputElement>
+    ) => (
+      <input
+        ref={ref}
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        className={className}
+        disabled={disabled}
+      />
+    )
+  ),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: ReactNode;
+  }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/components/ui/select', () => {
+  const SelectContext = React.createContext<(value: string) => void>(() => {});
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => <SelectContext.Provider value={onValueChange ?? (() => {})}>{children}</SelectContext.Provider>,
+    SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+    SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) => {
+      const onValueChange = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+function createFile(overrides: Partial<OptimizationHtmlFileInfo>): OptimizationHtmlFileInfo {
+  return {
+    strategy_name: 'production/alpha',
+    filename: 'optimization.html',
+    dataset_name: 'dataset-a',
+    created_at: '2026-02-10T12:00:00Z',
+    ...overrides,
+  } as OptimizationHtmlFileInfo;
+}
+
+describe('OptimizationHtmlFileBrowser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHookState.filesData = { files: [], total: 0 };
+    mockHookState.filesLoading = false;
+    mockHookState.contentByKey = {};
+    mockHookState.contentLoading = false;
+    mockHookState.rename.isPending = false;
+    mockHookState.rename.isError = false;
+    mockHookState.rename.error = null;
+    mockHookState.delete.isPending = false;
+    mockHookState.delete.isError = false;
+    mockHookState.delete.error = null;
+
+    mockUseOptimizationHtmlFiles.mockImplementation((_strategy?: string) => ({
+      data: mockHookState.filesData,
+      isLoading: mockHookState.filesLoading,
+    }));
+    mockUseOptimizationHtmlFileContent.mockImplementation((strategy: string | null, filename: string | null) => {
+      if (!strategy || !filename) {
+        return { data: null, isLoading: false };
+      }
+      return {
+        data: mockHookState.contentByKey[`${strategy}/${filename}`] ?? null,
+        isLoading: mockHookState.contentLoading,
+      };
+    });
+  });
+
+  it('renders loading and empty states', () => {
+    mockHookState.filesLoading = true;
+    const { container, rerender } = render(<OptimizationHtmlFileBrowser />);
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+
+    mockHookState.filesLoading = false;
+    mockHookState.filesData = { files: [], total: 0 };
+    rerender(<OptimizationHtmlFileBrowser />);
+
+    expect(screen.getByText('No optimization result files found')).toBeInTheDocument();
+    expect(screen.getByText('Select a file to preview')).toBeInTheDocument();
+  });
+
+  it('filters files, selects file, and opens optimization report in a new tab', async () => {
+    const user = userEvent.setup();
+    mockHookState.filesData = {
+      files: [
+        createFile({
+          strategy_name: 'production/alpha',
+          filename: 'alpha-opt.html',
+          dataset_name: 'dataset-alpha',
+          created_at: '2026-02-10T08:00:00Z',
+        }),
+        createFile({
+          strategy_name: 'experimental/beta',
+          filename: 'beta-opt.html',
+          dataset_name: 'dataset-beta',
+          created_at: '2026-02-11T08:00:00Z',
+        }),
+      ],
+      total: 4,
+    };
+    mockHookState.contentByKey['experimental/beta/beta-opt.html'] = {
+      html_content: btoa('<html><body>opt-beta</body></html>'),
+    } as OptimizationHtmlFileContentResponse;
+
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:opt-report');
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((handler) => {
+      if (typeof handler === 'function') handler();
+      return 0 as unknown as number;
+    });
+
+    render(<OptimizationHtmlFileBrowser />);
+
+    expect(screen.getByText('2 files (4 total)')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('Search files...'), 'beta');
+    expect(screen.getByText('beta-opt.html')).toBeInTheDocument();
+    expect(screen.queryByText('alpha-opt.html')).not.toBeInTheDocument();
+
+    const betaFileButton = screen.getByText('beta-opt.html').closest('button');
+    expect(betaFileButton).not.toBeNull();
+    await user.click(betaFileButton as HTMLButtonElement);
+    expect(mockUseOptimizationHtmlFileContent).toHaveBeenLastCalledWith('experimental/beta', 'beta-opt.html');
+    expect(screen.getByTestId('opt-viewer')).toHaveTextContent('<html><body>opt-beta</body></html>');
+
+    await user.click(screen.getByRole('button', { name: 'Open in new tab' }));
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('blob:opt-report', '_blank');
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000);
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:opt-report');
+
+    await user.click(screen.getByRole('button', { name: 'production/alpha' }));
+    expect(mockUseOptimizationHtmlFiles).toHaveBeenLastCalledWith('production/alpha');
+  });
+
+  it('renames and deletes optimization result files', async () => {
+    const user = userEvent.setup();
+    mockHookState.filesData = {
+      files: [createFile({ filename: 'alpha-opt.html' })],
+      total: 1,
+    };
+    mockHookState.contentByKey['production/alpha/alpha-opt.html'] = {
+      html_content: btoa('<html><body>opt-alpha</body></html>'),
+    } as OptimizationHtmlFileContentResponse;
+
+    mockRenameMutate.mockImplementation(
+      (
+        _payload: unknown,
+        options?: {
+          onSuccess?: (data: { new_filename: string }) => void;
+        }
+      ) => {
+        options?.onSuccess?.({ new_filename: 'renamed-opt.html' });
+      }
+    );
+    mockDeleteMutate.mockImplementation(
+      (
+        _payload: unknown,
+        options?: {
+          onSuccess?: () => void;
+        }
+      ) => {
+        options?.onSuccess?.();
+      }
+    );
+
+    const { container } = render(<OptimizationHtmlFileBrowser />);
+    const alphaFileButton = screen.getByText('alpha-opt.html').closest('button');
+    expect(alphaFileButton).not.toBeNull();
+    await user.click(alphaFileButton as HTMLButtonElement);
+
+    const renameButton = container.querySelector('svg.lucide-pencil')?.closest('button');
+    await user.click(renameButton as HTMLButtonElement);
+
+    const renameInput = screen.getByDisplayValue('alpha-opt.html');
+    await user.clear(renameInput);
+    await user.type(renameInput, 'renamed-opt');
+    await user.keyboard('{Enter}');
+
+    expect(mockRenameMutate).toHaveBeenCalledWith(
+      {
+        strategy: 'production/alpha',
+        filename: 'alpha-opt.html',
+        request: { new_filename: 'renamed-opt.html' },
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByText('renamed-opt.html')).toBeInTheDocument();
+
+    const deleteButton = container.querySelector('svg.lucide-trash2')?.closest('button');
+    await user.click(deleteButton as HTMLButtonElement);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockDeleteMutate).toHaveBeenCalledWith(
+      {
+        strategy: 'production/alpha',
+        filename: 'renamed-opt.html',
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByText('Select a file to preview')).toBeInTheDocument();
+  });
+
+  it('handles invalid base64 and mutation errors', async () => {
+    const user = userEvent.setup();
+    mockHookState.filesData = {
+      files: [createFile({ filename: 'bad-opt.html' })],
+      total: 1,
+    };
+    mockHookState.contentByKey['production/alpha/bad-opt.html'] = {
+      html_content: '###invalid###',
+    } as OptimizationHtmlFileContentResponse;
+    mockHookState.rename.isError = true;
+    mockHookState.rename.error = new Error('rename optimization failed');
+    mockHookState.delete.isError = true;
+    mockHookState.delete.error = new Error('delete optimization failed');
+
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(<OptimizationHtmlFileBrowser />);
+    const badFileButton = screen.getByText('bad-opt.html').closest('button');
+    expect(badFileButton).not.toBeNull();
+    await user.click(badFileButton as HTMLButtonElement);
+    expect(screen.getByText('rename optimization failed')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Open in new tab' }));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to decode base64 HTML content');
+    expect(openSpy).not.toHaveBeenCalled();
+
+    const deleteButton = container.querySelector('svg.lucide-trash2')?.closest('button');
+    await user.click(deleteButton as HTMLButtonElement);
+    expect(screen.getByText('Error: delete optimization failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/RenameDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/RenameDialog.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RenameDialog } from './RenameDialog';
+
+const mockMutate = vi.fn();
+const mockRenameState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+};
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useRenameStrategy: () => ({
+    mutate: mockMutate,
+    isPending: mockRenameState.isPending,
+    isError: mockRenameState.isError,
+    error: mockRenameState.error,
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: ({
+    id,
+    value,
+    onChange,
+    placeholder,
+  }: {
+    id?: string;
+    value?: string;
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+  }) => <input id={id} value={value} onChange={onChange} placeholder={placeholder} />,
+}));
+
+describe('RenameDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRenameState.isPending = false;
+    mockRenameState.isError = false;
+    mockRenameState.error = null;
+  });
+
+  it('renames strategy with trimmed name and invokes success callbacks', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn();
+
+    mockMutate.mockImplementation((_payload, options) => {
+      options?.onSuccess?.({ new_name: 'renamed_strategy' });
+    });
+
+    render(
+      <RenameDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        strategyName="experimental/original_name"
+        onSuccess={onSuccess}
+      />
+    );
+
+    const renameButton = screen.getByRole('button', { name: 'Rename' });
+    expect(renameButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText('New Strategy Name'), '  renamed_strategy  ');
+    expect(renameButton).toBeEnabled();
+    await user.click(renameButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        name: 'experimental/original_name',
+        request: { new_name: 'renamed_strategy' },
+      },
+      expect.any(Object)
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledWith('renamed_strategy');
+  });
+
+  it('keeps rename disabled when input equals current strategy name', async () => {
+    const user = userEvent.setup();
+    render(<RenameDialog open={true} onOpenChange={vi.fn()} strategyName="experimental/original_name" />);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename' });
+    await user.type(screen.getByLabelText('New Strategy Name'), 'original_name');
+
+    expect(renameButton).toBeDisabled();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('resets input when canceled and shows pending/error states', async () => {
+    const user = userEvent.setup();
+    mockRenameState.isPending = true;
+    mockRenameState.isError = true;
+    mockRenameState.error = new Error('rename failed');
+
+    render(<RenameDialog open={true} onOpenChange={vi.fn()} strategyName="experimental/original_name" />);
+
+    const input = screen.getByLabelText('New Strategy Name') as HTMLInputElement;
+    await user.type(input, 'tmp_name');
+    expect(input.value).toBe('tmp_name');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(input.value).toBe('');
+    expect(screen.getByRole('button', { name: 'Renaming...' })).toBeDisabled();
+    expect(screen.getByText('Error: rename failed')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/ResultHtmlViewer.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/ResultHtmlViewer.test.tsx
@@ -25,7 +25,7 @@ describe('ResultHtmlViewer', () => {
       if (typeof handler === 'function') {
         handler();
       }
-      return 0 as unknown as number;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
     render(<ResultHtmlViewer htmlContent="<html><body>report</body></html>" isLoading={false} />);

--- a/apps/ts/packages/web/src/components/Backtest/ResultHtmlViewer.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/ResultHtmlViewer.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ResultHtmlViewer } from './ResultHtmlViewer';
+
+describe('ResultHtmlViewer', () => {
+  it('renders loading state', () => {
+    render(<ResultHtmlViewer htmlContent={null} isLoading={true} />);
+
+    expect(screen.queryByText('No HTML report available')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open in New Tab' })).not.toBeInTheDocument();
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('renders empty state when html content is missing', () => {
+    render(<ResultHtmlViewer htmlContent={null} isLoading={false} />);
+
+    expect(screen.getByText('No HTML report available')).toBeInTheDocument();
+  });
+
+  it('renders iframe and opens report in a new tab', () => {
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test-url');
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((handler) => {
+      if (typeof handler === 'function') {
+        handler();
+      }
+      return 0 as unknown as number;
+    });
+
+    render(<ResultHtmlViewer htmlContent="<html><body>report</body></html>" isLoading={false} />);
+
+    expect(screen.getByText('Backtest Report')).toBeInTheDocument();
+    expect(screen.getByTitle('Backtest Report')).toHaveAttribute('srcdoc', '<html><body>report</body></html>');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open in New Tab' }));
+
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('blob:test-url', '_blank');
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000);
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:test-url');
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/ResultMetricsCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/ResultMetricsCard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { BacktestResultSummary } from '@/types/backtest';
+import { ResultMetricsCard } from './ResultMetricsCard';
+
+function createSummary(overrides: Partial<BacktestResultSummary> = {}): BacktestResultSummary {
+  return {
+    total_return: 12.34,
+    sharpe_ratio: 1.23,
+    max_drawdown: -8.5,
+    win_rate: 64.2,
+    calmar_ratio: 0.87,
+    trade_count: 42,
+    ...overrides,
+  } as BacktestResultSummary;
+}
+
+describe('ResultMetricsCard', () => {
+  it('renders nothing when summary is missing', () => {
+    const { container } = render(<ResultMetricsCard summary={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders metrics with positive return and high win-rate styles', () => {
+    render(<ResultMetricsCard summary={createSummary()} />);
+
+    expect(screen.getByText('Return')).toBeInTheDocument();
+    expect(screen.getByText('+12.34%')).toHaveClass('text-green-500');
+    expect(screen.getByText('1.23')).toBeInTheDocument();
+    expect(screen.getByText('-8.50%')).toHaveClass('text-red-500');
+    expect(screen.getByText('+64.20%')).toHaveClass('text-green-500');
+    expect(screen.getByText('0.87')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders negative return and low win-rate styles', () => {
+    render(
+      <ResultMetricsCard
+        summary={createSummary({
+          total_return: -1.2,
+          win_rate: 49.4,
+        })}
+      />
+    );
+
+    expect(screen.getByText('-1.20%')).toHaveClass('text-red-500');
+    expect(screen.getByText('+49.40%')).toHaveClass('text-yellow-500');
+  });
+});

--- a/apps/ts/packages/web/src/components/Backtest/SignalReferencePanel.component.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/SignalReferencePanel.component.test.tsx
@@ -1,0 +1,133 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SignalReferenceResponse } from '@/types/backtest';
+import { SignalReferencePanel } from './SignalReferencePanel';
+
+const mockUseSignalReference = vi.fn();
+const mockLoggerWarn = vi.fn();
+
+vi.mock('@/hooks/useBacktest', () => ({
+  useSignalReference: () => mockUseSignalReference(),
+}));
+
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const baseSignalData = {
+  categories: [
+    { key: 'breakout', label: 'Breakout' },
+    { key: 'trend', label: 'Trend' },
+  ],
+  signals: [
+    {
+      key: 'breakout.close_gt_sma',
+      category: 'breakout',
+      name: 'Close > SMA',
+      description: 'Close price is above moving average',
+      usage_hint: 'Use this for trend confirmation',
+      yaml_snippet: 'entry_filter:\n  breakout.close_gt_sma:\n    enabled: true',
+      fields: [
+        {
+          name: 'period',
+          description: 'SMA period',
+          options: ['5', '10'],
+          constraints: { gt: 0, le: 50 },
+        },
+      ],
+    },
+    {
+      key: 'trend.unknown',
+      category: 'not-defined',
+      name: 'Unknown category signal',
+      description: 'should trigger warn log',
+      usage_hint: 'N/A',
+      yaml_snippet: 'exit_trigger: {}',
+      fields: [],
+    },
+  ],
+} as SignalReferenceResponse;
+
+describe('SignalReferencePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    mockUseSignalReference.mockReturnValue({
+      data: baseSignalData,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders loading state', () => {
+    mockUseSignalReference.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<SignalReferencePanel onCopySnippet={vi.fn()} />);
+
+    expect(screen.getByText('Loading signals...')).toBeInTheDocument();
+  });
+
+  it('renders error states for Error and unknown errors', () => {
+    mockUseSignalReference.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('request failed'),
+    });
+
+    const { rerender } = render(<SignalReferencePanel onCopySnippet={vi.fn()} />);
+    expect(screen.getByText('Failed to load signal reference')).toBeInTheDocument();
+    expect(screen.getByText('request failed')).toBeInTheDocument();
+
+    mockUseSignalReference.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: { message: 'plain object error' },
+    });
+    rerender(<SignalReferencePanel onCopySnippet={vi.fn()} />);
+    expect(screen.getByText('Unknown error occurred')).toBeInTheDocument();
+  });
+
+  it('renders categories, filters by search, expands detail, and copies snippet', () => {
+    vi.useFakeTimers();
+    const onCopySnippet = vi.fn();
+    render(<SignalReferencePanel onCopySnippet={onCopySnippet} />);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Unknown signal category: not-defined (signal: trend.unknown)'
+    );
+    expect(screen.getByText('Signal Reference')).toBeInTheDocument();
+    expect(screen.getByText('Breakout')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    const signalHeaderButton = screen.getByText('Close > SMA').closest('button');
+    expect(signalHeaderButton).not.toBeNull();
+    fireEvent.click(signalHeaderButton as HTMLButtonElement);
+    expect(screen.getByText('Use this for trend confirmation')).toBeInTheDocument();
+    expect(screen.getByText('[>0, <=50]')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(onCopySnippet).toHaveBeenCalledWith('entry_filter:\n  breakout.close_gt_sma:\n    enabled: true');
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search signals...'), { target: { value: 'non-existent' } });
+    expect(screen.getByText('No signals found')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit tests for Backtest UI components under apps/ts/packages/web/src/components/Backtest
- cover runner/status/results dialogs and dataset flows including BacktestRunner.tsx and BacktestStatus.tsx
- add new tests for previously uncovered files: DatasetJobProgress.tsx, HtmlFileBrowser.tsx, OptimizationHtmlFileBrowser.tsx, SignalReferencePanel.tsx

## Verification
- bun run --filter @trading25/web test -- src/components/Backtest/DatasetJobProgress.test.tsx src/components/Backtest/SignalReferencePanel.component.test.tsx src/components/Backtest/HtmlFileBrowser.test.tsx src/components/Backtest/OptimizationHtmlFileBrowser.test.tsx
- bun run --filter @trading25/web test:coverage

## Coverage Impact
- web all-files line coverage improved to 80.76%
- Backtest directory line coverage improved to 97.54%