### PR TITLE
docs: add public repository readiness audit for open-sourcing

### DIFF
--- a/docs/reports/public-repo-readiness-audit-2026-02-20.md
+++ b/docs/reports/public-repo-readiness-audit-2026-02-20.md
@@ -1,0 +1,77 @@
+# Public Repository Readiness Audit (2026-02-20)
+
+## Scope
+- Repository-wide static review for public化 readiness.
+- Focus areas: secret exposure, security posture, governance artifacts, and operational safety for open-source publication.
+
+## Method
+- Pattern-based secret scan (`rg`) on tracked files.
+- Manual review of core operational/security-related files.
+- Check for OSS governance files commonly expected in public repos.
+
+## Findings
+
+### ✅ Positive findings
+1. **No obvious leaked credentials in tracked files**
+   - High-risk token/private-key patterns were not detected by repository-wide `rg` scan.
+2. **Environment files are ignored by default**
+   - `.env` and `.env.*` are ignored in root `.gitignore`.
+3. **Runtime databases/ephemeral artifacts are mostly excluded**
+   - DB, cache, logs, and test artifacts are broadly ignored.
+4. **CORS is currently restricted to local development origins**
+   - FastAPI CORS origins are localhost/127.0.0.1 only.
+
+### ⚠️ Risks / gaps before making repo public
+
+#### High priority
+1. **Encryption key file may be accidentally committed**
+   - `SecureEnvManager` defaults key path to `./.trading25.key` (current working directory).
+   - Root `.gitignore` does **not** currently ignore `.trading25.key`.
+   - Risk: local encryption key can be committed if generated from repo root.
+
+2. **No published security disclosure policy**
+   - `SECURITY.md` is missing at repo root.
+   - Public users/researchers have no documented vuln reporting path or SLA.
+
+#### Medium priority
+3. **No explicit OSS license file**
+   - `LICENSE` is missing.
+   - Public repository without clear license is legally ambiguous for contributors/users.
+
+4. **No CODEOWNERS for review boundaries**
+   - `.github/CODEOWNERS` is missing.
+   - Ownership/mandatory review routing is undefined for public contributions.
+
+5. **No dependency/security automation metadata detected**
+   - Dependabot config and dedicated secret scanning workflow/config were not found.
+   - CI currently emphasizes lint/type/test quality, but not supply-chain/security scanning.
+
+#### Low priority / operational
+6. **No `.env` template for safer onboarding**
+   - `.env` is ignored (good), but no `.env.example` / `.env.template` was found.
+   - New external contributors may create ad-hoc env files inconsistently.
+
+## Recommended action plan
+
+### Phase A (must-do before public)
+1. Add `.trading25.key` to `.gitignore` (and optionally `**/.trading25.key`).
+2. Add `SECURITY.md` with:
+   - reporting channel,
+   - supported versions,
+   - disclosure policy/timeline.
+3. Add `LICENSE` (e.g., MIT/Apache-2.0/proprietary choice explicitly).
+
+### Phase B (strongly recommended)
+4. Add `.github/CODEOWNERS` for `apps/bt`, `apps/ts`, `contracts`, `docs`.
+5. Add dependency/security automation:
+   - `.github/dependabot.yml`,
+   - secret scan in CI (e.g., gitleaks/detect-secrets),
+   - vulnerability audit step (pip/bun ecosystem).
+
+### Phase C (nice-to-have)
+6. Add `.env.example` (no real secrets) documenting required vars:
+   - `JQUANTS_API_KEY`, `JQUANTS_PLAN`, `API_BASE_URL`, `BT_API_URL`.
+7. Add a short `docs/security/public-repo-hardening.md` runbook for maintainers.
+
+## Notes
+- This audit is static/repository-centric; runtime infrastructure hardening (cloud IAM, WAF, secret manager, network policies) must be reviewed separately before production public service exposure.

--- a/issues/ts-131-public-repo-governance-baseline.md
+++ b/issues/ts-131-public-repo-governance-baseline.md
@@ -1,0 +1,36 @@
+---
+id: ts-131
+title: "Public repository governance baseline (SECURITY / LICENSE / CODEOWNERS)"
+status: open
+priority: high
+labels: [security, governance, oss]
+project: ts
+created: 2026-02-21
+updated: 2026-02-21
+depends_on: []
+blocks: []
+parent: null
+---
+
+# ts-131 Public repository governance baseline (SECURITY / LICENSE / CODEOWNERS)
+
+## 目的
+private -> public 移行前に、公開リポジトリとして必須のガバナンス文書を整備する。
+
+## 受け入れ条件
+- ルートに `SECURITY.md` を追加し、脆弱性報告窓口・初回応答目標・公開方針を明記する。
+- ルートに `LICENSE` を追加し、採用ライセンスを明示する。
+- `.github/CODEOWNERS` を追加し、`apps/bt` `apps/ts` `contracts` `docs` のレビュー責務を定義する。
+- README から上記文書への導線を追加する。
+
+## 実施内容
+- [ ] `SECURITY.md` のドラフト作成（報告経路、SLA、対象バージョン）
+- [ ] `LICENSE` の選定・追加（法務合意を含む）
+- [ ] `.github/CODEOWNERS` の作成
+- [ ] `README.md` へ参照リンク追加
+
+## 結果
+- 未着手
+
+## 補足
+- 背景: `docs/reports/public-repo-readiness-audit-2026-02-20.md` の High/Medium 対応。

--- a/issues/ts-132-public-repo-security-automation.md
+++ b/issues/ts-132-public-repo-security-automation.md
@@ -1,0 +1,37 @@
+---
+id: ts-132
+title: "Public repository security automation (Dependabot + secret scan + vuln audit)"
+status: open
+priority: high
+labels: [security, ci, dependency]
+project: ts
+created: 2026-02-21
+updated: 2026-02-21
+depends_on: []
+blocks: []
+parent: null
+---
+
+# ts-132 Public repository security automation (Dependabot + secret scan + vuln audit)
+
+## 目的
+公開後の継続運用で、依存関係脆弱性と秘密情報混入をCIで早期検知できる状態を作る。
+
+## 受け入れ条件
+- `.github/dependabot.yml` を追加し、bun/uv/github-actions の更新監視を有効化する。
+- CI に secret scan（例: gitleaks or detect-secrets）を追加する。
+- CI に依存関係脆弱性チェック（Python/Bun 両系）を追加する。
+- 失敗時の triage 手順を runbook に明記する。
+
+## 実施内容
+- [ ] Dependabot 設定追加（更新頻度、PR上限、ラベル）
+- [ ] secret scan ジョブ追加
+- [ ] Python/Bun の vuln audit ジョブ追加
+- [ ] false positive の運用ルール定義
+- [ ] `issues/ts-011-ops-runbook.md` か docs に手順追記
+
+## 結果
+- 未着手
+
+## 補足
+- 背景: `docs/reports/public-repo-readiness-audit-2026-02-20.md` の Medium 対応。

--- a/issues/ts-133-secret-key-file-ignore-and-handling.md
+++ b/issues/ts-133-secret-key-file-ignore-and-handling.md
@@ -1,0 +1,34 @@
+---
+id: ts-133
+title: "Secret key file hardening (.trading25.key ignore + handling rule)"
+status: open
+priority: high
+labels: [security, secret-management]
+project: ts
+created: 2026-02-21
+updated: 2026-02-21
+depends_on: [ts-013]
+blocks: []
+parent: null
+---
+
+# ts-133 Secret key file hardening (.trading25.key ignore + handling rule)
+
+## 目的
+`SecureEnvManager` が生成する暗号鍵ファイルの誤コミットを防止し、鍵運用ルールを明文化する。
+
+## 受け入れ条件
+- ルート `.gitignore` に `.trading25.key`（必要なら `**/.trading25.key`）を追加する。
+- `apps/ts/packages/shared` のドキュメントに鍵ファイルの配置・権限・ローテーション方針を追記する。
+- 既存トラッキング確認手順（`git ls-files | rg trading25.key` 等）を runbook に追記する。
+
+## 実施内容
+- [ ] `.gitignore` 更新
+- [ ] 鍵ファイル運用（生成場所/権限/削除）の文書化
+- [ ] pre-commit/CI での検知方法を検討
+
+## 結果
+- 未着手
+
+## 補足
+- 背景: `docs/reports/public-repo-readiness-audit-2026-02-20.md` の High 対応。

--- a/issues/ts-134-public-env-template-and-onboarding.md
+++ b/issues/ts-134-public-env-template-and-onboarding.md
@@ -1,0 +1,35 @@
+---
+id: ts-134
+title: "Public onboarding env template (.env.example)"
+status: open
+priority: medium
+labels: [docs, onboarding, security]
+project: ts
+created: 2026-02-21
+updated: 2026-02-21
+depends_on: []
+blocks: []
+parent: null
+---
+
+# ts-134 Public onboarding env template (.env.example)
+
+## 目的
+公開リポジトリでの初期セットアップを安全かつ一貫化するため、秘密情報を含まない env テンプレートを提供する。
+
+## 受け入れ条件
+- `apps/ts/.env.example`（必要なら `apps/bt` 用補足）を追加する。
+- 必須変数（`JQUANTS_API_KEY`, `JQUANTS_PLAN`, `API_BASE_URL`, `BT_API_URL`）をコメント付きで定義する。
+- README / Quick Start にテンプレートコピー手順を追記する。
+- テンプレートに実鍵・実URL（本番）を含めない。
+
+## 実施内容
+- [ ] `.env.example` 作成
+- [ ] README 追記
+- [ ] 開発/CI での読み込み差異を確認
+
+## 結果
+- 未着手
+
+## 補足
+- 背景: `docs/reports/public-repo-readiness-audit-2026-02-20.md` の Low 対応。


### PR DESCRIPTION
### Motivation
- Add a short, actionable repository-wide readiness audit to surface security and governance gaps before transitioning the repository from private to public.

### Description
- Add `docs/reports/public-repo-readiness-audit-2026-02-20.md` which records scan results and manual findings (secret-scan summary, missing `SECURITY.md`/`LICENSE`/`CODEOWNERS`, risk of committing `.trading25.key`, and a Phase A/B/C remediation plan).

### Testing
- Performed automated pattern scans and checks including `rg` for common secret/key patterns, inspected `.gitignore` and CI (`.github/workflows/ci.yml`), and ran `test -f` checks for `SECURITY.md`/`LICENSE`/`.github/CODEOWNERS`/`.github/dependabot.yml`, and committed the generated report when checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998eade1b1083318bcfdd588cbb9a9f)