### PR TITLE
feat(bt): add cfo-to-net-profit fundamental signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ uv run pyright src/              # 型チェック
 - `/api/optimize/jobs/{id}` は `best_score` / `total_combinations` に加えて `best_params` / `worst_score` / `worst_params` を返し、最適化ジョブ結果カードで best/worst 条件を比較表示できる
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
 - Fundamental signal system は `cfo_margin` / `simple_fcf_margin`（売上高比マージン判定）をサポートし、`OperatingCashFlow` / `InvestingCashFlow` / `Sales` をデータ要件とする
+- Fundamental signal は `cfo_to_net_profit_ratio`（営業CF/純利益）をサポートし、`consecutive_periods` 判定は比率値同値時でも開示更新（OperatingCashFlow/Profit）を起点に連続判定する
 - Strategy group 再振り分けは `/api/strategies/{strategy_name}/move`（`target_category`: `production` / `experimental` / `legacy`）を SoT とし、web の `Backtest > Strategies` から実行する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest

--- a/apps/bt/src/models/signals/fundamental.py
+++ b/apps/bt/src/models/signals/fundamental.py
@@ -215,6 +215,28 @@ class FundamentalSignalParams(BaseSignalParams):
             description="連続期間数（直近N回分の決算発表で条件を満たす必要がある）",
         )
 
+    class CFOToNetProfitRatioParams(BaseModel):
+        """営業CF/純利益シグナルパラメータ"""
+
+        enabled: bool = Field(
+            default=False,
+            description="営業CF/純利益シグナル有効",
+        )
+        threshold: float = Field(
+            default=1.0,
+            description="営業CF/純利益閾値（1.0以上は利益の質が高い目安）",
+        )
+        condition: Literal["above", "below"] = Field(
+            default="above",
+            description="条件（above=閾値以上、below=閾値未満）",
+        )
+        consecutive_periods: int = Field(
+            default=1,
+            ge=1,
+            le=10,
+            description="連続期間数（直近N回分の決算発表で条件を満たす必要がある）",
+        )
+
     class DividendYieldParams(BaseModel):
         """配当利回りシグナルパラメータ"""
 
@@ -428,6 +450,9 @@ class FundamentalSignalParams(BaseSignalParams):
     )
     operating_cash_flow: OperatingCashFlowParams = Field(
         default_factory=OperatingCashFlowParams, description="営業CFシグナル"
+    )
+    cfo_to_net_profit_ratio: CFOToNetProfitRatioParams = Field(
+        default_factory=CFOToNetProfitRatioParams, description="営業CF/純利益シグナル"
     )
     dividend_yield: DividendYieldParams = Field(
         default_factory=DividendYieldParams, description="配当利回りシグナル"

--- a/apps/bt/src/strategies/signals/fundamental.py
+++ b/apps/bt/src/strategies/signals/fundamental.py
@@ -55,6 +55,7 @@ from .fundamental_quality import (
 from .fundamental_cashflow import (
     cfo_margin_threshold,
     cfo_yield_threshold,
+    cfo_to_net_profit_ratio_threshold,
     is_growing_cfo_yield,
     is_growing_simple_fcf_yield,
     market_cap_threshold,
@@ -87,6 +88,7 @@ __all__ = [
     "is_high_dividend_yield",
     # キャッシュフロー系・時価総額系
     "operating_cash_flow_threshold",
+    "cfo_to_net_profit_ratio_threshold",
     "simple_fcf_threshold",
     "cfo_margin_threshold",
     "simple_fcf_margin_threshold",

--- a/apps/bt/src/strategies/signals/registry.py
+++ b/apps/bt/src/strategies/signals/registry.py
@@ -23,6 +23,7 @@ from .crossover import indicator_crossover_signal
 from .fundamental import (
     cfo_margin_threshold,
     cfo_yield_threshold,
+    cfo_to_net_profit_ratio_threshold,
     is_expected_growth_eps,
     is_growing_cfo_yield,
     is_growing_dividend_per_share,
@@ -864,6 +865,27 @@ SIGNAL_REGISTRY: list[SignalDefinition] = [
         param_key="fundamental.operating_cash_flow",
         data_checker=lambda d: _has_statements_column(d, "OperatingCashFlow"),
         data_requirements=["statements:OperatingCashFlow"],
+    ),
+    # 27-2. 営業CF/純利益シグナル
+    SignalDefinition(
+        name="営業CF/純利益",
+        signal_func=cfo_to_net_profit_ratio_threshold,
+        enabled_checker=lambda p: p.fundamental.enabled
+        and p.fundamental.cfo_to_net_profit_ratio.enabled,
+        param_builder=lambda p, d: {
+            "operating_cash_flow": d["statements_data"]["OperatingCashFlow"],
+            "net_profit": d["statements_data"]["Profit"],
+            "threshold": p.fundamental.cfo_to_net_profit_ratio.threshold,
+            "condition": p.fundamental.cfo_to_net_profit_ratio.condition,
+            "consecutive_periods": p.fundamental.cfo_to_net_profit_ratio.consecutive_periods,
+        },
+        entry_purpose="営業CF/純利益が閾値以上の企業を選定",
+        exit_purpose="営業CF/純利益が閾値を下回った企業を除外",
+        category="fundamental",
+        description="営業CF/純利益比率の閾値判定",
+        param_key="fundamental.cfo_to_net_profit_ratio",
+        data_checker=lambda d: _has_statements_columns(d, "OperatingCashFlow", "Profit"),
+        data_requirements=["statements:OperatingCashFlow", "statements:Profit"],
     ),
     # 28. 配当利回りシグナル
     SignalDefinition(

--- a/apps/bt/tests/server/test_signal_reference.py
+++ b/apps/bt/tests/server/test_signal_reference.py
@@ -82,6 +82,7 @@ class TestBuildSignalReference:
         assert "fundamental_dividend_per_share_growth" in keys
         assert "fundamental_cfo_margin" in keys
         assert "fundamental_simple_fcf_margin" in keys
+        assert "fundamental_cfo_to_net_profit_ratio" in keys
         assert "fundamental_cfo_yield_growth" in keys
         assert "fundamental_simple_fcf_yield_growth" in keys
 


### PR DESCRIPTION
## Summary
- add fundamental.cfo_to_net_profit_ratio signal parameter and registry wiring
- implement cfo_to_net_profit_ratio_threshold with release-aware consecutive_periods evaluation
- expand unit tests for new signal, edge cases, registry helpers, and signal reference
- update AGENTS.md with the new signal-system behavior

## Validation
- uv run pytest tests/unit/strategies/signals/test_fundamental.py tests/unit/strategies/signals/test_registry.py tests/server/test_signal_reference.py tests/server/test_schema_sync.py
- uv run coverage run --branch -m pytest tests/unit/strategies/signals/test_fundamental.py tests/unit/strategies/signals/test_registry.py tests/server/test_signal_reference.py tests/server/test_schema_sync.py
- uv run coverage report -m src/strategies/signals/fundamental_cashflow.py src/strategies/signals/registry.py src/models/signals/fundamental.py
- uv run ruff check src/strategies/signals/fundamental_cashflow.py tests/unit/strategies/signals/test_fundamental.py tests/unit/strategies/signals/test_registry.py