### PR TITLE
feat(web): fundamentals panel metric controls and dynamic height

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ bun run cli backtest attribution run <strategy> --wait
 - Backtest `Strategies > Optimize` は `Open Editor` ポップアップで Monaco + Signal Reference を表示し、`Current` / `Saved` / `State` 要約を維持する。保存ブロックは YAML 構文エラー時のみとする
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 - `analysis screening`（web/cli）は production 戦略を動的選択し、非同期ジョブ（2秒ポーリング）で実行する。`sortBy` 既定は `matchedDate`、`order` 既定は `desc`。`backtestMetric` は廃止
-- Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集できる
+- Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Fundamental Metrics / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集し、Fundamentals パネル内部の指標は `fundamentalsMetricOrder` / `fundamentalsMetricVisibility` で順序・表示ON/OFFを保持する。Fundamentals パネル高さは表示中指標数に応じて動的に変化する
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDown,
   ArrowUp,
   BarChart3,
+  BookOpen,
   Eye,
   Loader2,
   Search,
@@ -17,6 +18,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import {
+  countVisibleFundamentalMetrics,
+  FUNDAMENTAL_METRIC_DEFINITIONS,
+  type FundamentalMetricId,
+} from '@/constants/fundamentalMetrics';
 import { useSignalReference } from '@/hooks/useBacktest';
 import { type StockSearchResultItem, useStockSearch } from '@/hooks/useStockSearch';
 import { cn } from '@/lib/utils';
@@ -85,8 +91,17 @@ const PANEL_VISIBILITY_TOGGLES: PanelVisibilityToggle[] = [
 const PANEL_TOGGLE_BY_ID = Object.fromEntries(
   PANEL_VISIBILITY_TOGGLES.map((toggle) => [toggle.panelId, toggle])
 ) as Record<FundamentalsPanelId, PanelVisibilityToggle>;
+const FUNDAMENTAL_METRIC_LABEL_BY_ID = Object.fromEntries(
+  FUNDAMENTAL_METRIC_DEFINITIONS.map((definition) => [definition.id, definition.label])
+) as Record<FundamentalMetricId, string>;
 
-type SettingDialogId = 'chartSettings' | 'panelLayout' | 'overlayIndicators' | 'subChartIndicators' | 'signalOverlay';
+type SettingDialogId =
+  | 'chartSettings'
+  | 'panelLayout'
+  | 'fundamentalMetrics'
+  | 'overlayIndicators'
+  | 'subChartIndicators'
+  | 'signalOverlay';
 
 interface SettingDialogDefinition {
   id: SettingDialogId;
@@ -107,6 +122,12 @@ const SETTING_DIALOGS: SettingDialogDefinition[] = [
     title: 'Panel Layout',
     description: 'Choose visible panels and their display order.',
     icon: Eye,
+  },
+  {
+    id: 'fundamentalMetrics',
+    title: 'Fundamental Metrics',
+    description: 'Toggle and reorder metrics shown inside the fundamentals panel.',
+    icon: BookOpen,
   },
   {
     id: 'overlayIndicators',
@@ -297,6 +318,44 @@ export function ChartControls() {
     [settings.fundamentalsPanelOrder, updateSettings]
   );
 
+  const updateFundamentalMetricVisibility = useCallback(
+    (metricId: FundamentalMetricId, checked: boolean) => {
+      updateSettings({
+        fundamentalsMetricVisibility: {
+          ...settings.fundamentalsMetricVisibility,
+          [metricId]: checked,
+        },
+      });
+    },
+    [settings.fundamentalsMetricVisibility, updateSettings]
+  );
+
+  const moveFundamentalMetricOrder = useCallback(
+    (metricId: FundamentalMetricId, direction: 'up' | 'down') => {
+      const currentOrder = settings.fundamentalsMetricOrder;
+      const currentIndex = currentOrder.indexOf(metricId);
+      if (currentIndex < 0) return;
+
+      const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      if (targetIndex < 0 || targetIndex >= currentOrder.length) return;
+
+      const nextOrder = [...currentOrder];
+      const currentMetric = nextOrder[currentIndex];
+      const targetMetric = nextOrder[targetIndex];
+      if (!currentMetric || !targetMetric) return;
+
+      nextOrder[currentIndex] = targetMetric;
+      nextOrder[targetIndex] = currentMetric;
+      updateSettings({ fundamentalsMetricOrder: nextOrder });
+    },
+    [settings.fundamentalsMetricOrder, updateSettings]
+  );
+
+  const visibleFundamentalMetricCount = useMemo(
+    () => countVisibleFundamentalMetrics(settings.fundamentalsMetricOrder, settings.fundamentalsMetricVisibility),
+    [settings.fundamentalsMetricOrder, settings.fundamentalsMetricVisibility]
+  );
+
   const updateRiskAdjustedReturn = useCallback(
     (newSettings: Partial<ChartSettings['riskAdjustedReturn']>) => {
       updateSettings({
@@ -412,6 +471,63 @@ export function ChartControls() {
                       className="h-7 px-2"
                       onClick={() => movePanelOrder(panelId, 'down')}
                       disabled={index === settings.fundamentalsPanelOrder.length - 1}
+                    >
+                      <ArrowDown className="h-3.5 w-3.5 mr-1" />
+                      Down
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+
+      case 'fundamentalMetrics':
+        return (
+          <div className="space-y-2">
+            <div className="rounded glass-panel p-2">
+              <p className="text-xs text-muted-foreground">
+                Visible: {visibleFundamentalMetricCount} / {settings.fundamentalsMetricOrder.length}
+              </p>
+            </div>
+            {settings.fundamentalsMetricOrder.map((metricId, index) => {
+              const metricLabel = FUNDAMENTAL_METRIC_LABEL_BY_ID[metricId];
+              const isVisible = settings.fundamentalsMetricVisibility[metricId];
+              const switchId = `fundamental-metric-${metricId}`;
+              return (
+                <div key={metricId} className="rounded glass-panel p-2 space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-xs text-muted-foreground">Order {index + 1}</p>
+                      <Label htmlFor={switchId} className="text-sm font-medium cursor-pointer">
+                        {metricLabel}
+                      </Label>
+                    </div>
+                    <Switch
+                      id={switchId}
+                      checked={isVisible}
+                      onCheckedChange={(checked) => updateFundamentalMetricVisibility(metricId, checked)}
+                    />
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 px-2"
+                      onClick={() => moveFundamentalMetricOrder(metricId, 'up')}
+                      disabled={index === 0}
+                    >
+                      <ArrowUp className="h-3.5 w-3.5 mr-1" />
+                      Up
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 px-2"
+                      onClick={() => moveFundamentalMetricOrder(metricId, 'down')}
+                      disabled={index === settings.fundamentalsMetricOrder.length - 1}
                     >
                       <ArrowDown className="h-3.5 w-3.5 mr-1" />
                       Down

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
@@ -1,19 +1,28 @@
-import { hasActualFinancialData, isFiscalYear } from '@/utils/fundamental-analysis';
 import { useMemo } from 'react';
 import { DataStateWrapper } from '@/components/ui/data-state-wrapper';
+import {
+  DEFAULT_FUNDAMENTAL_METRIC_ORDER,
+  DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
+  type FundamentalMetricId,
+} from '@/constants/fundamentalMetrics';
 import { useFundamentals } from '@/hooks/useFundamentals';
+import { hasActualFinancialData, isFiscalYear } from '@/utils/fundamental-analysis';
 import { FundamentalsSummaryCard } from './FundamentalsSummaryCard';
 
 interface FundamentalsPanelProps {
   symbol: string | null;
   enabled?: boolean;
   tradingValuePeriod?: number;
+  metricOrder?: FundamentalMetricId[];
+  metricVisibility?: Record<FundamentalMetricId, boolean>;
 }
 
 export function FundamentalsPanel({
   symbol,
   enabled = true,
   tradingValuePeriod = 15,
+  metricOrder = DEFAULT_FUNDAMENTAL_METRIC_ORDER,
+  metricVisibility = DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
 }: FundamentalsPanelProps) {
   const { data, isLoading, error } = useFundamentals(symbol, { enabled, tradingValuePeriod });
 
@@ -104,6 +113,8 @@ export function FundamentalsPanel({
           <FundamentalsSummaryCard
             metrics={latestFyMetrics}
             tradingValuePeriod={data.tradingValuePeriod ?? tradingValuePeriod}
+            metricOrder={metricOrder}
+            metricVisibility={metricVisibility}
           />
         </div>
       )}

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -1,8 +1,9 @@
 /* @vitest-environment jsdom */
 
-import type { ApiFundamentalDataPoint } from '@trading25/shared/types/api-types';
 import { render, screen } from '@testing-library/react';
+import type { ApiFundamentalDataPoint } from '@trading25/shared/types/api-types';
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY } from '@/constants/fundamentalMetrics';
 import { FundamentalsSummaryCard } from './FundamentalsSummaryCard';
 
 const baseMetrics: ApiFundamentalDataPoint = {
@@ -101,5 +102,22 @@ describe('FundamentalsSummaryCard', () => {
     render(<FundamentalsSummaryCard metrics={metrics} />);
     expect(screen.queryByText(/予:/)).not.toBeInTheDocument();
     expect(screen.queryByText('(17.43x)')).not.toBeInTheDocument();
+  });
+
+  it('supports metric visibility and ordering', () => {
+    render(
+      <FundamentalsSummaryCard
+        metrics={baseMetrics}
+        metricOrder={['eps', 'per', 'pbr']}
+        metricVisibility={{
+          ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
+          pbr: false,
+        }}
+      />
+    );
+
+    expect(screen.getByText('EPS')).toBeInTheDocument();
+    expect(screen.getByText('PER')).toBeInTheDocument();
+    expect(screen.queryByText('PBR')).not.toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
@@ -1,5 +1,9 @@
 import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_FUNDAMENTAL_METRIC_ORDER,
+  DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
+} from '@/constants/fundamentalMetrics';
 import type { StockDataPoint } from '@/types/chart';
 import { calculateChangePct, formatPrice, StockChart, timeToDateString } from './StockChart';
 
@@ -19,6 +23,8 @@ const mockChartStore = {
     showMarginPressurePanel: true,
     showFactorRegressionPanel: true,
     fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'],
+    fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
+    fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
     visibleBars: 30,
     relativeMode: false,
     indicators: {

--- a/apps/ts/packages/web/src/constants/fundamentalMetrics.ts
+++ b/apps/ts/packages/web/src/constants/fundamentalMetrics.ts
@@ -1,0 +1,127 @@
+export const FUNDAMENTAL_METRIC_IDS = [
+  'per',
+  'pbr',
+  'roe',
+  'roa',
+  'eps',
+  'bps',
+  'dividendPerShare',
+  'operatingMargin',
+  'netMargin',
+  'cashFlowOperating',
+  'cashFlowInvesting',
+  'cashFlowFinancing',
+  'cashAndEquivalents',
+  'fcf',
+  'fcfYield',
+  'fcfMargin',
+  'cfoToNetProfitRatio',
+  'tradingValueToMarketCapRatio',
+] as const;
+
+export type FundamentalMetricId = (typeof FUNDAMENTAL_METRIC_IDS)[number];
+
+export interface FundamentalMetricDefinition {
+  id: FundamentalMetricId;
+  label: string;
+}
+
+export const FUNDAMENTAL_METRIC_DEFINITIONS: FundamentalMetricDefinition[] = [
+  { id: 'per', label: 'PER' },
+  { id: 'pbr', label: 'PBR' },
+  { id: 'roe', label: 'ROE' },
+  { id: 'roa', label: 'ROA' },
+  { id: 'eps', label: 'EPS' },
+  { id: 'bps', label: 'BPS' },
+  { id: 'dividendPerShare', label: '1株配当' },
+  { id: 'operatingMargin', label: '営業利益率' },
+  { id: 'netMargin', label: '純利益率' },
+  { id: 'cashFlowOperating', label: '営業CF' },
+  { id: 'cashFlowInvesting', label: '投資CF' },
+  { id: 'cashFlowFinancing', label: '財務CF' },
+  { id: 'cashAndEquivalents', label: '現金' },
+  { id: 'fcf', label: 'FCF' },
+  { id: 'fcfYield', label: 'FCF利回り' },
+  { id: 'fcfMargin', label: 'FCFマージン' },
+  { id: 'cfoToNetProfitRatio', label: '営業CF/純利益' },
+  { id: 'tradingValueToMarketCapRatio', label: '時価総額/売買代金' },
+];
+
+export const DEFAULT_FUNDAMENTAL_METRIC_ORDER: FundamentalMetricId[] = [...FUNDAMENTAL_METRIC_IDS];
+
+export const DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY: Record<FundamentalMetricId, boolean> = {
+  per: true,
+  pbr: true,
+  roe: true,
+  roa: true,
+  eps: true,
+  bps: true,
+  dividendPerShare: true,
+  operatingMargin: true,
+  netMargin: true,
+  cashFlowOperating: true,
+  cashFlowInvesting: true,
+  cashFlowFinancing: true,
+  cashAndEquivalents: true,
+  fcf: true,
+  fcfYield: true,
+  fcfMargin: true,
+  cfoToNetProfitRatio: true,
+  tradingValueToMarketCapRatio: true,
+};
+
+const FUNDAMENTAL_METRIC_ID_SET = new Set<FundamentalMetricId>(FUNDAMENTAL_METRIC_IDS);
+
+export function isFundamentalMetricId(value: unknown): value is FundamentalMetricId {
+  return typeof value === 'string' && FUNDAMENTAL_METRIC_ID_SET.has(value as FundamentalMetricId);
+}
+
+export function normalizeFundamentalMetricOrder(value: unknown): FundamentalMetricId[] {
+  const normalizedOrder: FundamentalMetricId[] = [];
+  const seen = new Set<FundamentalMetricId>();
+
+  if (Array.isArray(value)) {
+    for (const metricId of value) {
+      if (!isFundamentalMetricId(metricId) || seen.has(metricId)) continue;
+      seen.add(metricId);
+      normalizedOrder.push(metricId);
+    }
+  }
+
+  for (const metricId of DEFAULT_FUNDAMENTAL_METRIC_ORDER) {
+    if (seen.has(metricId)) continue;
+    normalizedOrder.push(metricId);
+  }
+
+  return normalizedOrder;
+}
+
+export function normalizeFundamentalMetricVisibility(value: unknown): Record<FundamentalMetricId, boolean> {
+  const normalized = { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY };
+  if (typeof value !== 'object' || value === null) return normalized;
+
+  for (const metricId of FUNDAMENTAL_METRIC_IDS) {
+    const raw = (value as Record<string, unknown>)[metricId];
+    if (typeof raw === 'boolean') {
+      normalized[metricId] = raw;
+    }
+  }
+
+  return normalized;
+}
+
+export function countVisibleFundamentalMetrics(
+  metricOrder: FundamentalMetricId[],
+  metricVisibility: Record<FundamentalMetricId, boolean>
+): number {
+  return metricOrder.filter((metricId) => metricVisibility[metricId]).length;
+}
+
+export const FUNDAMENTALS_METRIC_GRID_COLUMNS = 8;
+export const FUNDAMENTALS_PANEL_BASE_HEIGHT_PX = 220;
+export const FUNDAMENTALS_PANEL_ROW_HEIGHT_PX = 74;
+
+export function resolveFundamentalsPanelHeightPx(visibleMetricCount: number): number {
+  const rows = Math.max(1, Math.ceil(visibleMetricCount / FUNDAMENTALS_METRIC_GRID_COLUMNS));
+  return FUNDAMENTALS_PANEL_BASE_HEIGHT_PX + rows * FUNDAMENTALS_PANEL_ROW_HEIGHT_PX;
+}

--- a/apps/ts/packages/web/src/hooks/useBtIndicators.test.ts
+++ b/apps/ts/packages/web/src/hooks/useBtIndicators.test.ts
@@ -1,5 +1,9 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_FUNDAMENTAL_METRIC_ORDER,
+  DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
+} from '@/constants/fundamentalMetrics';
 import { apiPost } from '@/lib/api-client';
 import type { ChartSettings } from '@/stores/chartStore';
 import { createTestWrapper } from '@/test-utils';
@@ -32,7 +36,12 @@ describe('buildIndicatorSpecs', () => {
     },
     volumeComparison: { shortPeriod: 20, longPeriod: 100, lowerMultiplier: 1.0, higherMultiplier: 1.5 },
     tradingValueMA: { period: 20 },
-    riskAdjustedReturn: { lookbackPeriod: 60, ratioType: 'sortino' as const, threshold: 1.0, condition: 'above' as const },
+    riskAdjustedReturn: {
+      lookbackPeriod: 60,
+      ratioType: 'sortino' as const,
+      threshold: 1.0,
+      condition: 'above' as const,
+    },
     chartType: 'candlestick' as const,
     showVolume: true,
     showPPOChart: false,
@@ -43,7 +52,14 @@ describe('buildIndicatorSpecs', () => {
     showFundamentalsHistoryPanel: true,
     showMarginPressurePanel: true,
     showFactorRegressionPanel: true,
-    fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'] as ChartSettings['fundamentalsPanelOrder'],
+    fundamentalsPanelOrder: [
+      'fundamentals',
+      'fundamentalsHistory',
+      'marginPressure',
+      'factorRegression',
+    ] as ChartSettings['fundamentalsPanelOrder'],
+    fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
+    fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
     visibleBars: 200,
     relativeMode: false,
     signalOverlay: { enabled: false, signals: [] },
@@ -143,7 +159,12 @@ describe('buildIndicatorSpecs', () => {
     const settings = {
       ...baseSettings,
       showRiskAdjustedReturnChart: true,
-      riskAdjustedReturn: { lookbackPeriod: 80, ratioType: 'sharpe' as const, threshold: 1.2, condition: 'below' as const },
+      riskAdjustedReturn: {
+        lookbackPeriod: 80,
+        ratioType: 'sharpe' as const,
+        threshold: 1.2,
+        condition: 'below' as const,
+      },
     };
     const specs = buildIndicatorSpecs(settings);
     expect(specs).toContainEqual({
@@ -318,7 +339,12 @@ describe('useBtIndicators', () => {
     },
     volumeComparison: { shortPeriod: 20, longPeriod: 100, lowerMultiplier: 1.0, higherMultiplier: 1.5 },
     tradingValueMA: { period: 20 },
-    riskAdjustedReturn: { lookbackPeriod: 60, ratioType: 'sortino' as const, threshold: 1.0, condition: 'above' as const },
+    riskAdjustedReturn: {
+      lookbackPeriod: 60,
+      ratioType: 'sortino' as const,
+      threshold: 1.0,
+      condition: 'above' as const,
+    },
     chartType: 'candlestick' as const,
     showVolume: true,
     showPPOChart: false,
@@ -329,7 +355,14 @@ describe('useBtIndicators', () => {
     showFundamentalsHistoryPanel: true,
     showMarginPressurePanel: true,
     showFactorRegressionPanel: true,
-    fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'] as ChartSettings['fundamentalsPanelOrder'],
+    fundamentalsPanelOrder: [
+      'fundamentals',
+      'fundamentalsHistory',
+      'marginPressure',
+      'factorRegression',
+    ] as ChartSettings['fundamentalsPanelOrder'],
+    fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
+    fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
     visibleBars: 200,
     relativeMode: false,
     signalOverlay: { enabled: false, signals: [] },
@@ -352,10 +385,13 @@ describe('useBtIndicators', () => {
     const relativeModeSettings = { ...baseSettings, relativeMode: true };
     renderHook(() => useBtIndicators('7203', 'daily', relativeModeSettings), { wrapper });
     await waitFor(() => {
-      expect(mockApiPost).toHaveBeenCalledWith('/api/indicators/compute', expect.objectContaining({
-        benchmark_code: 'topix',
-        relative_options: { align_dates: true, handle_zero_division: 'skip' },
-      }));
+      expect(mockApiPost).toHaveBeenCalledWith(
+        '/api/indicators/compute',
+        expect.objectContaining({
+          benchmark_code: 'topix',
+          relative_options: { align_dates: true, handle_zero_division: 'skip' },
+        })
+      );
     });
   });
 
@@ -444,10 +480,10 @@ describe('useBtIndicators', () => {
     };
 
     const { wrapper } = createTestWrapper();
-    const { rerender } = renderHook(
-      ({ chartSettings }) => useBtIndicators('7203', 'daily', chartSettings),
-      { wrapper, initialProps: { chartSettings: settings } }
-    );
+    const { rerender } = renderHook(({ chartSettings }) => useBtIndicators('7203', 'daily', chartSettings), {
+      wrapper,
+      initialProps: { chartSettings: settings },
+    });
 
     await waitFor(() => expect(mockApiPost).toHaveBeenCalledTimes(1));
 
@@ -490,10 +526,10 @@ describe('useBtIndicators', () => {
     };
 
     const { wrapper } = createTestWrapper();
-    const { rerender } = renderHook(
-      ({ chartSettings }) => useBtIndicators('7203', 'daily', chartSettings),
-      { wrapper, initialProps: { chartSettings: settings } }
-    );
+    const { rerender } = renderHook(({ chartSettings }) => useBtIndicators('7203', 'daily', chartSettings), {
+      wrapper,
+      initialProps: { chartSettings: settings },
+    });
 
     await waitFor(() => expect(mockApiPost).toHaveBeenCalledTimes(1));
 

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -14,6 +14,7 @@ import { TradingValueMAChart } from '@/components/Chart/TradingValueMAChart';
 import { VolumeComparisonChart } from '@/components/Chart/VolumeComparisonChart';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Button } from '@/components/ui/button';
+import { countVisibleFundamentalMetrics, resolveFundamentalsPanelHeightPx } from '@/constants/fundamentalMetrics';
 import { useBtMarginIndicators } from '@/hooks/useBtMarginIndicators';
 import { useFundamentals } from '@/hooks/useFundamentals';
 import { useStockData } from '@/hooks/useStockData';
@@ -200,6 +201,14 @@ export function ChartsPage() {
     if (!daily || daily.length === 0) return null;
     return daily[daily.length - 1]?.marketCap ?? null;
   }, [fundamentalsData, settings.showFundamentalsHistoryPanel, settings.showFundamentalsPanel]);
+  const visibleFundamentalMetricCount = useMemo(
+    () => countVisibleFundamentalMetrics(settings.fundamentalsMetricOrder, settings.fundamentalsMetricVisibility),
+    [settings.fundamentalsMetricOrder, settings.fundamentalsMetricVisibility]
+  );
+  const fundamentalsPanelHeight = useMemo(
+    () => resolveFundamentalsPanelHeightPx(visibleFundamentalMetricCount),
+    [visibleFundamentalMetricCount]
+  );
 
   const renderErrorState = () => (
     <div className="flex h-full items-center justify-center">
@@ -286,7 +295,12 @@ export function ChartsPage() {
     switch (panelId) {
       case 'fundamentals':
         return (
-          <div key={panelId} ref={fundamentalsPanelSection.sectionRef} className="h-[440px]">
+          <div
+            key={panelId}
+            ref={fundamentalsPanelSection.sectionRef}
+            data-testid="fundamentals-panel-section"
+            style={{ height: `${fundamentalsPanelHeight}px` }}
+          >
             <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
               <div className="absolute inset-0 gradient-glass opacity-50" />
               <div className="relative z-10 h-full">
@@ -299,6 +313,8 @@ export function ChartsPage() {
                       symbol={selectedSymbol}
                       enabled={fundamentalsPanelSection.isVisible}
                       tradingValuePeriod={tradingValuePeriod}
+                      metricOrder={settings.fundamentalsMetricOrder}
+                      metricVisibility={settings.fundamentalsMetricVisibility}
                     />
                   </ErrorBoundary>
                 </div>

--- a/apps/ts/packages/web/src/stores/chartStore.test.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.test.ts
@@ -247,6 +247,8 @@ describe('chartStore', () => {
     expect(state.settings.showFundamentalsHistoryPanel).toBe(defaultSettings.showFundamentalsHistoryPanel);
     expect(state.settings.showMarginPressurePanel).toBe(defaultSettings.showMarginPressurePanel);
     expect(state.settings.showFactorRegressionPanel).toBe(defaultSettings.showFactorRegressionPanel);
+    expect(state.settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
+    expect(state.settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
     expect(state.settings.signalOverlay.enabled).toBe(false);
     expect(state.settings.signalOverlay.signals).toEqual([]);
     expect(state.presets[0]?.settings.tradingValueMA.period).toBe(defaultSettings.tradingValueMA.period);
@@ -292,6 +294,8 @@ describe('chartStore', () => {
     expect(state.settings.visibleBars).toBe(defaultSettings.visibleBars);
     expect(state.settings.indicators.ppo.enabled).toBe(defaultSettings.indicators.ppo.enabled);
     expect(state.settings.indicators.ppo.fast).toBe(defaultSettings.indicators.ppo.fast);
+    expect(state.settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
+    expect(state.settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
     expect(state.settings.signalOverlay.enabled).toBe(defaultSettings.signalOverlay.enabled);
     expect(state.settings.signalOverlay.signals).toHaveLength(1);
     expect(state.settings.signalOverlay.signals[0]?.enabled).toBe(true);
@@ -313,6 +317,8 @@ describe('chartStore', () => {
       'marginPressure',
       'factorRegression',
     ]);
+    expect(settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
+    expect(settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
   });
 
   it('defaults risk adjusted return chart settings', () => {
@@ -359,6 +365,11 @@ describe('chartStore', () => {
         state: {
           settings: {
             fundamentalsPanelOrder: ['marginPressure', 'invalid', 'marginPressure'],
+            fundamentalsMetricOrder: ['eps', 'invalid', 'eps'],
+            fundamentalsMetricVisibility: {
+              eps: false,
+              per: 'yes',
+            },
           },
         },
         version: 0,
@@ -374,5 +385,11 @@ describe('chartStore', () => {
       'fundamentalsHistory',
       'factorRegression',
     ]);
+    expect(settings.fundamentalsMetricOrder).toEqual([
+      'eps',
+      ...defaultSettings.fundamentalsMetricOrder.filter((metricId) => metricId !== 'eps'),
+    ]);
+    expect(settings.fundamentalsMetricVisibility.eps).toBe(false);
+    expect(settings.fundamentalsMetricVisibility.per).toBe(defaultSettings.fundamentalsMetricVisibility.per);
   });
 });

--- a/apps/ts/packages/web/src/stores/chartStore.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.ts
@@ -1,5 +1,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  DEFAULT_FUNDAMENTAL_METRIC_ORDER,
+  DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
+  type FundamentalMetricId,
+  normalizeFundamentalMetricOrder,
+  normalizeFundamentalMetricVisibility,
+} from '@/constants/fundamentalMetrics';
 
 export type DisplayTimeframe = 'daily' | 'weekly' | 'monthly';
 export type RiskAdjustedReturnRatioType = 'sharpe' | 'sortino';
@@ -64,6 +71,8 @@ export interface ChartSettings {
   showMarginPressurePanel: boolean;
   showFactorRegressionPanel: boolean;
   fundamentalsPanelOrder: FundamentalsPanelId[];
+  fundamentalsMetricOrder: FundamentalMetricId[];
+  fundamentalsMetricVisibility: Record<FundamentalMetricId, boolean>;
   visibleBars: number;
   relativeMode: boolean;
   signalOverlay: SignalOverlaySettings;
@@ -160,6 +169,8 @@ export const defaultSettings: ChartSettings = {
   showMarginPressurePanel: true,
   showFactorRegressionPanel: true,
   fundamentalsPanelOrder: [...DEFAULT_FUNDAMENTALS_PANEL_ORDER],
+  fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
+  fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
   visibleBars: 120,
   relativeMode: false,
   signalOverlay: {
@@ -388,6 +399,8 @@ function normalizeSettings(settings: unknown): ChartSettings {
       defaultSettings.showFactorRegressionPanel
     ),
     fundamentalsPanelOrder: normalizeFundamentalsPanelOrder(partial.fundamentalsPanelOrder),
+    fundamentalsMetricOrder: normalizeFundamentalMetricOrder(partial.fundamentalsMetricOrder),
+    fundamentalsMetricVisibility: normalizeFundamentalMetricVisibility(partial.fundamentalsMetricVisibility),
     visibleBars: normalizePositiveInt(partial.visibleBars, defaultSettings.visibleBars),
     relativeMode: normalizeBoolean(partial.relativeMode, defaultSettings.relativeMode),
     signalOverlay: {


### PR DESCRIPTION
## Summary
- add persisted fundamentals metric configuration (fundamentalsMetricOrder / fundamentalsMetricVisibility) to chart settings
- add a new Fundamental Metrics sidebar dialog with per-metric On/Off and Up/Down reordering
- render fundamentals cards from configured order/visibility and show an empty hint when all metrics are disabled
- make fundamentals panel height dynamic based on the number of visible metric cards
- update AGENTS.md to document the new sidebar behavior and dynamic height rule

## Testing
- bun run typecheck (apps/ts/packages/web)
- bun run test (targeted web chart tests)
- bunx vitest run --coverage (targeted web chart tests)
