### PR TITLE
fix(web): require companyName for stock add payloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ bun run cli backtest attribution run <strategy> --wait
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 - `analysis screening`（web/cli）は production 戦略を動的選択し、非同期ジョブ（2秒ポーリング）で実行する。`sortBy` 既定は `matchedDate`、`order` 既定は `desc`。`backtestMetric` は廃止
 - Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Fundamental Metrics / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集し、Fundamentals パネル内部の指標は `fundamentalsMetricOrder` / `fundamentalsMetricVisibility` で順序・表示ON/OFFを保持する。Fundamentals パネル高さは表示中指標数に応じて動的に変化する
-- Portfolio / Watchlist の銘柄追加入力はチャート検索と同等の銘柄サーチ（コード/銘柄名）を使う。Watchlist 追加の送信は 4 桁コードのみ許可する
+- Portfolio / Watchlist の銘柄追加入力はチャート検索と同等の銘柄サーチ（コード/銘柄名）を使う。追加送信 payload は `companyName` 必須（候補選択時は候補名、未選択時はコードをフォールバック）。Watchlist 追加の送信は 4 桁コードのみ許可する
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/apps/ts/packages/web/src/components/Portfolio/AddStockDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Portfolio/AddStockDialog.test.tsx
@@ -1,0 +1,187 @@
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAddPortfolioItem } from '@/hooks/usePortfolio';
+import { AddStockDialog } from './AddStockDialog';
+
+const mockMutate = vi.fn();
+const mockValidateStockForm = vi.fn((data: { code?: string; purchasePrice: string }) =>
+  Boolean((data.code || '').trim()) && data.purchasePrice.length > 0
+);
+
+vi.mock('@/hooks/usePortfolio', () => ({
+  useAddPortfolioItem: vi.fn(),
+}));
+
+vi.mock('./StockFormFields', () => ({
+  StockFormFields: ({
+    data,
+    onChange,
+    onStockSelect,
+  }: {
+    data: {
+      code?: string;
+      quantity: string;
+      purchasePrice: string;
+      purchaseDate: string;
+      account: string;
+      notes: string;
+    };
+    onChange: (next: {
+      code?: string;
+      quantity: string;
+      purchasePrice: string;
+      purchaseDate: string;
+      account: string;
+      notes: string;
+    }) => void;
+    onStockSelect?: (stock: { code: string; companyName: string }) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onChange({
+            ...data,
+            code: '7203',
+            quantity: '100',
+            purchasePrice: '2500',
+            purchaseDate: '2026-02-19',
+            account: '',
+            notes: '',
+          })
+        }
+      >
+        Fill7203
+      </button>
+      <button type="button" onClick={() => onStockSelect?.({ code: '7203', companyName: 'Toyota Motor' })}>
+        SelectToyota
+      </button>
+      <button type="button" onClick={() => onChange({ ...data, code: '6501' })}>
+        ChangeCode6501
+      </button>
+    </div>
+  ),
+  validateStockForm: (data: { code?: string; purchasePrice: string }) => mockValidateStockForm(data),
+}));
+
+describe('AddStockDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAddPortfolioItem).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useAddPortfolioItem>);
+  });
+
+  it('submits selected company name when search candidate is selected', async () => {
+    const user = userEvent.setup();
+    render(<AddStockDialog portfolioId={1} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add Stock' }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(screen.getByRole('button', { name: 'Fill7203' }));
+    await user.click(screen.getByRole('button', { name: 'SelectToyota' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Add Stock' }));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        portfolioId: 1,
+        data: expect.objectContaining({
+          code: '7203',
+          companyName: 'Toyota Motor',
+          quantity: 100,
+          purchasePrice: 2500,
+        }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('falls back to code as companyName when code diverges from selected stock', async () => {
+    const user = userEvent.setup();
+    render(<AddStockDialog portfolioId={1} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add Stock' }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(screen.getByRole('button', { name: 'Fill7203' }));
+    await user.click(screen.getByRole('button', { name: 'SelectToyota' }));
+    await user.click(screen.getByRole('button', { name: 'ChangeCode6501' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Add Stock' }));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          code: '6501',
+          companyName: '6501',
+        }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('resets selected stock when dialog is closed', async () => {
+    const user = userEvent.setup();
+    render(<AddStockDialog portfolioId={1} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add Stock' }));
+    await user.click(screen.getByRole('button', { name: 'Fill7203' }));
+    await user.click(screen.getByRole('button', { name: 'SelectToyota' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await user.click(screen.getByRole('button', { name: 'Add Stock' }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(screen.getByRole('button', { name: 'Fill7203' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Add Stock' }));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          code: '7203',
+          companyName: '7203',
+        }),
+      }),
+      expect.any(Object)
+    );
+
+    const callback = mockMutate.mock.calls[0]?.[1];
+    if (callback?.onSuccess) {
+      await act(async () => {
+        callback.onSuccess();
+      });
+    }
+  });
+
+  it('does not submit when form is invalid', async () => {
+    const user = userEvent.setup();
+    render(<AddStockDialog portfolioId={1} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add Stock' }));
+    const dialog = screen.getByRole('dialog');
+    const submitButton = within(dialog).getByRole('button', { name: 'Add Stock' });
+
+    expect(submitButton).toBeDisabled();
+    await user.click(submitButton);
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('renders mutation error and pending state', async () => {
+    vi.mocked(useAddPortfolioItem).mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+      error: new Error('Failed to add'),
+    } as unknown as ReturnType<typeof useAddPortfolioItem>);
+
+    const user = userEvent.setup();
+    render(<AddStockDialog portfolioId={1} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add Stock' }));
+    const dialog = screen.getByRole('dialog');
+
+    expect(within(dialog).getByText('Failed to add')).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Add Stock' })).toBeDisabled();
+    expect(document.querySelector('.animate-spin')).toBeTruthy();
+  });
+});

--- a/apps/ts/packages/web/src/components/Portfolio/StockFormFields.tsx
+++ b/apps/ts/packages/web/src/components/Portfolio/StockFormFields.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { StockSearchInput } from '@/components/Stock/StockSearchInput';
+import type { StockSearchResultItem } from '@/hooks/useStockSearch';
 
 export interface StockFormData {
   code?: string;
@@ -16,9 +17,16 @@ interface StockFormFieldsProps {
   onChange: (data: StockFormData) => void;
   showCodeField?: boolean;
   idPrefix?: string;
+  onStockSelect?: (stock: StockSearchResultItem) => void;
 }
 
-export function StockFormFields({ data, onChange, showCodeField = true, idPrefix = 'stock' }: StockFormFieldsProps) {
+export function StockFormFields({
+  data,
+  onChange,
+  showCodeField = true,
+  idPrefix = 'stock',
+  onStockSelect,
+}: StockFormFieldsProps) {
   const updateField = <K extends keyof StockFormData>(field: K, value: StockFormData[K]) => {
     onChange({ ...data, [field]: value });
   };
@@ -33,7 +41,10 @@ export function StockFormFields({ data, onChange, showCodeField = true, idPrefix
               id={`${idPrefix}-code`}
               value={data.code || ''}
               onValueChange={(value) => updateField('code', value)}
-              onSelect={(stock) => updateField('code', stock.code)}
+              onSelect={(stock) => {
+                updateField('code', stock.code);
+                onStockSelect?.(stock);
+              }}
               placeholder="銘柄コードまたは会社名で検索..."
               required
               autoFocus

--- a/apps/ts/packages/web/src/components/Watchlist/WatchlistDetail.test.tsx
+++ b/apps/ts/packages/web/src/components/Watchlist/WatchlistDetail.test.tsx
@@ -108,7 +108,7 @@ describe('WatchlistDetail', () => {
     await user.click(screen.getByRole('button', { name: 'Add' }));
 
     expect(mockAddItemMutate).toHaveBeenCalledWith(
-      { watchlistId: 1, data: { code: '6501', memo: 'watch' } },
+      { watchlistId: 1, data: { code: '6501', companyName: '6501', memo: 'watch' } },
       expect.any(Object)
     );
   });
@@ -139,7 +139,7 @@ describe('WatchlistDetail', () => {
     await user.click(screen.getByRole('button', { name: 'Add' }));
 
     expect(mockAddItemMutate).toHaveBeenCalledWith(
-      { watchlistId: 1, data: { code: '6501', memo: undefined } },
+      { watchlistId: 1, data: { code: '6501', companyName: 'Hitachi', memo: undefined } },
       expect.any(Object)
     );
   });

--- a/apps/ts/packages/web/src/hooks/usePortfolio.test.tsx
+++ b/apps/ts/packages/web/src/hooks/usePortfolio.test.tsx
@@ -123,6 +123,7 @@ describe('usePortfolio hooks', () => {
 
     const data: CreatePortfolioItemRequest = {
       code: '7203',
+      companyName: 'Toyota Motor',
       quantity: 100,
       purchasePrice: 2500,
       purchaseDate: '2025-01-30',

--- a/apps/ts/packages/web/src/hooks/useWatchlist.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useWatchlist.test.tsx
@@ -102,9 +102,9 @@ describe('useWatchlist hooks', () => {
     const spy = vi.spyOn(queryClient, 'invalidateQueries');
     const { result } = renderHook(() => useAddWatchlistItem(), { wrapper });
     await act(async () => {
-      await result.current.mutateAsync({ watchlistId: 1, data: { code: '7203' } });
+      await result.current.mutateAsync({ watchlistId: 1, data: { code: '7203', companyName: 'Toyota Motor' } });
     });
-    expect(apiPost).toHaveBeenCalledWith('/api/watchlist/1/items', { code: '7203' });
+    expect(apiPost).toHaveBeenCalledWith('/api/watchlist/1/items', { code: '7203', companyName: 'Toyota Motor' });
     expect(spy).toHaveBeenCalledWith({ queryKey: ['watchlist', 1] });
     expect(spy).toHaveBeenCalledWith({ queryKey: ['watchlist-prices', 1] });
   });

--- a/apps/ts/packages/web/src/types/portfolio.ts
+++ b/apps/ts/packages/web/src/types/portfolio.ts
@@ -30,7 +30,7 @@ export interface UpdatePortfolioRequest {
 
 export interface CreatePortfolioItemRequest {
   code: string;
-  companyName?: string;
+  companyName: string;
   quantity: number;
   purchasePrice: number;
   purchaseDate: string;

--- a/apps/ts/packages/web/src/types/watchlist.ts
+++ b/apps/ts/packages/web/src/types/watchlist.ts
@@ -31,6 +31,6 @@ export interface UpdateWatchlistRequest {
 
 export interface CreateWatchlistItemRequest {
   code: string;
-  companyName?: string;
+  companyName: string;
   memo?: string;
 }


### PR DESCRIPTION
## Summary
- always include companyName in portfolio/watchlist add-stock payloads to match FastAPI validation contract
- preserve selected search candidate company name and fallback to stock code when candidate is not selected
- reset selected candidate state on dialog close (Cancel) to avoid stale payload data
- align web request types and hook tests with required companyName
- add AddStockDialog tests and update related tests

## Validation
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test src/components/Portfolio/AddStockDialog.test.tsx src/components/Portfolio/StockFormFields.test.tsx src/components/Watchlist/WatchlistDetail.test.tsx src/hooks/usePortfolio.test.tsx src/hooks/useWatchlist.test.tsx
- bun run test --coverage --coverage.reporter=text --coverage.include=src/components/Portfolio/AddStockDialog.tsx --coverage.include=src/components/Portfolio/StockFormFields.tsx --coverage.include=src/components/Watchlist/WatchlistDetail.tsx src/components/Portfolio/AddStockDialog.test.tsx src/components/Portfolio/StockFormFields.test.tsx src/components/Watchlist/WatchlistDetail.test.tsx