### PR TITLE
fix: prioritize revised forecast EPS in fundamentals

### DIFF
--- a/apps/bt/src/data/loaders/data_preparation.py
+++ b/apps/bt/src/data/loaders/data_preparation.py
@@ -332,7 +332,7 @@ def prepare_multi_data(
                             start_date,
                             end_date,
                             period_type="all",
-                            actual_only=True,
+                            actual_only=False,
                         )
                     except (ConnectionError, RuntimeError, BatchAPIError, APIError) as e:
                         logger.warning(

--- a/apps/bt/src/data/loaders/multi_asset_loaders.py
+++ b/apps/bt/src/data/loaders/multi_asset_loaders.py
@@ -260,7 +260,7 @@ def load_multiple_statements_data(
                         start_date,
                         end_date,
                         period_type="all",
-                        actual_only=True,
+                        actual_only=False,
                     )
                 except (ConnectionError, RuntimeError, BatchAPIError) as e:
                     logger.warning(f"財務諸表四半期修正バッチ取得失敗、FYのみで続行: {e}")

--- a/apps/bt/src/data/loaders/statements_loaders.py
+++ b/apps/bt/src/data/loaders/statements_loaders.py
@@ -364,7 +364,7 @@ def load_statements_data(
                     start_date,
                     end_date,
                     period_type="all",
-                    actual_only=actual_only,
+                    actual_only=False,
                 )
             except Exception as e:  # noqa: BLE001 - continue with FY-only baseline
                 logger.warning(

--- a/apps/bt/src/server/services/screening_market_loader.py
+++ b/apps/bt/src/server/services/screening_market_loader.py
@@ -302,7 +302,7 @@ def _attach_statements(
                 start_date=start_date,
                 end_date=end_date,
                 period_type="all",
-                actual_only=True,
+                actual_only=False,
             )
         except sqlite3.OperationalError as e:
             warnings.append(f"market statements revision load failed ({e})")

--- a/apps/bt/tests/unit/data/test_multi_asset_loaders.py
+++ b/apps/bt/tests/unit/data/test_multi_asset_loaders.py
@@ -1,10 +1,17 @@
-"""multi_asset_loaders.py の財務諸表読み込みテスト"""
+"""multi_asset_loaders.py のテスト"""
 
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
-from src.data.loaders.multi_asset_loaders import load_multiple_statements_data
+from src.data.loaders.multi_asset_loaders import (
+    load_multiple_indices,
+    load_multiple_margin_data,
+    load_multiple_statements_data,
+    load_multiple_stocks,
+)
+from src.exceptions import BatchAPIError, NoValidDataError
 
 
 def _mock_context_manager(client: MagicMock) -> MagicMock:
@@ -12,6 +19,211 @@ def _mock_context_manager(client: MagicMock) -> MagicMock:
     manager.__enter__ = MagicMock(return_value=client)
     manager.__exit__ = MagicMock(return_value=False)
     return manager
+
+
+def _price_df(values: list[float] | None = None, column: str = "Close") -> pd.DataFrame:
+    if values is None:
+        values = [100.0, 101.0, 102.0]
+    return pd.DataFrame(
+        {column: values},
+        index=pd.date_range("2025-01-01", periods=len(values), freq="D"),
+    )
+
+
+def _margin_df(values: list[float] | None = None, column: str = "TotalMargin") -> pd.DataFrame:
+    if values is None:
+        values = [1000.0, 1100.0, 1200.0]
+    return pd.DataFrame(
+        {column: values},
+        index=pd.date_range("2025-01-01", periods=len(values), freq="D"),
+    )
+
+
+class TestLoadMultipleStocks:
+    @patch("src.data.loaders.multi_asset_loaders.DataCache.get_instance")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_batch_api_uses_valid_price_columns_only(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_cache_get_instance,
+    ):
+        cache = MagicMock()
+        cache.is_enabled.return_value = False
+        mock_cache_get_instance.return_value = cache
+        mock_extract.return_value = "testds"
+
+        client = MagicMock()
+        client.get_stocks_ohlcv_batch.return_value = {
+            "7203": _price_df([100.0, 101.0, 102.0], "Close"),
+            "6758": _price_df([90.0, 91.0, 92.0], "Open"),
+        }
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        result = load_multiple_stocks(
+            dataset="dataset.db",
+            stock_codes=["7203", "6758"],
+            price_column="Close",
+        )
+
+        assert list(result.columns) == ["7203"]
+        assert len(result.index) == 3
+
+    @patch("src.data.loaders.multi_asset_loaders.load_stock_data")
+    @patch("src.data.loaders.multi_asset_loaders.DataCache.get_instance")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_batch_failure_falls_back_to_individual_load(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_cache_get_instance,
+        mock_load_stock_data,
+    ):
+        cache = MagicMock()
+        cache.is_enabled.return_value = False
+        mock_cache_get_instance.return_value = cache
+        mock_extract.return_value = "testds"
+
+        client = MagicMock()
+        client.get_stocks_ohlcv_batch.side_effect = BatchAPIError("batch failed")
+        mock_get_client.return_value = _mock_context_manager(client)
+        mock_load_stock_data.side_effect = [
+            _price_df([10.0, 11.0, 12.0], "Close"),
+            ValueError("missing"),
+        ]
+
+        result = load_multiple_stocks(
+            dataset="dataset.db",
+            stock_codes=["7203", "6758"],
+            price_column="Close",
+        )
+
+        assert list(result.columns) == ["7203"]
+        assert mock_load_stock_data.call_count == 2
+
+    @patch("src.data.loaders.multi_asset_loaders.load_stock_data")
+    @patch("src.data.loaders.multi_asset_loaders.DataCache.get_instance")
+    def test_raises_when_no_valid_stock_data(self, mock_cache_get_instance, mock_load_stock_data):
+        cache = MagicMock()
+        cache.is_enabled.return_value = True
+        mock_cache_get_instance.return_value = cache
+        mock_load_stock_data.side_effect = ValueError("missing")
+
+        with pytest.raises(NoValidDataError):
+            load_multiple_stocks(
+                dataset="dataset.db",
+                stock_codes=["7203"],
+                price_column="Close",
+            )
+
+
+class TestLoadMultipleIndices:
+    @patch("src.data.loaders.multi_asset_loaders.load_index_data")
+    def test_partial_failure_is_skipped(self, mock_load_index_data):
+        mock_load_index_data.side_effect = [
+            _price_df([3000.0, 3010.0, 3020.0], "Close"),
+            ValueError("missing"),
+        ]
+
+        result = load_multiple_indices(
+            dataset="dataset.db",
+            index_codes=["TOPIX", "JPX-NIKKEI"],
+            price_column="Close",
+        )
+
+        assert list(result.columns) == ["TOPIX"]
+        assert len(result.index) == 3
+
+    @patch("src.data.loaders.multi_asset_loaders.load_index_data")
+    def test_raises_when_no_valid_indices(self, mock_load_index_data):
+        mock_load_index_data.side_effect = ValueError("missing")
+
+        with pytest.raises(ValueError, match="No valid index data"):
+            load_multiple_indices(
+                dataset="dataset.db",
+                index_codes=["TOPIX"],
+                price_column="Close",
+            )
+
+
+class TestLoadMultipleMarginData:
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    @patch("src.data.loaders.multi_asset_loaders.transform_margin_df")
+    def test_batch_api_margin_success(
+        self,
+        mock_transform_margin_df,
+        mock_get_client,
+        mock_extract,
+    ):
+        mock_extract.return_value = "testds"
+        mock_transform_margin_df.side_effect = lambda df: df
+
+        client = MagicMock()
+        client.get_margin_batch.return_value = {
+            "7203": _margin_df([1000.0, 1100.0, 1200.0], "TotalMargin")
+        }
+        mock_get_client.return_value = _mock_context_manager(client)
+
+        result = load_multiple_margin_data(
+            dataset="dataset.db",
+            stock_codes=["7203"],
+            margin_column="TotalMargin",
+        )
+
+        assert list(result.columns) == ["7203"]
+        assert result.iloc[-1, 0] == 1200.0
+
+    @patch("src.data.loaders.multi_asset_loaders.load_margin_data")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_batch_failure_margin_fallback(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_load_margin_data,
+    ):
+        mock_extract.return_value = "testds"
+
+        client = MagicMock()
+        client.get_margin_batch.side_effect = BatchAPIError("batch failed")
+        mock_get_client.return_value = _mock_context_manager(client)
+        mock_load_margin_data.side_effect = [
+            _margin_df([11.0, 12.0, 13.0], "LongMargin"),
+            ValueError("missing"),
+        ]
+
+        result = load_multiple_margin_data(
+            dataset="dataset.db",
+            stock_codes=["7203", "6758"],
+            margin_column="LongMargin",
+        )
+
+        assert list(result.columns) == ["7203"]
+
+    @patch("src.data.loaders.multi_asset_loaders.load_margin_data")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_raises_when_no_valid_margin_data(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_load_margin_data,
+    ):
+        mock_extract.return_value = "testds"
+        client = MagicMock()
+        client.get_margin_batch.return_value = {}
+        mock_get_client.return_value = _mock_context_manager(client)
+        mock_load_margin_data.side_effect = ValueError("missing")
+
+        with pytest.raises(ValueError, match="No valid margin data"):
+            load_multiple_margin_data(
+                dataset="dataset.db",
+                stock_codes=["7203"],
+                margin_column="TotalMargin",
+            )
 
 
 class TestLoadMultipleStatementsData:
@@ -68,6 +280,7 @@ class TestLoadMultipleStatementsData:
         assert client.get_statements_batch.call_count == 2
         assert client.get_statements_batch.call_args_list[0].kwargs["period_type"] == "FY"
         assert client.get_statements_batch.call_args_list[1].kwargs["period_type"] == "all"
+        assert client.get_statements_batch.call_args_list[1].kwargs["actual_only"] is False
 
     @patch("src.data.loaders.multi_asset_loaders.logger")
     @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
@@ -216,3 +429,76 @@ class TestLoadMultipleStatementsData:
         )
 
         assert result.loc["2025-01-05", "7203"] == 80.0
+
+    @patch("src.data.loaders.multi_asset_loaders.load_statements_data")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_batch_missing_requested_column_falls_back_to_individual(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_load_statements_data,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+
+        client = MagicMock()
+        client.get_statements_batch.return_value = {
+            "7203": pd.DataFrame(
+                {
+                    "disclosedDate": [pd.Timestamp("2025-01-01")],
+                    "typeOfCurrentPeriod": ["FY"],
+                    "earningsPerShare": [80.0],
+                    "profit": [1000.0],
+                    "equity": [5000.0],
+                }
+            ).set_index("disclosedDate")
+        }
+        mock_get_client.return_value = _mock_context_manager(client)
+        mock_load_statements_data.return_value = pd.DataFrame(
+            {"CustomMetric": [42.0]},
+            index=[pd.Timestamp("2025-01-01")],
+        ).reindex(daily_index, method="ffill")
+
+        result = load_multiple_statements_data(
+            dataset="testds",
+            stock_codes=["7203"],
+            daily_index=daily_index,
+            statements_column="CustomMetric",
+            period_type="FY",
+        )
+
+        assert result.loc["2025-01-05", "7203"] == 42.0
+        mock_load_statements_data.assert_called_once()
+
+    @patch("src.data.loaders.multi_asset_loaders.logger")
+    @patch("src.data.loaders.multi_asset_loaders.load_statements_data")
+    @patch("src.data.loaders.multi_asset_loaders.extract_dataset_name")
+    @patch("src.data.loaders.multi_asset_loaders.get_dataset_client")
+    def test_batch_failure_and_invalid_fallback_rows_raise(
+        self,
+        mock_get_client,
+        mock_extract,
+        mock_load_statements_data,
+        mock_logger,
+    ):
+        mock_extract.return_value = "testds"
+        daily_index = pd.date_range("2025-01-01", "2025-01-05")
+        client = MagicMock()
+        client.get_statements_batch.side_effect = BatchAPIError("batch failed")
+        mock_get_client.return_value = _mock_context_manager(client)
+        mock_load_statements_data.side_effect = [
+            pd.DataFrame({"Other": [1.0]}, index=[pd.Timestamp("2025-01-01")]),
+            ValueError("invalid"),
+        ]
+
+        with pytest.raises(ValueError, match="No valid statements data"):
+            load_multiple_statements_data(
+                dataset="testds",
+                stock_codes=["7203", "6758"],
+                daily_index=daily_index,
+                statements_column="CustomMetric",
+                period_type="FY",
+            )
+
+        assert mock_logger.warning.call_count >= 2

--- a/apps/bt/tests/unit/data/test_statements_loaders.py
+++ b/apps/bt/tests/unit/data/test_statements_loaders.py
@@ -271,6 +271,7 @@ class TestLoadStatementsDataPeriodType:
         assert mock_client.get_statements.call_count == 2
         assert mock_client.get_statements.call_args_list[0].kwargs["period_type"] == "FY"
         assert mock_client.get_statements.call_args_list[1].kwargs["period_type"] == "all"
+        assert mock_client.get_statements.call_args_list[1].kwargs["actual_only"] is False
         assert result.loc["2024-07-29", "ForwardForecastEPS"] == 100.0
         assert result.loc["2024-07-30", "ForwardForecastEPS"] == 120.0
         # 分母はFY実績EPSを維持

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
@@ -176,6 +176,49 @@ describe('FundamentalsPanel', () => {
     expect(mockSummaryCard.mock.calls.at(-1)?.[0]).toMatchObject({ tradingValuePeriod: 20 });
   });
 
+  it('prioritizes revised forecast EPS from latestMetrics in summary payload', () => {
+    mockUseFundamentals.mockReturnValue({
+      data: {
+        data: [
+          {
+            date: '2024-03-31',
+            periodType: 'FY',
+            adjustedEps: 100,
+            eps: 95,
+            adjustedForecastEps: 120,
+            forecastEps: 110,
+            cashFlowOperating: 100,
+            cashFlowInvesting: -50,
+            cashFlowFinancing: -20,
+            cashAndEquivalents: 500,
+            netProfit: 200,
+            equity: 1000,
+          },
+        ],
+        latestMetrics: {
+          forecastEps: 580,
+          adjustedForecastEps: 560,
+          revisedForecastEps: 604,
+          revisedForecastSource: '1Q',
+          forecastEpsChangeRate: 999,
+        },
+        dailyValuation: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<FundamentalsPanel symbol="7203" />);
+
+    const metrics = (mockSummaryCard.mock.calls.at(-1)?.[0] as { metrics?: Record<string, unknown> }).metrics;
+    expect(metrics).toBeDefined();
+    expect(metrics?.forecastEps).toBe(604);
+    expect(metrics?.adjustedForecastEps).toBeNull();
+    expect(metrics?.revisedForecastEps).toBe(604);
+    expect(metrics?.revisedForecastSource).toBe('1Q');
+    expect(metrics?.forecastEpsChangeRate).toBe(504);
+  });
+
   it('falls back when latestMetrics is missing and adjusted EPS cannot compute change rate', () => {
     mockUseFundamentals.mockReturnValue({
       data: {

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
@@ -47,12 +47,20 @@ export function FundamentalsPanel({
     };
 
     // Start with FY data and merge enhanced fields from latestMetrics
+    const revisedForecastEps = data.latestMetrics?.revisedForecastEps ?? fyData.revisedForecastEps ?? null;
+    const revisedForecastSource = data.latestMetrics?.revisedForecastSource ?? fyData.revisedForecastSource ?? null;
+    const forecastEps = revisedForecastEps ?? data.latestMetrics?.forecastEps ?? null;
+    const adjustedForecastEps =
+      revisedForecastEps != null ? null : data.latestMetrics?.adjustedForecastEps ?? fyData.adjustedForecastEps ?? null;
+
     let result = {
       ...fyData,
       // Merge forecast and previous period data from latestMetrics (API enhances these)
-      forecastEps: data.latestMetrics?.forecastEps ?? null,
-      adjustedForecastEps: data.latestMetrics?.adjustedForecastEps ?? fyData.adjustedForecastEps ?? null,
+      forecastEps,
+      adjustedForecastEps,
       forecastEpsChangeRate: data.latestMetrics?.forecastEpsChangeRate ?? null,
+      revisedForecastEps,
+      revisedForecastSource,
       forecastDividendFy: data.latestMetrics?.forecastDividendFy ?? null,
       adjustedForecastDividendFy:
         data.latestMetrics?.adjustedForecastDividendFy ?? fyData.adjustedForecastDividendFy ?? null,
@@ -70,7 +78,7 @@ export function FundamentalsPanel({
     };
 
     const displayActualEps = result.adjustedEps ?? result.eps ?? null;
-    const displayForecastEps = result.adjustedForecastEps ?? result.forecastEps ?? null;
+    const displayForecastEps = result.revisedForecastEps ?? result.adjustedForecastEps ?? result.forecastEps ?? null;
     const epsChangeRate = resolveChangeRate(displayActualEps, displayForecastEps);
     if (epsChangeRate != null) {
       result = {

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -101,6 +101,21 @@ describe('FundamentalsSummaryCard', () => {
     expect(screen.queryByText(/株価 @ 開示日/)).not.toBeInTheDocument();
   });
 
+  it('prioritizes revised forecast EPS over adjusted/raw forecast EPS', () => {
+    const metrics: ApiFundamentalDataPoint = {
+      ...baseMetrics,
+      forecastEps: 580,
+      adjustedForecastEps: 560,
+      revisedForecastEps: 604,
+      revisedForecastSource: '1Q',
+    };
+
+    render(<FundamentalsSummaryCard metrics={metrics} />);
+
+    expect(screen.getByText('予: 604')).toBeInTheDocument();
+    expect(screen.queryByText('予: 560')).not.toBeInTheDocument();
+  });
+
   it('does not render EPS forecast block when forecast values are missing', () => {
     const metrics: ApiFundamentalDataPoint = {
       ...baseMetrics,

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -120,7 +120,7 @@ export function FundamentalsSummaryCard({
   }
 
   const displayEps = metrics.adjustedEps ?? metrics.eps;
-  const displayForecastEps = metrics.adjustedForecastEps ?? metrics.forecastEps;
+  const displayForecastEps = metrics.revisedForecastEps ?? metrics.adjustedForecastEps ?? metrics.forecastEps;
   const displayForecastPer = resolveForecastPer(metrics.stockPrice, displayForecastEps ?? null);
   const displayBps = metrics.adjustedBps ?? metrics.bps;
   const displayDividendFy = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;


### PR DESCRIPTION
Summary:
- prefer newer disclosures within same period for latest forecast EPS selection
- change statements upsert conflict handling to preserve existing non-null fields
- fetch quarterly revision rows with actual_only=false for statements loaders used by signal/screening
- prioritize revised forecast EPS in fundamentals panel and summary card
- add backend/frontend tests and update AGENTS.md

Validation:
- bt pytest suite for fundamentals/market_db/loaders/screening modules passed
- web vitest for FundamentalsPanel/FundamentalsSummaryCard passed
- branch coverage for target modules is >= 80%