### PR TITLE
fix(web): restore screening default results and table scrolling

### DIFF
--- a/apps/ts/packages/web/src/components/Screening/ScreeningTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { ScreeningResultItem } from '@/types/screening';
 import { ScreeningTable } from './ScreeningTable';
@@ -38,5 +39,16 @@ describe('ScreeningTable', () => {
   it('shows updating indicator while refetching', () => {
     render(<ScreeningTable results={mockResults} isLoading={false} isFetching error={null} onStockClick={vi.fn()} />);
     expect(screen.getByText('Updating...')).toBeInTheDocument();
+  });
+
+  it('calls onStockClick when a row is clicked', async () => {
+    const user = userEvent.setup();
+    const onStockClick = vi.fn();
+
+    render(<ScreeningTable results={mockResults} isLoading={false} error={null} onStockClick={onStockClick} />);
+
+    await user.click(screen.getByText('7203'));
+
+    expect(onStockClick).toHaveBeenCalledWith('7203');
   });
 });

--- a/apps/ts/packages/web/src/components/Screening/ScreeningTable.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningTable.tsx
@@ -14,11 +14,13 @@ interface ScreeningTableProps {
 
 export function ScreeningTable({ results, isLoading, isFetching = false, error, onStockClick }: ScreeningTableProps) {
   return (
-    <Card className="glass-panel overflow-hidden flex-1">
+    <Card className="glass-panel overflow-hidden flex flex-1 min-h-0 flex-col">
       <CardHeader className="border-b border-border/30 py-3">
         <CardTitle className="text-base flex items-center gap-2">
           Screening Results
-          {results.length > 0 && <span className="text-sm font-normal text-muted-foreground ml-2">({results.length})</span>}
+          {results.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground ml-2">({results.length})</span>
+          )}
           {isFetching && (
             <span className="inline-flex items-center gap-1 text-xs font-normal text-muted-foreground ml-2">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -27,7 +29,7 @@ export function ScreeningTable({ results, isLoading, isFetching = false, error, 
           )}
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-0 overflow-auto" style={{ maxHeight: 'calc(100vh - 280px)' }}>
+      <CardContent className="p-0 flex-1 min-h-0 overflow-auto">
         <DataStateWrapper
           isLoading={isLoading}
           error={error}

--- a/apps/ts/packages/web/src/hooks/useScreening.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useScreening.test.tsx
@@ -1,15 +1,20 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { apiGet, apiPost } from '@/lib/api-client';
+import { ApiError, apiGet, apiPost } from '@/lib/api-client';
 import { createTestWrapper } from '@/test-utils';
-import {
-  useCancelScreeningJob,
-  useRunScreeningJob,
-  useScreeningJobStatus,
-  useScreeningResult,
-} from './useScreening';
+import { logger } from '@/utils/logger';
+import { useCancelScreeningJob, useRunScreeningJob, useScreeningJobStatus, useScreeningResult } from './useScreening';
 
 vi.mock('@/lib/api-client', () => ({
+  ApiError: class ApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
   apiGet: vi.fn(),
   apiPost: vi.fn(),
   apiPut: vi.fn(),
@@ -58,6 +63,24 @@ describe('useRunScreeningJob', () => {
       limit: undefined,
     });
   });
+
+  it('logs error when starting screening job fails', async () => {
+    vi.mocked(apiPost).mockRejectedValueOnce(new Error('network'));
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useRunScreeningJob(), { wrapper });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          markets: 'prime',
+          recentDays: 10,
+        })
+      ).rejects.toThrow('network');
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Failed to start screening job', { error: 'network' });
+  });
 });
 
 describe('useScreeningJobStatus', () => {
@@ -83,6 +106,38 @@ describe('useScreeningJobStatus', () => {
     const { wrapper } = createTestWrapper();
     const { result } = renderHook(() => useScreeningJobStatus(null), { wrapper });
     expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('does not retry when job status returns 404', async () => {
+    vi.mocked(apiGet).mockRejectedValue(new ApiError('not found', 404));
+
+    const { queryClient, wrapper } = createTestWrapper();
+    queryClient.setDefaultOptions({
+      queries: {
+        retryDelay: 0,
+      },
+    });
+
+    const { result } = renderHook(() => useScreeningJobStatus('missing-job'), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(apiGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries up to two times for non-404 errors', async () => {
+    vi.mocked(apiGet).mockRejectedValue(new ApiError('server error', 500));
+
+    const { queryClient, wrapper } = createTestWrapper();
+    queryClient.setDefaultOptions({
+      queries: {
+        retryDelay: 0,
+      },
+    });
+
+    const { result } = renderHook(() => useScreeningJobStatus('job-500'), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(apiGet).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -112,6 +167,14 @@ describe('useScreeningResult', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiGet).toHaveBeenCalledWith('/api/analytics/screening/result/job-2');
   });
+
+  it('is disabled when explicit enabled flag is false', () => {
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useScreeningResult('job-2', false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(apiGet).not.toHaveBeenCalled();
+  });
 });
 
 describe('useCancelScreeningJob', () => {
@@ -133,5 +196,20 @@ describe('useCancelScreeningJob', () => {
     });
 
     expect(apiPost).toHaveBeenCalledWith('/api/analytics/screening/jobs/job-3/cancel');
+  });
+
+  it('logs error when cancellation fails', async () => {
+    vi.mocked(apiPost).mockRejectedValueOnce(new Error('cancel failed'));
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useCancelScreeningJob(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync('job-3')).rejects.toThrow('cancel failed');
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Failed to cancel screening job', {
+      error: 'cancel failed',
+    });
   });
 });

--- a/apps/ts/packages/web/src/hooks/useScreening.ts
+++ b/apps/ts/packages/web/src/hooks/useScreening.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiGet, apiPost } from '@/lib/api-client';
+import { ApiError, apiGet, apiPost } from '@/lib/api-client';
 import type {
   MarketScreeningResponse,
   ScreeningJobRequest,
@@ -66,6 +66,10 @@ export function useScreeningJobStatus(jobId: string | null) {
       return fetchScreeningJobStatus(jobId);
     },
     enabled: !!jobId,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status === 404) return false;
+      return failureCount < 2;
+    },
     refetchInterval: (query) => {
       const status = query.state.data?.status;
       if (status === 'running' || status === 'pending') return 2000;


### PR DESCRIPTION
## Summary
- clear stale screening job IDs when backend returns 404 so cached screening results remain visible
- stop retrying screening job status on 404 to avoid noisy repeated requests
- fix screening results panel layout with flex/min-h-0/overflow-auto so long result lists are scrollable
- refactor AnalysisPage rendering into focused subcomponents and add targeted regression tests

## Testing
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test src/pages/AnalysisPage.test.tsx src/hooks/useScreening.test.tsx src/components/Screening/ScreeningTable.test.tsx
- bun run --filter @trading25/web test --coverage src/pages/AnalysisPage.test.tsx src/hooks/useScreening.test.tsx src/components/Screening/ScreeningTable.test.tsx --coverage.include=src/pages/AnalysisPage.tsx --coverage.include=src/hooks/useScreening.ts --coverage.include=src/components/Screening/ScreeningTable.tsx
- bunx --bun biome check packages/web/src/pages/AnalysisPage.tsx packages/web/src/pages/AnalysisPage.test.tsx packages/web/src/hooks/useScreening.ts packages/web/src/hooks/useScreening.test.tsx packages/web/src/components/Screening/ScreeningTable.tsx packages/web/src/components/Screening/ScreeningTable.test.tsx