### PR TITLE
feat(bt): add cfo/fcf margin fundamental signals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ uv run pyright src/              # 型チェック
 - Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
 - `/api/optimize/jobs/{id}` は `best_score` / `total_combinations` に加えて `best_params` / `worst_score` / `worst_params` を返し、最適化ジョブ結果カードで best/worst 条件を比較表示できる
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
+- Fundamental signal system は `cfo_margin` / `simple_fcf_margin`（売上高比マージン判定）をサポートし、`OperatingCashFlow` / `InvestingCashFlow` / `Sales` をデータ要件とする
 - Strategy group 再振り分けは `/api/strategies/{strategy_name}/move`（`target_category`: `production` / `experimental` / `legacy`）を SoT とし、web の `Backtest > Strategies` から実行する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest

--- a/apps/bt/src/models/signals/fundamental.py
+++ b/apps/bt/src/models/signals/fundamental.py
@@ -249,6 +249,36 @@ class FundamentalSignalParams(BaseSignalParams):
             description="連続期間数（直近N回分の決算発表で条件を満たす必要がある）",
         )
 
+    class CFOMarginParams(BaseModel):
+        """CFOマージン（営業CF/売上高）シグナルパラメータ"""
+
+        enabled: bool = Field(default=False, description="CFOマージンシグナル有効")
+        threshold: float = Field(
+            default=5.0,
+            ge=-100.0,
+            le=100.0,
+            description="CFOマージン閾値（この値以上で高CFOマージン判定、%単位）",
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値以下）",
+        )
+
+    class SimpleFCFMarginParams(BaseModel):
+        """簡易FCFマージン（(CFO+CFI)/売上高）シグナルパラメータ"""
+
+        enabled: bool = Field(default=False, description="簡易FCFマージンシグナル有効")
+        threshold: float = Field(
+            default=5.0,
+            ge=-100.0,
+            le=100.0,
+            description="簡易FCFマージン閾値（この値以上で高FCFマージン判定、%単位）",
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値以下）",
+        )
+
     # =========================================================================
     # 時価総額系パラメータ
     # =========================================================================
@@ -404,6 +434,12 @@ class FundamentalSignalParams(BaseSignalParams):
     )
     simple_fcf: SimpleFCFParams = Field(
         default_factory=SimpleFCFParams, description="簡易FCF（CFO+CFI）シグナル"
+    )
+    cfo_margin: CFOMarginParams = Field(
+        default_factory=CFOMarginParams, description="CFOマージンシグナル"
+    )
+    simple_fcf_margin: SimpleFCFMarginParams = Field(
+        default_factory=SimpleFCFMarginParams, description="簡易FCFマージンシグナル"
     )
 
     # 利回り系

--- a/apps/bt/src/strategies/signals/fundamental.py
+++ b/apps/bt/src/strategies/signals/fundamental.py
@@ -53,11 +53,13 @@ from .fundamental_quality import (
 
 # キャッシュフロー系・時価総額系シグナル
 from .fundamental_cashflow import (
+    cfo_margin_threshold,
     cfo_yield_threshold,
     is_growing_cfo_yield,
     is_growing_simple_fcf_yield,
     market_cap_threshold,
     operating_cash_flow_threshold,
+    simple_fcf_margin_threshold,
     simple_fcf_threshold,
     simple_fcf_yield_threshold,
 )
@@ -86,6 +88,8 @@ __all__ = [
     # キャッシュフロー系・時価総額系
     "operating_cash_flow_threshold",
     "simple_fcf_threshold",
+    "cfo_margin_threshold",
+    "simple_fcf_margin_threshold",
     "cfo_yield_threshold",
     "simple_fcf_yield_threshold",
     "is_growing_cfo_yield",

--- a/apps/bt/tests/server/test_signal_reference.py
+++ b/apps/bt/tests/server/test_signal_reference.py
@@ -80,6 +80,8 @@ class TestBuildSignalReference:
         result = build_signal_reference()
         keys = {s["key"] for s in result["signals"]}
         assert "fundamental_dividend_per_share_growth" in keys
+        assert "fundamental_cfo_margin" in keys
+        assert "fundamental_simple_fcf_margin" in keys
         assert "fundamental_cfo_yield_growth" in keys
         assert "fundamental_simple_fcf_yield_growth" in keys
 

--- a/apps/bt/tests/unit/strategies/signals/test_registry.py
+++ b/apps/bt/tests/unit/strategies/signals/test_registry.py
@@ -210,6 +210,25 @@ class TestSignalRegistry:
         assert "statements:InvestingCashFlow" in sig.data_requirements
         assert "statements:SharesOutstanding" in sig.data_requirements
 
+    def test_cfo_margin_registered(self) -> None:
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.cfo_margin"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "CFOマージン"
+        assert sig.category == "fundamental"
+        assert "statements:OperatingCashFlow" in sig.data_requirements
+        assert "statements:Sales" in sig.data_requirements
+
+    def test_simple_fcf_margin_registered(self) -> None:
+        matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.simple_fcf_margin"]
+        assert len(matches) == 1
+        sig = matches[0]
+        assert sig.name == "簡易FCFマージン"
+        assert sig.category == "fundamental"
+        assert "statements:OperatingCashFlow" in sig.data_requirements
+        assert "statements:InvestingCashFlow" in sig.data_requirements
+        assert "statements:Sales" in sig.data_requirements
+
     def test_roa_registered(self) -> None:
         """roa（総資産利益率）がレジストリに登録されていること"""
         matches = [s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.roa"]
@@ -258,6 +277,20 @@ class TestSignalRegistry:
         assert sig.enabled_checker(params)
 
         params.fundamental.cfo_yield_growth.enabled = False
+        assert not sig.enabled_checker(params)
+
+    def test_cfo_margin_enabled_checker(self) -> None:
+        sig = next(s for s in SIGNAL_REGISTRY if s.param_key == "fundamental.cfo_margin")
+
+        params = SignalParams()
+        params.fundamental.enabled = False
+        params.fundamental.cfo_margin.enabled = True
+        assert not sig.enabled_checker(params)
+
+        params.fundamental.enabled = True
+        assert sig.enabled_checker(params)
+
+        params.fundamental.cfo_margin.enabled = False
         assert not sig.enabled_checker(params)
 
     def test_risk_adjusted_return_registered_as_volatility(self) -> None:

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -7490,7 +7490,7 @@
                   "additionalProperties": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/OHLCVRecord"
+                      "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                     }
                   },
                   "title": "Response Get Dataset Ohlcv Batch Api Dataset  Name  Stocks Ohlcv Batch Get"
@@ -7610,7 +7610,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/OHLCVRecord"
+                    "$ref": "#/components/schemas/src__server__schemas__dataset_data__OHLCVRecord"
                   },
                   "title": "Response Get Dataset Stock Ohlcv Api Dataset  Name  Stocks  Code  Ohlcv Get"
                 }
@@ -12516,7 +12516,7 @@
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/DateRange"
+                "$ref": "#/components/schemas/src__server__schemas__dataset__DateRange"
               },
               {
                 "type": "null"
@@ -12564,19 +12564,19 @@
       },
       "DateRange": {
         "properties": {
-          "min": {
+          "from": {
             "type": "string",
-            "title": "Min"
+            "title": "From"
           },
-          "max": {
+          "to": {
             "type": "string",
-            "title": "Max"
+            "title": "To"
           }
         },
         "type": "object",
         "required": [
-          "min",
-          "max"
+          "from",
+          "to"
         ],
         "title": "DateRange"
       },
@@ -12727,21 +12727,21 @@
           },
           "sector17Matches": {
             "items": {
-              "$ref": "#/components/schemas/IndexMatch"
+              "$ref": "#/components/schemas/src__server__schemas__factor_regression__IndexMatch"
             },
             "type": "array",
             "title": "Sector17Matches"
           },
           "sector33Matches": {
             "items": {
-              "$ref": "#/components/schemas/IndexMatch"
+              "$ref": "#/components/schemas/src__server__schemas__factor_regression__IndexMatch"
             },
             "type": "array",
             "title": "Sector33Matches"
           },
           "topixStyleMatches": {
             "items": {
-              "$ref": "#/components/schemas/IndexMatch"
+              "$ref": "#/components/schemas/src__server__schemas__factor_regression__IndexMatch"
             },
             "type": "array",
             "title": "Topixstylematches"
@@ -14180,37 +14180,26 @@
       },
       "IndexMatch": {
         "properties": {
-          "indexCode": {
+          "code": {
             "type": "string",
-            "title": "Indexcode"
+            "title": "Code"
           },
-          "indexName": {
+          "name": {
             "type": "string",
-            "title": "Indexname"
-          },
-          "category": {
-            "type": "string",
-            "title": "Category"
+            "title": "Name"
           },
           "rSquared": {
             "type": "number",
             "title": "Rsquared"
-          },
-          "beta": {
-            "type": "number",
-            "title": "Beta"
           }
         },
         "type": "object",
         "required": [
-          "indexCode",
-          "indexName",
-          "category",
-          "rSquared",
-          "beta"
+          "code",
+          "name",
+          "rSquared"
         ],
-        "title": "IndexMatch",
-        "description": "指数マッチ結果"
+        "title": "IndexMatch"
       },
       "IndexOHLCRecord": {
         "properties": {
@@ -16221,27 +16210,33 @@
         "properties": {
           "date": {
             "type": "string",
-            "title": "Date"
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
           },
           "open": {
             "type": "number",
-            "title": "Open"
+            "title": "Open",
+            "description": "始値"
           },
           "high": {
             "type": "number",
-            "title": "High"
+            "title": "High",
+            "description": "高値"
           },
           "low": {
             "type": "number",
-            "title": "Low"
+            "title": "Low",
+            "description": "安値"
           },
           "close": {
             "type": "number",
-            "title": "Close"
+            "title": "Close",
+            "description": "終値"
           },
           "volume": {
-            "type": "integer",
-            "title": "Volume"
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
           }
         },
         "type": "object",
@@ -16253,7 +16248,8 @@
           "close",
           "volume"
         ],
-        "title": "OHLCVRecord"
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
       },
       "OHLCVResampleRequest": {
         "properties": {
@@ -16374,7 +16370,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__indicators__OHLCVRecord"
+              "$ref": "#/components/schemas/OHLCVRecord"
             },
             "type": "array",
             "title": "Data",
@@ -16975,21 +16971,21 @@
           },
           "sector17Matches": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__IndexMatch"
+              "$ref": "#/components/schemas/IndexMatch"
             },
             "type": "array",
             "title": "Sector17Matches"
           },
           "sector33Matches": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__IndexMatch"
+              "$ref": "#/components/schemas/IndexMatch"
             },
             "type": "array",
             "title": "Sector33Matches"
           },
           "topixStyleMatches": {
             "items": {
-              "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__IndexMatch"
+              "$ref": "#/components/schemas/IndexMatch"
             },
             "type": "array",
             "title": "Topixstylematches"
@@ -17003,7 +16999,7 @@
             "title": "Datapoints"
           },
           "dateRange": {
-            "$ref": "#/components/schemas/src__server__schemas__portfolio_factor_regression__DateRange"
+            "$ref": "#/components/schemas/DateRange"
           },
           "excludedStocks": {
             "items": {
@@ -21863,6 +21859,62 @@
         "type": "object",
         "title": "WatchlistUpdateRequest"
       },
+      "src__server__schemas__dataset__DateRange": {
+        "properties": {
+          "min": {
+            "type": "string",
+            "title": "Min"
+          },
+          "max": {
+            "type": "string",
+            "title": "Max"
+          }
+        },
+        "type": "object",
+        "required": [
+          "min",
+          "max"
+        ],
+        "title": "DateRange"
+      },
+      "src__server__schemas__dataset_data__OHLCVRecord": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date"
+          },
+          "open": {
+            "type": "number",
+            "title": "Open"
+          },
+          "high": {
+            "type": "number",
+            "title": "High"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close"
+          },
+          "volume": {
+            "type": "integer",
+            "title": "Volume"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
+        ],
+        "title": "OHLCVRecord"
+      },
       "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
@@ -21900,91 +21952,39 @@
         "title": "DateRange",
         "description": "分析期間"
       },
-      "src__server__schemas__indicators__OHLCVRecord": {
+      "src__server__schemas__factor_regression__IndexMatch": {
         "properties": {
-          "date": {
+          "indexCode": {
             "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
+            "title": "Indexcode"
           },
-          "open": {
-            "type": "number",
-            "title": "Open",
-            "description": "始値"
-          },
-          "high": {
-            "type": "number",
-            "title": "High",
-            "description": "高値"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low",
-            "description": "安値"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close",
-            "description": "終値"
-          },
-          "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
-        ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
-      },
-      "src__server__schemas__portfolio_factor_regression__DateRange": {
-        "properties": {
-          "from": {
+          "indexName": {
             "type": "string",
-            "title": "From"
+            "title": "Indexname"
           },
-          "to": {
+          "category": {
             "type": "string",
-            "title": "To"
-          }
-        },
-        "type": "object",
-        "required": [
-          "from",
-          "to"
-        ],
-        "title": "DateRange"
-      },
-      "src__server__schemas__portfolio_factor_regression__IndexMatch": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
+            "title": "Category"
           },
           "rSquared": {
             "type": "number",
             "title": "Rsquared"
+          },
+          "beta": {
+            "type": "number",
+            "title": "Beta"
           }
         },
         "type": "object",
         "required": [
-          "code",
-          "name",
-          "rSquared"
+          "indexCode",
+          "indexName",
+          "category",
+          "rSquared",
+          "beta"
         ],
-        "title": "IndexMatch"
+        "title": "IndexMatch",
+        "description": "指数マッチ結果"
       },
       "src__server__schemas__portfolio_performance__DateRange": {
         "properties": {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -3075,7 +3075,7 @@ export interface components {
              * @description Stocks with OHLCV data
              */
             stocksWithQuotes: number;
-            dateRange?: components["schemas"]["DateRange"] | null;
+            dateRange?: components["schemas"]["src__server__schemas__dataset__DateRange"] | null;
             validation: components["schemas"]["DatasetValidation"];
         };
         /** DatasetValidation */
@@ -3089,10 +3089,10 @@ export interface components {
         };
         /** DateRange */
         DateRange: {
-            /** Min */
-            min: string;
-            /** Max */
-            max: string;
+            /** From */
+            from: string;
+            /** To */
+            to: string;
         };
         /**
          * DefaultConfigResponse
@@ -3189,11 +3189,11 @@ export interface components {
             /** Marketrsquared */
             marketRSquared: number;
             /** Sector17Matches */
-            sector17Matches: components["schemas"]["IndexMatch"][];
+            sector17Matches: components["schemas"]["src__server__schemas__factor_regression__IndexMatch"][];
             /** Sector33Matches */
-            sector33Matches: components["schemas"]["IndexMatch"][];
+            sector33Matches: components["schemas"]["src__server__schemas__factor_regression__IndexMatch"][];
             /** Topixstylematches */
-            topixStyleMatches: components["schemas"]["IndexMatch"][];
+            topixStyleMatches: components["schemas"]["src__server__schemas__factor_regression__IndexMatch"][];
             /** Analysisdate */
             analysisDate: string;
             /** Datapoints */
@@ -3930,21 +3930,14 @@ export interface components {
              */
             end_date?: string | null;
         };
-        /**
-         * IndexMatch
-         * @description 指数マッチ結果
-         */
+        /** IndexMatch */
         IndexMatch: {
-            /** Indexcode */
-            indexCode: string;
-            /** Indexname */
-            indexName: string;
-            /** Category */
-            category: string;
+            /** Code */
+            code: string;
+            /** Name */
+            name: string;
             /** Rsquared */
             rSquared: number;
-            /** Beta */
-            beta: number;
         };
         /**
          * IndexOHLCRecord
@@ -4964,19 +4957,40 @@ export interface components {
             /** Close */
             close: number;
         };
-        /** OHLCVRecord */
+        /**
+         * OHLCVRecord
+         * @description OHLCVレコード
+         */
         OHLCVRecord: {
-            /** Date */
+            /**
+             * Date
+             * @description 日付 (YYYY-MM-DD)
+             */
             date: string;
-            /** Open */
+            /**
+             * Open
+             * @description 始値
+             */
             open: number;
-            /** High */
+            /**
+             * High
+             * @description 高値
+             */
             high: number;
-            /** Low */
+            /**
+             * Low
+             * @description 安値
+             */
             low: number;
-            /** Close */
+            /**
+             * Close
+             * @description 終値
+             */
             close: number;
-            /** Volume */
+            /**
+             * Volume
+             * @description 出来高
+             */
             volume: number;
         };
         /**
@@ -5055,7 +5069,7 @@ export interface components {
              * Data
              * @description OHLCVデータ
              */
-            data: components["schemas"]["src__server__schemas__indicators__OHLCVRecord"][];
+            data: components["schemas"]["OHLCVRecord"][];
         };
         /**
          * OptimizationGridConfig
@@ -5397,16 +5411,16 @@ export interface components {
             /** Marketrsquared */
             marketRSquared: number;
             /** Sector17Matches */
-            sector17Matches: components["schemas"]["src__server__schemas__portfolio_factor_regression__IndexMatch"][];
+            sector17Matches: components["schemas"]["IndexMatch"][];
             /** Sector33Matches */
-            sector33Matches: components["schemas"]["src__server__schemas__portfolio_factor_regression__IndexMatch"][];
+            sector33Matches: components["schemas"]["IndexMatch"][];
             /** Topixstylematches */
-            topixStyleMatches: components["schemas"]["src__server__schemas__portfolio_factor_regression__IndexMatch"][];
+            topixStyleMatches: components["schemas"]["IndexMatch"][];
             /** Analysisdate */
             analysisDate: string;
             /** Datapoints */
             dataPoints: number;
-            dateRange: components["schemas"]["src__server__schemas__portfolio_factor_regression__DateRange"];
+            dateRange: components["schemas"]["DateRange"];
             /** Excludedstocks */
             excludedStocks: components["schemas"]["ExcludedStock"][];
         };
@@ -7471,6 +7485,28 @@ export interface components {
             description?: string | null;
         };
         /** DateRange */
+        src__server__schemas__dataset__DateRange: {
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
+        };
+        /** OHLCVRecord */
+        src__server__schemas__dataset_data__OHLCVRecord: {
+            /** Date */
+            date: string;
+            /** Open */
+            open: number;
+            /** High */
+            high: number;
+            /** Low */
+            low: number;
+            /** Close */
+            close: number;
+            /** Volume */
+            volume: number;
+        };
+        /** DateRange */
         src__server__schemas__db__DateRange: {
             /** Min */
             min: string;
@@ -7488,56 +7524,20 @@ export interface components {
             to: string;
         };
         /**
-         * OHLCVRecord
-         * @description OHLCVレコード
+         * IndexMatch
+         * @description 指数マッチ結果
          */
-        src__server__schemas__indicators__OHLCVRecord: {
-            /**
-             * Date
-             * @description 日付 (YYYY-MM-DD)
-             */
-            date: string;
-            /**
-             * Open
-             * @description 始値
-             */
-            open: number;
-            /**
-             * High
-             * @description 高値
-             */
-            high: number;
-            /**
-             * Low
-             * @description 安値
-             */
-            low: number;
-            /**
-             * Close
-             * @description 終値
-             */
-            close: number;
-            /**
-             * Volume
-             * @description 出来高
-             */
-            volume: number;
-        };
-        /** DateRange */
-        src__server__schemas__portfolio_factor_regression__DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
-        };
-        /** IndexMatch */
-        src__server__schemas__portfolio_factor_regression__IndexMatch: {
-            /** Code */
-            code: string;
-            /** Name */
-            name: string;
+        src__server__schemas__factor_regression__IndexMatch: {
+            /** Indexcode */
+            indexCode: string;
+            /** Indexname */
+            indexName: string;
+            /** Category */
+            category: string;
             /** Rsquared */
             rSquared: number;
+            /** Beta */
+            beta: number;
         };
         /** DateRange */
         src__server__schemas__portfolio_performance__DateRange: {
@@ -13010,7 +13010,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: components["schemas"]["OHLCVRecord"][];
+                        [key: string]: components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                     };
                 };
             };
@@ -13073,7 +13073,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["OHLCVRecord"][];
+                    "application/json": components["schemas"]["src__server__schemas__dataset_data__OHLCVRecord"][];
                 };
             };
             /** @description Bad Request */


### PR DESCRIPTION
## Summary
- add cfo_margin and simple_fcf_margin to bt fundamental signal params
- implement margin signal functions and wire them into signal registry/export
- add unit tests and signal reference assertions
- sync shared OpenAPI/types via bt:sync
- update AGENTS.md with the new fundamental signal support

## Validation
- uv run pytest tests/unit/strategies/signals/test_fundamental.py tests/unit/strategies/signals/test_registry.py tests/server/test_signal_reference.py
- uv run pyright src/models/signals/fundamental.py src/strategies/signals/fundamental_cashflow.py src/strategies/signals/registry.py
- uv run ruff check src/strategies/signals/fundamental_cashflow.py tests/unit/strategies/signals/test_fundamental.py
- uv run coverage run --branch -m pytest tests/unit/strategies/signals/test_fundamental.py tests/unit/strategies/signals/test_registry.py tests/server/test_signal_reference.py
- uv run coverage report -m --include=src/strategies/signals/fundamental_cashflow.py,src/strategies/signals/registry.py,src/models/signals/fundamental.py
