### PR TITLE
chore(skills): refresh stale openapi path reference

### DIFF
--- a/.codex/skills/ts-api-endpoints/references/openapi-paths.md
+++ b/.codex/skills/ts-api-endpoints/references/openapi-paths.md
@@ -2,13 +2,14 @@
 
 Generated from `apps/ts/packages/shared/openapi/bt-openapi.json`. Do not edit manually.
 
-Total paths: **117**
+Total paths: **118**
 
 ## /api/analytics
 
 | Path | Methods |
 |---|---|
 | `/api/analytics/factor-regression/{symbol}` | `GET` |
+| `/api/analytics/fundamental-ranking` | `GET` |
 | `/api/analytics/fundamentals/{symbol}` | `GET` |
 | `/api/analytics/portfolio-factor-regression/{portfolioId}` | `GET` |
 | `/api/analytics/ranking` | `GET` |


### PR DESCRIPTION
## Summary
- refresh generated skill reference for ts-api-endpoints
- include newly added /api/analytics/fundamental-ranking path
- fix CI failures in quality and package-unit-tests caused by stale reference check

## Validation
- python3 scripts/skills/refresh_skill_references.py --check
- python3 scripts/skills/audit_skills.py --strict-legacy
- uv run --project /Users/shinjiroaso/dev/trading25/apps/bt pytest apps/bt/tests/unit/scripts/test_refresh_skill_references.py