### PR TITLE
perf(bt): speed up Optuna with prefetch and stage-1 pruning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ uv run pyright src/              # 型チェック
 - Lab `evolve/optimize` の API/Web は `target_scope`（`entry_filter_only` / `exit_trigger_only` / `both`）を受け付ける（`entry_filter_only` は互換フラグとして維持）
 - Lab `evolve/optimize` の frontend `allowed categories` は `all` / `fundamental only` を提供
 - Lab frontend は `Run` / `History` タブを持ち、`/api/lab/jobs` で実行履歴を一覧し、選択したジョブの進捗・結果を再表示できる
+- Lab `optimize`（Optuna）は開始時に OHLCV/benchmark を1回プリフェッチして trial 間で再利用し、`pruning=true` 時は第1段階バックテストの暫定スコアで早期枝刈りを行う
 - Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
 - `/api/optimize/jobs/{id}` は `best_score` / `total_combinations` に加えて `best_params` / `worst_score` / `worst_params` を返し、最適化ジョブ結果カードで best/worst 条件を比較表示できる
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する


### PR DESCRIPTION
## Summary
- add one-time OHLCV/benchmark prefetch in Optuna optimize flow and reuse data across trials
- enable Optuna pruner wiring and implement stage-1 provisional-score pruning before stage-2 execution
- add/extend unit tests for pruner wiring, prefetch behavior, fallback paths, and pruning flow
- update AGENTS.md with the new Lab optimize behavior

## Verification
- uv run --project apps/bt ruff check apps/bt/src/agent/optuna_optimizer.py apps/bt/tests/unit/agent/test_optuna_optimizer.py
- uv run --project apps/bt pytest apps/bt/tests/unit/agent/test_optuna_optimizer.py -q
- uv run --project apps/bt pyright apps/bt/src/agent/optuna_optimizer.py
- uv run coverage run --branch -m pytest tests/unit/agent/test_optuna_optimizer.py -q
- uv run coverage report -m src/agent/optuna_optimizer.py