### PR TITLE
feat: add CFO yield/margin to fundamentals panel

### DIFF
--- a/apps/bt/src/server/schemas/fundamentals.py
+++ b/apps/bt/src/server/schemas/fundamentals.py
@@ -101,6 +101,8 @@ class FundamentalDataPoint(BaseModel):
     fcf: float | None = Field(None, description="Free cash flow (millions JPY)")
     fcfYield: float | None = Field(None, description="FCF yield (%)")
     fcfMargin: float | None = Field(None, description="FCF margin (%)")
+    cfoYield: float | None = Field(None, description="CFO yield (%)")
+    cfoMargin: float | None = Field(None, description="CFO margin (%)")
     cfoToNetProfitRatio: float | None = Field(
         None, description="Operating cash flow / net profit ratio (x)"
     )

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -13182,6 +13182,30 @@
             "title": "Fcfmargin",
             "description": "FCF margin (%)"
           },
+          "cfoYield": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cfoyield",
+            "description": "CFO yield (%)"
+          },
+          "cfoMargin": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cfomargin",
+            "description": "CFO margin (%)"
+          },
           "cfoToNetProfitRatio": {
             "anyOf": [
               {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -3380,6 +3380,16 @@ export interface components {
              */
             fcfMargin?: number | null;
             /**
+             * Cfoyield
+             * @description CFO yield (%)
+             */
+            cfoYield?: number | null;
+            /**
+             * Cfomargin
+             * @description CFO margin (%)
+             */
+            cfoMargin?: number | null;
+            /**
              * Cfotonetprofitratio
              * @description Operating cash flow / net profit ratio (x)
              */

--- a/apps/ts/packages/shared/src/types/api-types.ts
+++ b/apps/ts/packages/shared/src/types/api-types.ts
@@ -222,6 +222,10 @@ export interface ApiFundamentalDataPoint {
   fcfYield: number | null;
   /** FCF Margin = FCF / Net Sales × 100 (%) */
   fcfMargin: number | null;
+  /** CFO Yield = CFO / Market Cap × 100 (%) */
+  cfoYield: number | null;
+  /** CFO Margin = CFO / Net Sales × 100 (%) */
+  cfoMargin: number | null;
   /** Operating Cash Flow / Net Profit (x) */
   cfoToNetProfitRatio: number | null;
   /** Market cap / N-day average trading value (x) */

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -34,6 +34,8 @@ const baseMetrics: ApiFundamentalDataPoint = {
   fcf: 4_000_000,
   fcfYield: 0.5,
   fcfMargin: 8.9,
+  cfoYield: 0.75,
+  cfoMargin: 13.3,
   cfoToNetProfitRatio: 1.5,
   tradingValueToMarketCapRatio: 8.33,
   forecastEps: 350,
@@ -55,6 +57,8 @@ describe('FundamentalsSummaryCard', () => {
   it('renders new ratio row with custom trading value period', () => {
     render(<FundamentalsSummaryCard metrics={baseMetrics} tradingValuePeriod={20} />);
 
+    expect(screen.getByText('CFO利回り')).toBeInTheDocument();
+    expect(screen.getByText('CFOマージン')).toBeInTheDocument();
     expect(screen.getByText('営業CF/純利益')).toBeInTheDocument();
     expect(screen.getByText('時価総額/20日売買代金')).toBeInTheDocument();
     expect(screen.getByText('1.50x')).toBeInTheDocument();

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -195,6 +195,10 @@ export function FundamentalsSummaryCard({
         return <MetricCard label="FCF利回り" value={metrics.fcfYield} format="percent" colorScheme="fcfYield" />;
       case 'fcfMargin':
         return <MetricCard label="FCFマージン" value={metrics.fcfMargin} format="percent" colorScheme="fcfMargin" />;
+      case 'cfoYield':
+        return <MetricCard label="CFO利回り" value={metrics.cfoYield} format="percent" colorScheme="cfoYield" />;
+      case 'cfoMargin':
+        return <MetricCard label="CFOマージン" value={metrics.cfoMargin} format="percent" colorScheme="cfoMargin" />;
       case 'cfoToNetProfitRatio':
         return <MetricCard label="営業CF/純利益" value={metrics.cfoToNetProfitRatio ?? null} format="times" />;
       case 'tradingValueToMarketCapRatio':

--- a/apps/ts/packages/web/src/constants/fundamentalMetrics.ts
+++ b/apps/ts/packages/web/src/constants/fundamentalMetrics.ts
@@ -15,6 +15,8 @@ export const FUNDAMENTAL_METRIC_IDS = [
   'fcf',
   'fcfYield',
   'fcfMargin',
+  'cfoYield',
+  'cfoMargin',
   'cfoToNetProfitRatio',
   'tradingValueToMarketCapRatio',
 ] as const;
@@ -43,6 +45,8 @@ export const FUNDAMENTAL_METRIC_DEFINITIONS: FundamentalMetricDefinition[] = [
   { id: 'fcf', label: 'FCF' },
   { id: 'fcfYield', label: 'FCF利回り' },
   { id: 'fcfMargin', label: 'FCFマージン' },
+  { id: 'cfoYield', label: 'CFO利回り' },
+  { id: 'cfoMargin', label: 'CFOマージン' },
   { id: 'cfoToNetProfitRatio', label: '営業CF/純利益' },
   { id: 'tradingValueToMarketCapRatio', label: '時価総額/売買代金' },
 ];
@@ -66,6 +70,8 @@ export const DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY: Record<FundamentalMetricId, 
   fcf: true,
   fcfYield: true,
   fcfMargin: true,
+  cfoYield: true,
+  cfoMargin: true,
   cfoToNetProfitRatio: true,
   tradingValueToMarketCapRatio: true,
 };

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -486,6 +486,8 @@ describe('ChartsPage', () => {
       fcf: false,
       fcfYield: false,
       fcfMargin: false,
+      cfoYield: false,
+      cfoMargin: false,
       cfoToNetProfitRatio: false,
       tradingValueToMarketCapRatio: false,
     };

--- a/apps/ts/packages/web/src/utils/color-schemes.test.ts
+++ b/apps/ts/packages/web/src/utils/color-schemes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getCfoMarginColor,
+  getCfoYieldColor,
   getCashFlowColor,
   getFcfMarginColor,
   getFcfYieldColor,
@@ -141,6 +143,34 @@ describe('getFcfMarginColor', () => {
   });
 });
 
+describe('getCfoYieldColor', () => {
+  it('returns green for >= 5', () => {
+    expect(getCfoYieldColor(5)).toBe('text-green-500');
+  });
+
+  it('returns yellow for >= 2 and < 5', () => {
+    expect(getCfoYieldColor(3)).toBe('text-yellow-500');
+  });
+
+  it('returns red for < 2', () => {
+    expect(getCfoYieldColor(1)).toBe('text-red-500');
+  });
+});
+
+describe('getCfoMarginColor', () => {
+  it('returns green for >= 10', () => {
+    expect(getCfoMarginColor(10)).toBe('text-green-500');
+  });
+
+  it('returns yellow for >= 5 and < 10', () => {
+    expect(getCfoMarginColor(7)).toBe('text-yellow-500');
+  });
+
+  it('returns red for < 5', () => {
+    expect(getCfoMarginColor(3)).toBe('text-red-500');
+  });
+});
+
 describe('getFundamentalColor', () => {
   it('returns muted for null value', () => {
     expect(getFundamentalColor(null, 'roe')).toBe('text-muted-foreground');
@@ -172,5 +202,13 @@ describe('getFundamentalColor', () => {
 
   it('dispatches to fcfMargin color', () => {
     expect(getFundamentalColor(12, 'fcfMargin')).toBe('text-green-500');
+  });
+
+  it('dispatches to cfoYield color', () => {
+    expect(getFundamentalColor(6, 'cfoYield')).toBe('text-green-500');
+  });
+
+  it('dispatches to cfoMargin color', () => {
+    expect(getFundamentalColor(12, 'cfoMargin')).toBe('text-green-500');
   });
 });

--- a/apps/ts/packages/web/src/utils/color-schemes.ts
+++ b/apps/ts/packages/web/src/utils/color-schemes.ts
@@ -70,6 +70,16 @@ export function getReturnColor(value: number | null | undefined): string {
   return 'text-muted-foreground';
 }
 
+function getTieredHigherIsBetterColor(
+  value: number,
+  excellentThreshold: number,
+  acceptableThreshold: number
+): string {
+  if (value >= excellentThreshold) return 'text-green-500';
+  if (value >= acceptableThreshold) return 'text-yellow-500';
+  return 'text-red-500';
+}
+
 /**
  * Get color class for FCF Yield values (higher is better).
  * - >= 5%: Green (excellent)
@@ -78,9 +88,7 @@ export function getReturnColor(value: number | null | undefined): string {
  * - Negative: Red
  */
 export function getFcfYieldColor(value: number): string {
-  if (value >= 5) return 'text-green-500';
-  if (value >= 2) return 'text-yellow-500';
-  return 'text-red-500';
+  return getTieredHigherIsBetterColor(value, 5, 2);
 }
 
 /**
@@ -91,15 +99,44 @@ export function getFcfYieldColor(value: number): string {
  * - Negative: Red
  */
 export function getFcfMarginColor(value: number): string {
-  if (value >= 10) return 'text-green-500';
-  if (value >= 5) return 'text-yellow-500';
-  return 'text-red-500';
+  return getTieredHigherIsBetterColor(value, 10, 5);
+}
+
+/**
+ * Get color class for CFO Yield values (higher is better).
+ * - >= 5%: Green (excellent)
+ * - >= 2%: Yellow (acceptable)
+ * - < 2%: Red (poor)
+ * - Negative: Red
+ */
+export function getCfoYieldColor(value: number): string {
+  return getTieredHigherIsBetterColor(value, 5, 2);
+}
+
+/**
+ * Get color class for CFO Margin values (higher is better).
+ * - >= 10%: Green (excellent)
+ * - >= 5%: Yellow (acceptable)
+ * - < 5%: Red (poor)
+ * - Negative: Red
+ */
+export function getCfoMarginColor(value: number): string {
+  return getTieredHigherIsBetterColor(value, 10, 5);
 }
 
 /**
  * Color scheme types for fundamental metrics
  */
-export type FundamentalColorScheme = 'roe' | 'per' | 'pbr' | 'cashFlow' | 'fcfYield' | 'fcfMargin' | 'neutral';
+export type FundamentalColorScheme =
+  | 'roe'
+  | 'per'
+  | 'pbr'
+  | 'cashFlow'
+  | 'fcfYield'
+  | 'fcfMargin'
+  | 'cfoYield'
+  | 'cfoMargin'
+  | 'neutral';
 
 /**
  * Get color class for fundamental metrics based on scheme type.
@@ -122,6 +159,10 @@ export function getFundamentalColor(value: number | null, scheme: FundamentalCol
       return getFcfYieldColor(value);
     case 'fcfMargin':
       return getFcfMarginColor(value);
+    case 'cfoYield':
+      return getCfoYieldColor(value);
+    case 'cfoMargin':
+      return getCfoMarginColor(value);
     default:
       return 'text-foreground';
   }


### PR DESCRIPTION
## Summary
- add `cfoYield` and `cfoMargin` to bt fundamentals schema/service output
- extend shared OpenAPI/types and generated bt client types
- add CFO yield/margin to chart fundamentals metric definitions and summary cards
- align color schemes with existing FCF yield/margin behavior and simplify duplicated threshold logic

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/server/services/test_fundamentals_service.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/server/routes/test_fundamentals.py tests/unit/server/test_routes_analytics_fundamentals.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/server/schemas/fundamentals.py src/server/services/fundamentals_service.py tests/server/services/test_fundamentals_service.py`
- `bun run --filter @trading25/web test src/components/Chart/FundamentalsSummaryCard.test.tsx src/utils/color-schemes.test.ts src/pages/ChartsPage.test.tsx`
- `bun run --filter @trading25/web typecheck`
- `bun run --filter @trading25/shared typecheck`
- `bun run --filter @trading25/shared bt:check`
