### PR TITLE
feat(fundamentals): normalize payout ratio and add FY history metric controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ uv run pyright src/              # 型チェック
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
 - Fundamental signal system は `cfo_margin` / `simple_fcf_margin`（売上高比マージン判定）をサポートし、`OperatingCashFlow` / `InvestingCashFlow` / `Sales` をデータ要件とする
 - Fundamental signal は `cfo_to_net_profit_ratio`（営業CF/純利益）をサポートし、`consecutive_periods` 判定は比率値同値時でも開示更新（OperatingCashFlow/Profit）を起点に連続判定する
-- Fundamentals は EPS に加えて `dividend_fy` / `forecast_dividend_fy` と `payout_ratio` / `forecast_payout_ratio`（実績/予想）を SoT とし、Charts の Fundamentals panel と Backtest Signal system（`forward_dividend_growth` / `dividend_per_share_growth` / `payout_ratio` / `forward_payout_ratio`）で同一指標を使う
+- Fundamentals は EPS に加えて `dividend_fy` / `forecast_dividend_fy` と `payout_ratio` / `forecast_payout_ratio`（実績/予想）を SoT とし、Charts の Fundamentals panel と Backtest Signal system（`forward_dividend_growth` / `dividend_per_share_growth` / `payout_ratio` / `forward_payout_ratio`）で同一指標を使う。配当性向は API 返却時に percent 単位へ正規化し、decimal スケール値（例: 0.283）を 28.3% として扱う
 - fundamentals 最新値の forecast EPS は同一期末内で `DiscDate` が新しい開示を優先し、旧開示値の逆転表示を防ぐ
 - Strategy group 再振り分けは `/api/strategies/{strategy_name}/move`（`target_category`: `production` / `experimental` / `legacy`）を SoT とし、web の `Backtest > Strategies` から実行する
 
@@ -142,7 +142,7 @@ bun run cli backtest attribution run <strategy> --wait
 - Backtest `Strategies > Optimize` は `Open Editor` ポップアップで Monaco + Signal Reference を表示し、`Current` / `Saved` / `State` 要約を維持する。保存ブロックは YAML 構文エラー時のみとする
 - Backtest Runner の `Optimization` セクションは Grid 概要（params/combinations）に加えて `parameter_ranges` の具体値一覧を表示し、Optimization 完了カードでは Best/Worst Params と各 score を表示する
 - `analysis screening`（web/cli）は production 戦略を動的選択し、非同期ジョブ（2秒ポーリング）で実行する。`sortBy` 既定は `matchedDate`、`order` 既定は `desc`。`backtestMetric` は廃止
-- Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Fundamental Metrics / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集し、Fundamentals パネル内部の指標は `fundamentalsMetricOrder` / `fundamentalsMetricVisibility` で順序・表示ON/OFFを保持する。Fundamentals パネル高さは表示中指標数に応じて動的に変化する
+- Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Fundamental Metrics / FY History Metrics / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集し、Fundamentals パネル内部の指標は `fundamentalsMetricOrder` / `fundamentalsMetricVisibility`、FY History パネル内部の指標は `fundamentalsHistoryMetricOrder` / `fundamentalsHistoryMetricVisibility` で順序・表示ON/OFFを保持する。Fundamentals パネル高さは表示中指標数に応じて動的に変化する
 - Portfolio / Watchlist の銘柄追加入力はチャート検索と同等の銘柄サーチ（コード/銘柄名）を使う。追加送信 payload は `companyName` 必須（候補選択時は候補名、未選択時はコードをフォールバック）。Watchlist 追加の送信は 4 桁コードのみ許可する
 - Fundamentals summary の予想EPS表示は `revisedForecastEps > adjustedForecastEps > forecastEps` の優先順位を SoT とする
 

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -7,6 +7,10 @@ import {
   DEFAULT_FUNDAMENTAL_METRIC_ORDER,
   DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
 } from '@/constants/fundamentalMetrics';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+} from '@/constants/fundamentalsHistoryMetrics';
 import { ChartControls } from './ChartControls';
 
 const queryClient = new QueryClient({
@@ -49,6 +53,8 @@ const mockChartStore = {
     fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'],
     fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
     fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+    fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+    fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
     visibleBars: 30,
     relativeMode: false,
     indicators: {
@@ -136,6 +142,10 @@ describe('ChartControls', () => {
     ];
     mockChartStore.settings.fundamentalsMetricOrder = [...DEFAULT_FUNDAMENTAL_METRIC_ORDER];
     mockChartStore.settings.fundamentalsMetricVisibility = { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY };
+    mockChartStore.settings.fundamentalsHistoryMetricOrder = [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER];
+    mockChartStore.settings.fundamentalsHistoryMetricVisibility = {
+      ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+    };
     mockChartStore.settings.signalOverlay.signals = [];
     mockChartStore.setSelectedSymbol = vi.fn();
     mockChartStore.updateSettings = vi.fn();
@@ -285,6 +295,44 @@ describe('ChartControls', () => {
 
     expect(mockChartStore.updateSettings).toHaveBeenCalledWith({
       fundamentalsMetricOrder: ['pbr', 'per', ...DEFAULT_FUNDAMENTAL_METRIC_ORDER.slice(2)],
+    });
+  });
+
+  it('opens FY history metrics dialog and toggles metric visibility', async () => {
+    const user = userEvent.setup();
+    mockChartStore.updateSettings = vi.fn();
+
+    render(<ChartControls />, { wrapper: TestWrapper });
+
+    await user.click(screen.getByRole('button', { name: 'FY History Metrics' }));
+    await user.click(screen.getByRole('switch', { name: /^EPS$/i }));
+
+    expect(mockChartStore.updateSettings).toHaveBeenCalledWith({
+      fundamentalsHistoryMetricVisibility: {
+        ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+        eps: false,
+      },
+    });
+  });
+
+  it('moves FY history metric order down from FY history metrics dialog', async () => {
+    const user = userEvent.setup();
+    mockChartStore.updateSettings = vi.fn();
+
+    render(<ChartControls />, { wrapper: TestWrapper });
+
+    await user.click(screen.getByRole('button', { name: 'FY History Metrics' }));
+    const [firstDownButton] = screen.getAllByRole('button', { name: /^Down$/ });
+    expect(firstDownButton).toBeDefined();
+    if (!firstDownButton) return;
+    await user.click(firstDownButton);
+
+    expect(mockChartStore.updateSettings).toHaveBeenCalledWith({
+      fundamentalsHistoryMetricOrder: [
+        'forecastEps',
+        'eps',
+        ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER.slice(2),
+      ],
     });
   });
 

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsHistoryPanel.test.tsx
@@ -2,6 +2,10 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+} from '@/constants/fundamentalsHistoryMetrics';
 import { FundamentalsHistoryPanel } from './FundamentalsHistoryPanel';
 
 const mockUseFundamentals = vi.fn();
@@ -147,6 +151,94 @@ describe('FundamentalsHistoryPanel', () => {
     expect(screen.getByText('ROE')).toBeInTheDocument();
     expect(screen.getByText('2024/3期')).toBeInTheDocument();
     expect(screen.getByText('2023/3期')).toBeInTheDocument();
+  });
+
+  it('applies FY metric visibility settings to table columns', () => {
+    mockUseFundamentals.mockReturnValue({
+      data: {
+        data: [
+          {
+            date: '2024-03-31',
+            disclosedDate: '2024-05-10',
+            periodType: 'FY',
+            eps: 250,
+            bps: 3200,
+            roe: 12.5,
+            cashFlowOperating: 500,
+            cashFlowInvesting: -200,
+            cashFlowFinancing: -100,
+            dividendFy: 120,
+            forecastDividendFy: 125,
+            payoutRatio: 35,
+            forecastPayoutRatio: 38,
+            netProfit: 1000,
+            equity: 8000,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <FundamentalsHistoryPanel
+        symbol="7203"
+        metricVisibility={{
+          ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+          roe: false,
+          payoutRatio: false,
+        }}
+      />
+    );
+
+    expect(screen.queryByText('ROE')).not.toBeInTheDocument();
+    expect(screen.queryByText('配当性向')).not.toBeInTheDocument();
+    expect(screen.getByText('EPS')).toBeInTheDocument();
+    expect(screen.getByText('予想配当性向')).toBeInTheDocument();
+  });
+
+  it('applies FY metric order settings to table columns', () => {
+    mockUseFundamentals.mockReturnValue({
+      data: {
+        data: [
+          {
+            date: '2024-03-31',
+            disclosedDate: '2024-05-10',
+            periodType: 'FY',
+            eps: 250,
+            bps: 3200,
+            roe: 12.5,
+            cashFlowOperating: 500,
+            cashFlowInvesting: -200,
+            cashFlowFinancing: -100,
+            dividendFy: 120,
+            forecastDividendFy: 125,
+            payoutRatio: 35,
+            forecastPayoutRatio: 38,
+            netProfit: 1000,
+            equity: 8000,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <FundamentalsHistoryPanel
+        symbol="7203"
+        metricOrder={['payoutRatio', ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER.filter((id) => id !== 'payoutRatio')]}
+      />
+    );
+
+    const headers = screen
+      .getAllByRole('columnheader')
+      .map((header) => header.textContent?.trim())
+      .filter((text): text is string => typeof text === 'string' && text.length > 0);
+    expect(headers[0]).toBe('期別');
+    expect(headers[1]).toBe('発表日');
+    expect(headers[2]).toBe('配当性向');
+    expect(headers[3]).toBe('EPS');
   });
 
   it('sorts FY rows by date descending, then disclosedDate descending', () => {

--- a/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
@@ -4,6 +4,10 @@ import {
   DEFAULT_FUNDAMENTAL_METRIC_ORDER,
   DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
 } from '@/constants/fundamentalMetrics';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+} from '@/constants/fundamentalsHistoryMetrics';
 import type { StockDataPoint } from '@/types/chart';
 import { calculateChangePct, formatPrice, StockChart, timeToDateString } from './StockChart';
 
@@ -25,6 +29,8 @@ const mockChartStore = {
     fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'],
     fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
     fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+    fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+    fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
     visibleBars: 30,
     relativeMode: false,
     indicators: {

--- a/apps/ts/packages/web/src/constants/fundamentalsHistoryMetrics.test.ts
+++ b/apps/ts/packages/web/src/constants/fundamentalsHistoryMetrics.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countVisibleFundamentalsHistoryMetrics,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+  FUNDAMENTALS_HISTORY_METRIC_IDS,
+  isFundamentalsHistoryMetricId,
+  normalizeFundamentalsHistoryMetricOrder,
+  normalizeFundamentalsHistoryMetricVisibility,
+} from './fundamentalsHistoryMetrics';
+
+describe('fundamentalsHistoryMetrics', () => {
+  it('includes payout ratio metric in ids/defaults', () => {
+    expect(FUNDAMENTALS_HISTORY_METRIC_IDS).toContain('payoutRatio');
+    expect(DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER).toContain('payoutRatio');
+    expect(DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY.payoutRatio).toBe(true);
+  });
+
+  it('validates metric ids', () => {
+    expect(isFundamentalsHistoryMetricId('eps')).toBe(true);
+    expect(isFundamentalsHistoryMetricId('forecastPayoutRatio')).toBe(true);
+    expect(isFundamentalsHistoryMetricId('invalid')).toBe(false);
+  });
+
+  it('normalizes order by filtering invalid/duplicate ids and appending defaults', () => {
+    const normalized = normalizeFundamentalsHistoryMetricOrder(['payoutRatio', 'eps', 'eps', 'invalid']);
+    expect(normalized[0]).toBe('payoutRatio');
+    expect(normalized[1]).toBe('eps');
+    expect(normalized).toHaveLength(DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER.length);
+    expect(normalized).toEqual(expect.arrayContaining(DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER));
+  });
+
+  it('normalizes visibility while preserving booleans only', () => {
+    const normalized = normalizeFundamentalsHistoryMetricVisibility({
+      payoutRatio: false,
+      eps: false,
+      invalid: true,
+      forecastEps: 'true',
+    });
+
+    expect(normalized.payoutRatio).toBe(false);
+    expect(normalized.eps).toBe(false);
+    expect(normalized.forecastEps).toBe(true);
+    expect((normalized as Record<string, boolean>).invalid).toBeUndefined();
+  });
+
+  it('counts visible metrics from order + visibility', () => {
+    const order = ['eps', 'payoutRatio', 'roe'] as const;
+    const visibility = {
+      ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+      eps: true,
+      payoutRatio: false,
+      roe: true,
+    };
+    expect(countVisibleFundamentalsHistoryMetrics([...order], visibility)).toBe(2);
+  });
+});

--- a/apps/ts/packages/web/src/constants/fundamentalsHistoryMetrics.ts
+++ b/apps/ts/packages/web/src/constants/fundamentalsHistoryMetrics.ts
@@ -1,0 +1,101 @@
+export const FUNDAMENTALS_HISTORY_METRIC_IDS = [
+  'eps',
+  'forecastEps',
+  'bps',
+  'dividendPerShare',
+  'forecastDividendPerShare',
+  'payoutRatio',
+  'forecastPayoutRatio',
+  'roe',
+  'cashFlowOperating',
+  'cashFlowInvesting',
+  'cashFlowFinancing',
+] as const;
+
+export type FundamentalsHistoryMetricId = (typeof FUNDAMENTALS_HISTORY_METRIC_IDS)[number];
+
+export interface FundamentalsHistoryMetricDefinition {
+  id: FundamentalsHistoryMetricId;
+  label: string;
+}
+
+export const FUNDAMENTALS_HISTORY_METRIC_DEFINITIONS: FundamentalsHistoryMetricDefinition[] = [
+  { id: 'eps', label: 'EPS' },
+  { id: 'forecastEps', label: '来期予想EPS' },
+  { id: 'bps', label: 'BPS' },
+  { id: 'dividendPerShare', label: '1株配当' },
+  { id: 'forecastDividendPerShare', label: '予想1株配当' },
+  { id: 'payoutRatio', label: '配当性向' },
+  { id: 'forecastPayoutRatio', label: '予想配当性向' },
+  { id: 'roe', label: 'ROE' },
+  { id: 'cashFlowOperating', label: '営業CF' },
+  { id: 'cashFlowInvesting', label: '投資CF' },
+  { id: 'cashFlowFinancing', label: '財務CF' },
+];
+
+export const DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER: FundamentalsHistoryMetricId[] = [
+  ...FUNDAMENTALS_HISTORY_METRIC_IDS,
+];
+
+export const DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY: Record<FundamentalsHistoryMetricId, boolean> = {
+  eps: true,
+  forecastEps: true,
+  bps: true,
+  dividendPerShare: true,
+  forecastDividendPerShare: true,
+  payoutRatio: true,
+  forecastPayoutRatio: true,
+  roe: true,
+  cashFlowOperating: true,
+  cashFlowInvesting: true,
+  cashFlowFinancing: true,
+};
+
+const FUNDAMENTALS_HISTORY_METRIC_ID_SET = new Set<FundamentalsHistoryMetricId>(FUNDAMENTALS_HISTORY_METRIC_IDS);
+
+export function isFundamentalsHistoryMetricId(value: unknown): value is FundamentalsHistoryMetricId {
+  return typeof value === 'string' && FUNDAMENTALS_HISTORY_METRIC_ID_SET.has(value as FundamentalsHistoryMetricId);
+}
+
+export function normalizeFundamentalsHistoryMetricOrder(value: unknown): FundamentalsHistoryMetricId[] {
+  const normalizedOrder: FundamentalsHistoryMetricId[] = [];
+  const seen = new Set<FundamentalsHistoryMetricId>();
+
+  if (Array.isArray(value)) {
+    for (const metricId of value) {
+      if (!isFundamentalsHistoryMetricId(metricId) || seen.has(metricId)) continue;
+      seen.add(metricId);
+      normalizedOrder.push(metricId);
+    }
+  }
+
+  for (const metricId of DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER) {
+    if (seen.has(metricId)) continue;
+    normalizedOrder.push(metricId);
+  }
+
+  return normalizedOrder;
+}
+
+export function normalizeFundamentalsHistoryMetricVisibility(
+  value: unknown
+): Record<FundamentalsHistoryMetricId, boolean> {
+  const normalized = { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY };
+  if (typeof value !== 'object' || value === null) return normalized;
+
+  for (const metricId of FUNDAMENTALS_HISTORY_METRIC_IDS) {
+    const raw = (value as Record<string, unknown>)[metricId];
+    if (typeof raw === 'boolean') {
+      normalized[metricId] = raw;
+    }
+  }
+
+  return normalized;
+}
+
+export function countVisibleFundamentalsHistoryMetrics(
+  metricOrder: FundamentalsHistoryMetricId[],
+  metricVisibility: Record<FundamentalsHistoryMetricId, boolean>
+): number {
+  return metricOrder.filter((metricId) => metricVisibility[metricId]).length;
+}

--- a/apps/ts/packages/web/src/hooks/useBtIndicators.test.ts
+++ b/apps/ts/packages/web/src/hooks/useBtIndicators.test.ts
@@ -4,6 +4,10 @@ import {
   DEFAULT_FUNDAMENTAL_METRIC_ORDER,
   DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
 } from '@/constants/fundamentalMetrics';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+} from '@/constants/fundamentalsHistoryMetrics';
 import { apiPost } from '@/lib/api-client';
 import type { ChartSettings } from '@/stores/chartStore';
 import { createTestWrapper } from '@/test-utils';
@@ -60,6 +64,8 @@ describe('buildIndicatorSpecs', () => {
     ] as ChartSettings['fundamentalsPanelOrder'],
     fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
     fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+    fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+    fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
     visibleBars: 200,
     relativeMode: false,
     signalOverlay: { enabled: false, signals: [] },
@@ -363,6 +369,8 @@ describe('useBtIndicators', () => {
     ] as ChartSettings['fundamentalsPanelOrder'],
     fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
     fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+    fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+    fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
     visibleBars: 200,
     relativeMode: false,
     signalOverlay: { enabled: false, signals: [] },

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -7,6 +7,10 @@ import {
   DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
   resolveFundamentalsPanelHeightPx,
 } from '@/constants/fundamentalMetrics';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+} from '@/constants/fundamentalsHistoryMetrics';
 import { ChartsPage } from './ChartsPage';
 
 const mockUseMultiTimeframeChart = vi.fn();
@@ -15,6 +19,7 @@ const mockUseStockData = vi.fn();
 const mockUseFundamentals = vi.fn();
 const mockWindowOpen = vi.fn();
 const mockFundamentalsPanelProps = vi.fn<[unknown], void>();
+const mockFundamentalsHistoryPanelProps = vi.fn<[unknown], void>();
 
 vi.mock('@/components/Chart/hooks/useMultiTimeframeChart', () => ({
   useMultiTimeframeChart: () => mockUseMultiTimeframeChart(),
@@ -72,6 +77,8 @@ const mockSettings = {
   fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'],
   fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
   fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+  fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+  fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
   visibleBars: 120,
   relativeMode: true,
 };
@@ -116,7 +123,10 @@ vi.mock('@/components/Chart/FundamentalsPanel', () => ({
 }));
 
 vi.mock('@/components/Chart/FundamentalsHistoryPanel', () => ({
-  FundamentalsHistoryPanel: () => <div>FY History Panel</div>,
+  FundamentalsHistoryPanel: (props: unknown) => {
+    mockFundamentalsHistoryPanelProps(props);
+    return <div>FY History Panel</div>;
+  },
 }));
 
 const mockFactorRegressionPanelProps = vi.fn<[unknown], void>();
@@ -193,6 +203,7 @@ describe('ChartsPage', () => {
     mockUseStockData.mockReset();
     mockUseFundamentals.mockReset();
     mockFundamentalsPanelProps.mockReset();
+    mockFundamentalsHistoryPanelProps.mockReset();
     mockFactorRegressionPanelProps.mockReset();
 
     mockSettings.showPPOChart = true;
@@ -206,6 +217,8 @@ describe('ChartsPage', () => {
     mockSettings.fundamentalsPanelOrder = ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'];
     mockSettings.fundamentalsMetricOrder = [...DEFAULT_FUNDAMENTAL_METRIC_ORDER];
     mockSettings.fundamentalsMetricVisibility = { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY };
+    mockSettings.fundamentalsHistoryMetricOrder = [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER];
+    mockSettings.fundamentalsHistoryMetricVisibility = { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY };
     mockSettings.tradingValueMA.period = 15;
     mockSettings.relativeMode = true;
 
@@ -325,6 +338,12 @@ describe('ChartsPage', () => {
       symbol: '7203',
       enabled: false,
       tradingValuePeriod: 15,
+    });
+    expect(mockFundamentalsHistoryPanelProps.mock.calls.at(-1)?.[0]).toMatchObject({
+      symbol: '7203',
+      enabled: false,
+      metricOrder: DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+      metricVisibility: DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
     });
   });
 

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -333,7 +333,12 @@ export function ChartsPage() {
                 </div>
                 <div className="h-[calc(100%-4rem)] p-4">
                   <ErrorBoundary>
-                    <FundamentalsHistoryPanel symbol={selectedSymbol} enabled={fundamentalsHistorySection.isVisible} />
+                    <FundamentalsHistoryPanel
+                      symbol={selectedSymbol}
+                      enabled={fundamentalsHistorySection.isVisible}
+                      metricOrder={settings.fundamentalsHistoryMetricOrder}
+                      metricVisibility={settings.fundamentalsHistoryMetricVisibility}
+                    />
                   </ErrorBoundary>
                 </div>
               </div>

--- a/apps/ts/packages/web/src/stores/chartStore.test.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.test.ts
@@ -249,6 +249,10 @@ describe('chartStore', () => {
     expect(state.settings.showFactorRegressionPanel).toBe(defaultSettings.showFactorRegressionPanel);
     expect(state.settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
     expect(state.settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
+    expect(state.settings.fundamentalsHistoryMetricOrder).toEqual(defaultSettings.fundamentalsHistoryMetricOrder);
+    expect(state.settings.fundamentalsHistoryMetricVisibility).toEqual(
+      defaultSettings.fundamentalsHistoryMetricVisibility
+    );
     expect(state.settings.signalOverlay.enabled).toBe(false);
     expect(state.settings.signalOverlay.signals).toEqual([]);
     expect(state.presets[0]?.settings.tradingValueMA.period).toBe(defaultSettings.tradingValueMA.period);
@@ -296,6 +300,10 @@ describe('chartStore', () => {
     expect(state.settings.indicators.ppo.fast).toBe(defaultSettings.indicators.ppo.fast);
     expect(state.settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
     expect(state.settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
+    expect(state.settings.fundamentalsHistoryMetricOrder).toEqual(defaultSettings.fundamentalsHistoryMetricOrder);
+    expect(state.settings.fundamentalsHistoryMetricVisibility).toEqual(
+      defaultSettings.fundamentalsHistoryMetricVisibility
+    );
     expect(state.settings.signalOverlay.enabled).toBe(defaultSettings.signalOverlay.enabled);
     expect(state.settings.signalOverlay.signals).toHaveLength(1);
     expect(state.settings.signalOverlay.signals[0]?.enabled).toBe(true);
@@ -319,6 +327,8 @@ describe('chartStore', () => {
     ]);
     expect(settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
     expect(settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
+    expect(settings.fundamentalsHistoryMetricOrder).toEqual(defaultSettings.fundamentalsHistoryMetricOrder);
+    expect(settings.fundamentalsHistoryMetricVisibility).toEqual(defaultSettings.fundamentalsHistoryMetricVisibility);
   });
 
   it('defaults risk adjusted return chart settings', () => {
@@ -370,6 +380,11 @@ describe('chartStore', () => {
               eps: false,
               per: 'yes',
             },
+            fundamentalsHistoryMetricOrder: ['roe', 'invalid', 'roe'],
+            fundamentalsHistoryMetricVisibility: {
+              roe: false,
+              eps: 'no',
+            },
           },
         },
         version: 0,
@@ -391,5 +406,13 @@ describe('chartStore', () => {
     ]);
     expect(settings.fundamentalsMetricVisibility.eps).toBe(false);
     expect(settings.fundamentalsMetricVisibility.per).toBe(defaultSettings.fundamentalsMetricVisibility.per);
+    expect(settings.fundamentalsHistoryMetricOrder).toEqual([
+      'roe',
+      ...defaultSettings.fundamentalsHistoryMetricOrder.filter((metricId) => metricId !== 'roe'),
+    ]);
+    expect(settings.fundamentalsHistoryMetricVisibility.roe).toBe(false);
+    expect(settings.fundamentalsHistoryMetricVisibility.eps).toBe(
+      defaultSettings.fundamentalsHistoryMetricVisibility.eps
+    );
   });
 });

--- a/apps/ts/packages/web/src/stores/chartStore.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.ts
@@ -7,6 +7,13 @@ import {
   normalizeFundamentalMetricOrder,
   normalizeFundamentalMetricVisibility,
 } from '@/constants/fundamentalMetrics';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+  type FundamentalsHistoryMetricId,
+  normalizeFundamentalsHistoryMetricOrder,
+  normalizeFundamentalsHistoryMetricVisibility,
+} from '@/constants/fundamentalsHistoryMetrics';
 
 export type DisplayTimeframe = 'daily' | 'weekly' | 'monthly';
 export type RiskAdjustedReturnRatioType = 'sharpe' | 'sortino';
@@ -73,6 +80,8 @@ export interface ChartSettings {
   fundamentalsPanelOrder: FundamentalsPanelId[];
   fundamentalsMetricOrder: FundamentalMetricId[];
   fundamentalsMetricVisibility: Record<FundamentalMetricId, boolean>;
+  fundamentalsHistoryMetricOrder: FundamentalsHistoryMetricId[];
+  fundamentalsHistoryMetricVisibility: Record<FundamentalsHistoryMetricId, boolean>;
   visibleBars: number;
   relativeMode: boolean;
   signalOverlay: SignalOverlaySettings;
@@ -171,6 +180,8 @@ export const defaultSettings: ChartSettings = {
   fundamentalsPanelOrder: [...DEFAULT_FUNDAMENTALS_PANEL_ORDER],
   fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
   fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+  fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+  fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
   visibleBars: 120,
   relativeMode: false,
   signalOverlay: {
@@ -401,6 +412,10 @@ function normalizeSettings(settings: unknown): ChartSettings {
     fundamentalsPanelOrder: normalizeFundamentalsPanelOrder(partial.fundamentalsPanelOrder),
     fundamentalsMetricOrder: normalizeFundamentalMetricOrder(partial.fundamentalsMetricOrder),
     fundamentalsMetricVisibility: normalizeFundamentalMetricVisibility(partial.fundamentalsMetricVisibility),
+    fundamentalsHistoryMetricOrder: normalizeFundamentalsHistoryMetricOrder(partial.fundamentalsHistoryMetricOrder),
+    fundamentalsHistoryMetricVisibility: normalizeFundamentalsHistoryMetricVisibility(
+      partial.fundamentalsHistoryMetricVisibility
+    ),
     visibleBars: normalizePositiveInt(partial.visibleBars, defaultSettings.visibleBars),
     relativeMode: normalizeBoolean(partial.relativeMode, defaultSettings.relativeMode),
     signalOverlay: {


### PR DESCRIPTION
- normalize payout ratio values to percent scale in bt fundamentals service (actual + forecast)
- add FY History metric visibility/order settings and controls in web chart sidebar
- wire FY History panel to dynamic metric columns with store-backed order/visibility
- add backend/frontend tests and update AGENTS.md behavior notes

## Validation
- cd apps/bt && uv run pytest tests/server/services/test_fundamentals_service.py -k "payout or ForecastEps"
- cd apps/ts/packages/web && bun run test src/constants/fundamentalsHistoryMetrics.test.ts src/components/Chart/FundamentalsHistoryPanel.test.tsx src/components/Chart/ChartControls.test.tsx src/pages/ChartsPage.test.tsx src/stores/chartStore.test.ts