### PR TITLE
feat(web): add stock search input to portfolio/watchlist forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ bun run cli backtest attribution run <strategy> --wait
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 - `analysis screening`（web/cli）は production 戦略を動的選択し、非同期ジョブ（2秒ポーリング）で実行する。`sortBy` 既定は `matchedDate`、`order` 既定は `desc`。`backtestMetric` は廃止
 - Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集できる
+- Portfolio / Watchlist の銘柄追加入力はチャート検索と同等の銘柄サーチ（コード/銘柄名）を使う。Watchlist 追加の送信は 4 桁コードのみ許可する
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/apps/ts/packages/web/src/components/Portfolio/StockFormFields.test.tsx
+++ b/apps/ts/packages/web/src/components/Portfolio/StockFormFields.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { type StockFormData, StockFormFields, validateStockForm } from './StockFormFields';
+
+vi.mock('@/components/Stock/StockSearchInput', () => ({
+  StockSearchInput: ({
+    id,
+    value,
+    onValueChange,
+    onSelect,
+  }: {
+    id?: string;
+    value: string;
+    onValueChange: (value: string) => void;
+    onSelect: (stock: { code: string }) => void;
+  }) => (
+    <div>
+      <input
+        id={id}
+        aria-label="StockSearchInput"
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+      />
+      <button type="button" onClick={() => onSelect({ code: '6501' })}>
+        SelectStock
+      </button>
+    </div>
+  ),
+}));
+
+function createFormData(overrides: Partial<StockFormData> = {}): StockFormData {
+  return {
+    code: '7203',
+    quantity: '100',
+    purchasePrice: '2500',
+    purchaseDate: '2026-02-19',
+    account: '',
+    notes: '',
+    ...overrides,
+  };
+}
+
+function StockFormFieldsHarness({
+  initialData,
+  onChangeSpy,
+  showCodeField = true,
+  idPrefix = 'stock',
+}: {
+  initialData: StockFormData;
+  onChangeSpy: (data: StockFormData) => void;
+  showCodeField?: boolean;
+  idPrefix?: string;
+}) {
+  const [data, setData] = useState(initialData);
+  return (
+    <StockFormFields
+      data={data}
+      onChange={(next) => {
+        onChangeSpy(next);
+        setData(next);
+      }}
+      showCodeField={showCodeField}
+      idPrefix={idPrefix}
+    />
+  );
+}
+
+describe('StockFormFields', () => {
+  it('updates code from search input and selected candidate', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const data = createFormData({ code: '' });
+
+    render(<StockFormFieldsHarness initialData={data} onChangeSpy={onChange} showCodeField={true} idPrefix="add" />);
+
+    await user.type(screen.getByLabelText('Stock Code'), '72');
+    expect(onChange).toHaveBeenLastCalledWith({ ...data, code: '72' });
+
+    await user.click(screen.getByRole('button', { name: 'SelectStock' }));
+    expect(onChange).toHaveBeenLastCalledWith({ ...data, code: '6501' });
+  });
+
+  it('renders edit mode without stock code field', () => {
+    const onChange = vi.fn();
+    const data = createFormData();
+
+    render(<StockFormFieldsHarness initialData={data} onChangeSpy={onChange} showCodeField={false} idPrefix="edit" />);
+
+    expect(screen.queryByLabelText('Stock Code')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Purchase Price')).toBeInTheDocument();
+    expect(screen.getByLabelText('Purchase Date')).toBeInTheDocument();
+  });
+});
+
+describe('validateStockForm', () => {
+  it('returns true for valid data when code is required', () => {
+    expect(validateStockForm(createFormData(), true)).toBe(true);
+  });
+
+  it('returns false for invalid code when code is required', () => {
+    expect(validateStockForm(createFormData({ code: 'abcd' }), true)).toBe(false);
+  });
+
+  it('ignores code when requireCode is false', () => {
+    expect(validateStockForm(createFormData({ code: 'company-name' }), false)).toBe(true);
+  });
+
+  it('returns false for invalid numeric fields or date', () => {
+    expect(validateStockForm(createFormData({ quantity: '99' }), true)).toBe(false);
+    expect(validateStockForm(createFormData({ purchasePrice: '0' }), true)).toBe(false);
+    expect(validateStockForm(createFormData({ purchaseDate: '' }), true)).toBe(false);
+  });
+});

--- a/apps/ts/packages/web/src/components/Portfolio/StockFormFields.tsx
+++ b/apps/ts/packages/web/src/components/Portfolio/StockFormFields.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { StockSearchInput } from '@/components/Stock/StockSearchInput';
 
 export interface StockFormData {
   code?: string;
@@ -28,16 +29,18 @@ export function StockFormFields({ data, onChange, showCodeField = true, idPrefix
         {showCodeField && (
           <div className="grid gap-2">
             <Label htmlFor={`${idPrefix}-code`}>Stock Code</Label>
-            <Input
+            <StockSearchInput
               id={`${idPrefix}-code`}
               value={data.code || ''}
-              onChange={(e) => updateField('code', e.target.value)}
-              placeholder="7203"
-              maxLength={4}
+              onValueChange={(value) => updateField('code', value)}
+              onSelect={(stock) => updateField('code', stock.code)}
+              placeholder="銘柄コードまたは会社名で検索..."
               required
               autoFocus
+              className="border-input bg-transparent"
+              searchLimit={50}
             />
-            <p className="text-xs text-muted-foreground">4-digit code (e.g., 7203)</p>
+            <p className="text-xs text-muted-foreground">Search by code or company name, then select a symbol.</p>
           </div>
         )}
         <div className="grid gap-2">

--- a/apps/ts/packages/web/src/components/Stock/StockSearchInput.test.tsx
+++ b/apps/ts/packages/web/src/components/Stock/StockSearchInput.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StockSearchInput } from './StockSearchInput';
+
+const mockUseStockSearch = vi.fn();
+
+vi.mock('@/hooks/useStockSearch', () => ({
+  useStockSearch: (...args: unknown[]) => mockUseStockSearch(...args),
+}));
+
+const SEARCH_RESULT = {
+  code: '7203',
+  companyName: 'Toyota Motor',
+  companyNameEnglish: null,
+  marketCode: '0111',
+  marketName: 'Prime',
+  sector33Name: '輸送用機器',
+};
+
+function ControlledSearch({ onSelect }: { onSelect: (code: string) => void }) {
+  const [value, setValue] = useState('');
+  return (
+    <StockSearchInput
+      id="stock-search"
+      name="stock-search"
+      value={value}
+      onValueChange={setValue}
+      onSelect={(stock) => onSelect(stock.code)}
+    />
+  );
+}
+
+describe('StockSearchInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseStockSearch.mockImplementation((query: string) => ({
+      data: query ? { results: [SEARCH_RESULT] } : { results: [] },
+      isLoading: false,
+    }));
+  });
+
+  it('shows suggestion list and selects by click', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ControlledSearch onSelect={onSelect} />);
+
+    await user.type(screen.getByRole('searchbox'), 'toyo');
+    await user.click(await screen.findByRole('button', { name: /7203 Toyota Motor/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('7203');
+  });
+
+  it('supports keyboard selection from suggestions', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ControlledSearch onSelect={onSelect} />);
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'toyo');
+    await screen.findByText('Toyota Motor');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('7203');
+  });
+});

--- a/apps/ts/packages/web/src/components/Stock/StockSearchInput.tsx
+++ b/apps/ts/packages/web/src/components/Stock/StockSearchInput.tsx
@@ -1,0 +1,203 @@
+import { Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent, RefObject } from 'react';
+import { Input } from '@/components/ui/input';
+import { type StockSearchResultItem, useStockSearch } from '@/hooks/useStockSearch';
+import { cn } from '@/lib/utils';
+
+interface StockSearchInputProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  onSelect: (stock: StockSearchResultItem) => void;
+  id?: string;
+  name?: string;
+  placeholder?: string;
+  required?: boolean;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  className?: string;
+  maxLength?: number;
+  searchLimit?: number;
+}
+
+interface SearchSuggestionsProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+  results: StockSearchResultItem[];
+  selectedIndex: number;
+  onSelect: (stock: StockSearchResultItem) => void;
+}
+
+function SearchSuggestions({ containerRef, results, selectedIndex, onSelect }: SearchSuggestionsProps) {
+  return (
+    <div
+      ref={containerRef}
+      className="absolute left-0 top-full z-50 mt-1 w-full max-h-96 overflow-auto rounded-lg border border-border/50 bg-background/95 backdrop-blur-md shadow-xl"
+    >
+      {results.map((stock, index) => (
+        <button
+          key={stock.code}
+          type="button"
+          onClick={() => onSelect(stock)}
+          className={cn(
+            'w-full px-4 py-3 text-left hover:bg-accent/50 transition-colors',
+            'border-b border-border/30 last:border-b-0',
+            index === selectedIndex && 'bg-accent/50'
+          )}
+          aria-label={`${stock.code} ${stock.companyName}`}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-3 min-w-0">
+              <span className="font-mono font-bold text-primary text-base">{stock.code}</span>
+              <span className="text-sm text-foreground truncate">{stock.companyName}</span>
+            </div>
+            <span className="text-xs text-muted-foreground whitespace-nowrap">{stock.marketName}</span>
+          </div>
+          <div className="text-xs text-muted-foreground mt-1">{stock.sector33Name}</div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function StockSearchInput({
+  value,
+  onValueChange,
+  onSelect,
+  id,
+  name = 'stock-search',
+  placeholder = '銘柄コードまたは会社名で検索...',
+  required = false,
+  autoFocus = false,
+  disabled = false,
+  className,
+  maxLength,
+  searchLimit = 50,
+}: StockSearchInputProps) {
+  const [debouncedQuery, setDebouncedQuery] = useState(value);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const suggestionsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(value), 300);
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  const { data: searchResults, isLoading: isSearching } = useStockSearch(debouncedQuery, {
+    limit: searchLimit,
+    enabled: debouncedQuery.trim().length >= 1,
+  });
+  const searchCandidates = searchResults?.results ?? [];
+
+  const closeSuggestions = useCallback(() => {
+    setShowSuggestions(false);
+    setSelectedIndex(-1);
+  }, []);
+
+  useEffect(() => {
+    if (selectedIndex >= 0 && suggestionsRef.current) {
+      const selectedElement = suggestionsRef.current.children[selectedIndex] as HTMLElement;
+      selectedElement?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [selectedIndex]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        suggestionsRef.current &&
+        !suggestionsRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        closeSuggestions();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [closeSuggestions]);
+
+  const handleSelectStock = useCallback(
+    (stock: StockSearchResultItem) => {
+      onSelect(stock);
+      closeSuggestions();
+    },
+    [closeSuggestions, onSelect]
+  );
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      closeSuggestions();
+      return;
+    }
+
+    if (!showSuggestions || searchCandidates.length === 0) {
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) => Math.min(prev + 1, searchCandidates.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => Math.max(prev - 1, -1));
+        break;
+      case 'Enter':
+        if (selectedIndex >= 0 && searchCandidates[selectedIndex]) {
+          e.preventDefault();
+          handleSelectStock(searchCandidates[selectedIndex]);
+        }
+        break;
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        ref={inputRef}
+        id={id}
+        type="search"
+        name={name}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          onValueChange(e.target.value);
+          setShowSuggestions(true);
+          setSelectedIndex(-1);
+        }}
+        onFocus={() => setShowSuggestions(true)}
+        onKeyDown={handleKeyDown}
+        className={cn('w-full pr-10', className)}
+        required={required}
+        autoFocus={autoFocus}
+        maxLength={maxLength}
+        disabled={disabled}
+        autoComplete="off"
+        autoCapitalize="off"
+        autoCorrect="off"
+        spellCheck={false}
+        inputMode="search"
+        enterKeyHint="search"
+        data-form-type="other"
+        data-lpignore="true"
+        data-1p-ignore="true"
+      />
+      {isSearching && (
+        <div className="absolute right-3 top-1/2 -translate-y-1/2">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      {showSuggestions && searchCandidates.length > 0 && (
+        <SearchSuggestions
+          containerRef={suggestionsRef}
+          results={searchCandidates}
+          selectedIndex={selectedIndex}
+          onSelect={handleSelectStock}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/ts/packages/web/src/components/Watchlist/WatchlistDetail.tsx
+++ b/apps/ts/packages/web/src/components/Watchlist/WatchlistDetail.tsx
@@ -2,6 +2,7 @@ import { Eye, Loader2, Plus, Trash2, TrendingUp } from 'lucide-react';
 import { useNavigate } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
+import { StockSearchInput } from '@/components/Stock/StockSearchInput';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DataStateWrapper } from '@/components/ui/data-state-wrapper';
@@ -31,13 +32,15 @@ function AddStockDialog({ watchlistId }: { watchlistId: number }) {
   const [code, setCode] = useState('');
   const [memo, setMemo] = useState('');
   const addItem = useAddWatchlistItem();
+  const normalizedCode = code.trim();
+  const isValidCode = /^\d{4}$/.test(normalizedCode);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!code.trim()) return;
+    if (!isValidCode) return;
 
     addItem.mutate(
-      { watchlistId, data: { code: code.trim(), memo: memo.trim() || undefined } },
+      { watchlistId, data: { code: normalizedCode, memo: memo.trim() || undefined } },
       {
         onSuccess: () => {
           setOpen(false);
@@ -73,15 +76,18 @@ function AddStockDialog({ watchlistId }: { watchlistId: number }) {
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
               <Label htmlFor="stock-code">Stock Code</Label>
-              <Input
+              <StockSearchInput
                 id="stock-code"
                 value={code}
-                onChange={(e) => setCode(e.target.value)}
-                placeholder="7203"
+                onValueChange={setCode}
+                onSelect={(stock) => setCode(stock.code)}
+                placeholder="銘柄コードまたは会社名で検索..."
                 required
                 autoFocus
-                maxLength={4}
+                className="border-input bg-transparent"
+                searchLimit={50}
               />
+              <p className="text-xs text-muted-foreground">Search by code or company name, then select a symbol.</p>
             </div>
             <div className="grid gap-2">
               <Label htmlFor="stock-memo">Memo (optional)</Label>
@@ -98,7 +104,7 @@ function AddStockDialog({ watchlistId }: { watchlistId: number }) {
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={!code.trim() || addItem.isPending}>
+            <Button type="submit" disabled={!isValidCode || addItem.isPending}>
               {addItem.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Add
             </Button>


### PR DESCRIPTION
## Summary
- add reusable StockSearchInput using /api/chart/stocks/search suggestions
- replace chart search UI internals with the shared input component
- enable portfolio/watchlist add dialogs to search by code or company name
- harden watchlist add submit to allow only 4-digit codes
- add tests for shared search input, stock form fields, and watchlist validation
- update AGENTS.md to reflect the portfolio/watchlist search behavior

## Test
- bun run --filter @trading25/web test -- src/components/Portfolio/StockFormFields.test.tsx src/components/Chart/ChartControls.test.tsx src/components/Watchlist/WatchlistDetail.test.tsx src/components/Stock/StockSearchInput.test.tsx
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test:coverage -- src/components/Portfolio/StockFormFields.test.tsx src/components/Chart/ChartControls.test.tsx src/components/Watchlist/WatchlistDetail.test.tsx src/components/Stock/StockSearchInput.test.tsx
