### PR TITLE
perf(bt-screening): stock-major evaluation and per-stock signal cache

### DIFF
--- a/apps/bt/src/server/services/screening_job_service.py
+++ b/apps/bt/src/server/services/screening_job_service.py
@@ -81,7 +81,7 @@ class ScreeningJobService:
             else:
                 progress = max(0.0, min(1.0, completed / total))
 
-            message = f"戦略評価 {completed}/{total}"
+            message = f"スクリーニング評価 {completed}/{total}"
             loop.call_soon_threadsafe(
                 asyncio.create_task,
                 self._manager.update_job_status(


### PR DESCRIPTION
## Summary
- switch screening evaluation loop from strategy-major to stock-major to reduce repeated full-universe scans
- add per-stock signal cache so equivalent strategy evaluations reuse generated signals within a stock
- keep early-return path for entry filter recent window and pass screening-specific flags consistently
- align screening job progress message with stock-major processing and extend/adjust unit tests

## Testing
- PYTHONPYCACHEPREFIX=/tmp/pycache-a501 python3 -m py_compile apps/bt/src/server/services/screening_service.py apps/bt/src/server/services/screening_job_service.py apps/bt/src/strategies/signals/processor.py apps/bt/tests/unit/server/services/test_screening_service.py apps/bt/tests/unit/server/services/test_screening_service_helpers.py apps/bt/tests/unit/strategies/test_signal_processor.py
- pytest was not runnable in this environment (No module named pytest / dependency resolution blocked by network restrictions)
