### PR TITLE
fix(dataset): align dataset info contract and harden info dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする
+- Dataset API `GET /api/dataset/{name}/info` の SoT は `snapshot` + `stats` + `validation`（`details.dataCoverage` / `details.fkIntegrity` / `details.stockCountValidation` 含む）とし、web 側は legacy `snapshot` 形式を正規化して後方互換を維持する
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Screening API は非同期ジョブ方式（`POST /api/analytics/screening/jobs` / `GET /api/analytics/screening/jobs/{id}` / `POST /api/analytics/screening/jobs/{id}/cancel` / `GET /api/analytics/screening/result/{id}`）を SoT とする。旧 `GET /api/analytics/screening` は 410
 - Screening 実行時のデータ SoT は `market.db`（`stock_data` / `topix_data` / `indices_data` / `stocks`）とし、dataset へのフォールバックを禁止する

--- a/apps/bt/src/application/services/dataset_service.py
+++ b/apps/bt/src/application/services/dataset_service.py
@@ -9,18 +9,38 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
-from src.infrastructure.db.market.dataset_db import DatasetDb
+from src.application.services.dataset_presets import get_preset
+from src.application.services.dataset_resolver import DatasetResolver
 from src.entrypoints.http.schemas.dataset import (
+    DatasetDataCoverage,
+    DatasetExpectedRange,
+    DatasetFkIntegrity,
     DatasetInfoResponse,
     DatasetListItem,
     DatasetSampleResponse,
     DatasetSearchResponse,
     DatasetSnapshot,
+    DatasetSnapshotDateRange,
+    DatasetSnapshotValidation,
+    DatasetStats,
+    DatasetStatsDateRange,
+    DatasetStockCountValidation,
     DatasetValidation,
-    DateRange,
+    DatasetValidationDetails,
     SearchResultItem,
 )
-from src.application.services.dataset_resolver import DatasetResolver
+from src.infrastructure.db.market.dataset_db import DatasetDb
+
+
+def _read_dataset_metadata(db: DatasetDb | None) -> tuple[str | None, str | None]:
+    if db is None:
+        return None, None
+    try:
+        metadata = db.get_dataset_info()
+    except Exception:
+        # metadata is optional; keep listing even if dataset_info is missing/corrupted
+        return None, None
+    return metadata.get("preset"), metadata.get("created_at")
 
 
 def list_datasets(resolver: DatasetResolver) -> list[DatasetListItem]:
@@ -30,17 +50,30 @@ def list_datasets(resolver: DatasetResolver) -> list[DatasetListItem]:
         db_path = resolver.get_db_path(name)
         try:
             stat = os.stat(db_path)
+            preset, created_at = _read_dataset_metadata(resolver.resolve(name))
+
             items.append(
                 DatasetListItem(
                     name=name,
                     path=db_path,
                     fileSize=stat.st_size,
                     lastModified=datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                    preset=preset,
+                    createdAt=created_at,
                 )
             )
         except OSError:
             continue
     return items
+
+
+def _parse_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def get_dataset_info(resolver: DatasetResolver, name: str) -> DatasetInfoResponse | None:
@@ -57,18 +90,77 @@ def get_dataset_info(resolver: DatasetResolver, name: str) -> DatasetInfoRespons
     date_range = db.get_date_range()
     stock_count = db.get_stock_count()
     stocks_with_quotes = db.get_stocks_with_quotes_count()
+    stocks_with_margin = db.get_stocks_with_margin_count()
+    stocks_with_statements = db.get_stocks_with_statements_count()
+    fk_orphans = db.get_fk_orphan_counts()
+    orphan_stocks_count = db.get_stocks_without_quotes_count()
 
     errors: list[str] = []
     warnings: list[str] = []
+    preset_name = info.get("preset")
+    preset_config = get_preset(preset_name) if preset_name else None
+    expected_stock_count = _parse_int(info.get("stock_count"))
+    is_within_expected_stock_count = expected_stock_count is None or expected_stock_count == stock_count
+    total_quotes = table_counts.get("stock_data", 0)
+    topix_count = table_counts.get("topix_data", 0)
+    margin_count = table_counts.get("margin_data", 0)
+    statements_count = table_counts.get("statements", 0)
+    indices_count = table_counts.get("indices_data", 0)
+    has_margin_data = margin_count > 0
+    has_topix_data = topix_count > 0
+    has_sector_data = indices_count > 0
+    has_statements_data = statements_count > 0
 
     if stock_count == 0:
         errors.append("No stocks found")
-    if table_counts.get("stock_data", 0) == 0:
+    if total_quotes == 0:
         errors.append("No stock data found")
     if stocks_with_quotes == 0:
         warnings.append("No stocks have OHLCV data")
-    if table_counts.get("topix_data", 0) == 0:
+    if not is_within_expected_stock_count:
+        warnings.append(
+            "Stock count mismatch: "
+            f"expected={expected_stock_count}, actual={stock_count}"
+        )
+    if not has_topix_data and (preset_config is None or preset_config.include_topix):
         warnings.append("No TOPIX data")
+    if not has_margin_data and preset_config is not None and preset_config.include_margin:
+        warnings.append("No margin data")
+    if not has_statements_data and preset_config is not None and preset_config.include_statements:
+        warnings.append("No statements data")
+    if not has_sector_data and preset_config is not None and preset_config.include_sector_indices:
+        warnings.append("No sector index data")
+    if orphan_stocks_count > 0:
+        warnings.append(f"{orphan_stocks_count} stocks have no OHLCV records")
+
+    if any(count > 0 for count in fk_orphans.values()):
+        errors.append("Foreign key integrity issues detected")
+
+    top_level_validation = DatasetValidation(
+        isValid=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+        details=DatasetValidationDetails(
+            fkIntegrity=DatasetFkIntegrity(**fk_orphans),
+            orphanStocksCount=orphan_stocks_count,
+            stockCountValidation=DatasetStockCountValidation(
+                preset=preset_name,
+                expected=(
+                    DatasetExpectedRange(min=expected_stock_count, max=expected_stock_count)
+                    if expected_stock_count is not None
+                    else None
+                ),
+                actual=stock_count,
+                isWithinRange=is_within_expected_stock_count,
+            ),
+            dataCoverage=DatasetDataCoverage(
+                totalStocks=stock_count,
+                stocksWithQuotes=stocks_with_quotes,
+                stocksWithStatements=stocks_with_statements,
+                stocksWithMargin=stocks_with_margin,
+            ),
+        ),
+    )
 
     return DatasetInfoResponse(
         name=name,
@@ -76,16 +168,32 @@ def get_dataset_info(resolver: DatasetResolver, name: str) -> DatasetInfoRespons
         fileSize=stat.st_size,
         lastModified=datetime.fromtimestamp(stat.st_mtime).isoformat(),
         snapshot=DatasetSnapshot(
-            preset=info.get("preset"),
+            preset=preset_name,
+            createdAt=info.get("created_at"),
             totalStocks=stock_count,
             stocksWithQuotes=stocks_with_quotes,
-            dateRange=DateRange(**date_range) if date_range else None,
-            validation=DatasetValidation(
-                isValid=len(errors) == 0,
-                errors=errors,
-                warnings=warnings,
+            dateRange=DatasetSnapshotDateRange(**date_range) if date_range else None,
+            validation=DatasetSnapshotValidation(
+                isValid=top_level_validation.isValid,
+                errors=top_level_validation.errors,
+                warnings=top_level_validation.warnings,
             ),
         ),
+        stats=DatasetStats(
+            totalStocks=stock_count,
+            totalQuotes=total_quotes,
+            dateRange=(
+                DatasetStatsDateRange(from_=date_range["min"], to=date_range["max"])
+                if date_range
+                else DatasetStatsDateRange(from_="-", to="-")
+            ),
+            hasMarginData=has_margin_data,
+            hasTOPIXData=has_topix_data,
+            hasSectorData=has_sector_data,
+            hasStatementsData=has_statements_data,
+            statementsFieldCoverage=None,
+        ),
+        validation=top_level_validation,
     )
 
 

--- a/apps/bt/src/entrypoints/http/schemas/dataset.py
+++ b/apps/bt/src/entrypoints/http/schemas/dataset.py
@@ -6,7 +6,7 @@ Dataset 管理エンドポイントのリクエスト/レスポンススキー�
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # --- List ---
@@ -17,17 +17,25 @@ class DatasetListItem(BaseModel):
     path: str = Field(description="Full file path")
     fileSize: int = Field(description="File size in bytes")
     lastModified: str = Field(description="Last modified ISO datetime")
+    preset: str | None = Field(default=None, description="Preset name used to create dataset")
+    createdAt: str | None = Field(default=None, description="Created datetime stored in dataset_info")
 
 
 # --- Info ---
 
 
-class DateRange(BaseModel):
+class DatasetSnapshotDateRange(BaseModel):
     min: str
     max: str
 
 
-class DatasetValidation(BaseModel):
+class DatasetStatsDateRange(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    from_: str = Field(alias="from")
+    to: str
+
+
+class DatasetSnapshotValidation(BaseModel):
     isValid: bool
     errors: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
@@ -35,10 +43,87 @@ class DatasetValidation(BaseModel):
 
 class DatasetSnapshot(BaseModel):
     preset: str | None = Field(default=None, description="Preset name used")
-    totalStocks: int = Field(description="Number of stocks")
-    stocksWithQuotes: int = Field(description="Stocks with OHLCV data")
-    dateRange: DateRange | None = Field(default=None)
-    validation: DatasetValidation
+    createdAt: str | None = Field(default=None, description="Dataset created datetime")
+    totalStocks: int = Field(default=0, description="Number of stocks")
+    stocksWithQuotes: int = Field(default=0, description="Stocks with OHLCV data")
+    dateRange: DatasetSnapshotDateRange | None = Field(default=None)
+    validation: DatasetSnapshotValidation | None = None
+
+
+class DatasetStatementsFieldCoverage(BaseModel):
+    total: int = 0
+    totalFY: int = 0
+    totalHalf: int = 0
+    hasExtendedFields: bool = False
+    hasCashFlowFields: bool = False
+    earningsPerShare: int = 0
+    profit: int = 0
+    equity: int = 0
+    nextYearForecastEps: int = 0
+    bps: int = 0
+    sales: int = 0
+    operatingProfit: int = 0
+    ordinaryProfit: int = 0
+    operatingCashFlow: int = 0
+    dividendFY: int = 0
+    forecastEps: int = 0
+    investingCashFlow: int = 0
+    financingCashFlow: int = 0
+    cashAndEquivalents: int = 0
+    totalAssets: int = 0
+    sharesOutstanding: int = 0
+    treasuryShares: int = 0
+
+
+class DatasetStats(BaseModel):
+    totalStocks: int = 0
+    totalQuotes: int = 0
+    dateRange: DatasetStatsDateRange
+    hasMarginData: bool = False
+    hasTOPIXData: bool = False
+    hasSectorData: bool = False
+    hasStatementsData: bool = False
+    statementsFieldCoverage: DatasetStatementsFieldCoverage | None = None
+
+
+class DatasetFkIntegrity(BaseModel):
+    stockDataOrphans: int = 0
+    marginDataOrphans: int = 0
+    statementsOrphans: int = 0
+
+
+class DatasetExpectedRange(BaseModel):
+    min: int
+    max: int
+
+
+class DatasetStockCountValidation(BaseModel):
+    preset: str | None = None
+    expected: DatasetExpectedRange | None = None
+    actual: int = 0
+    isWithinRange: bool = True
+
+
+class DatasetDataCoverage(BaseModel):
+    totalStocks: int = 0
+    stocksWithQuotes: int = 0
+    stocksWithStatements: int = 0
+    stocksWithMargin: int = 0
+
+
+class DatasetValidationDetails(BaseModel):
+    dateGapsCount: int | None = None
+    fkIntegrity: DatasetFkIntegrity | None = None
+    orphanStocksCount: int | None = None
+    stockCountValidation: DatasetStockCountValidation | None = None
+    dataCoverage: DatasetDataCoverage | None = None
+
+
+class DatasetValidation(BaseModel):
+    isValid: bool
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    details: DatasetValidationDetails | None = None
 
 
 class DatasetInfoResponse(BaseModel):
@@ -47,6 +132,8 @@ class DatasetInfoResponse(BaseModel):
     fileSize: int
     lastModified: str
     snapshot: DatasetSnapshot
+    stats: DatasetStats
+    validation: DatasetValidation
 
 
 # --- Sample ---

--- a/apps/bt/tests/unit/server/test_dataset_service.py
+++ b/apps/bt/tests/unit/server/test_dataset_service.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from src.application.services import dataset_service
+
+
+class DummyResolver:
+    def __init__(self, base_dir: Path, names: list[str], db_by_name: dict[str, object | None]) -> None:
+        self._base_dir = base_dir
+        self._names = names
+        self._db_by_name = db_by_name
+
+    def list_datasets(self) -> list[str]:
+        return self._names
+
+    def get_db_path(self, name: str) -> str:
+        return str(self._base_dir / f"{name}.db")
+
+    def resolve(self, name: str) -> object | None:
+        return self._db_by_name.get(name)
+
+    def evict(self, name: str) -> None:
+        self._db_by_name.pop(name, None)
+
+
+class DummyDb:
+    def __init__(
+        self,
+        info: dict[str, str],
+        table_counts: dict[str, int],
+        date_range: dict[str, str] | None,
+        stock_count: int,
+        stocks_with_quotes: int,
+        stocks_with_margin: int,
+        stocks_with_statements: int,
+        fk_orphans: dict[str, int],
+        stocks_without_quotes: int,
+    ) -> None:
+        self._info = info
+        self._table_counts = table_counts
+        self._date_range = date_range
+        self._stock_count = stock_count
+        self._stocks_with_quotes = stocks_with_quotes
+        self._stocks_with_margin = stocks_with_margin
+        self._stocks_with_statements = stocks_with_statements
+        self._fk_orphans = fk_orphans
+        self._stocks_without_quotes = stocks_without_quotes
+
+    def get_dataset_info(self) -> dict[str, str]:
+        return self._info
+
+    def get_table_counts(self) -> dict[str, int]:
+        return self._table_counts
+
+    def get_date_range(self) -> dict[str, str] | None:
+        return self._date_range
+
+    def get_stock_count(self) -> int:
+        return self._stock_count
+
+    def get_stocks_with_quotes_count(self) -> int:
+        return self._stocks_with_quotes
+
+    def get_stocks_with_margin_count(self) -> int:
+        return self._stocks_with_margin
+
+    def get_stocks_with_statements_count(self) -> int:
+        return self._stocks_with_statements
+
+    def get_fk_orphan_counts(self) -> dict[str, int]:
+        return self._fk_orphans
+
+    def get_stocks_without_quotes_count(self) -> int:
+        return self._stocks_without_quotes
+
+
+def test_list_datasets_skips_missing_files_and_handles_optional_metadata(tmp_path: Path) -> None:
+    (tmp_path / "a.db").write_text("", encoding="utf-8")
+    (tmp_path / "b.db").write_text("", encoding="utf-8")
+
+    class MetadataErrorDb:
+        def get_dataset_info(self) -> dict[str, str]:
+            raise RuntimeError("broken metadata")
+
+    resolver = DummyResolver(
+        base_dir=tmp_path,
+        names=["a", "b", "missing"],
+        db_by_name={
+            "a": None,  # metadata is optional
+            "b": MetadataErrorDb(),  # metadata read failure is optional
+        },
+    )
+
+    items = dataset_service.list_datasets(cast(Any, resolver))
+
+    assert [item.name for item in items] == ["a", "b"]
+    assert items[0].preset is None and items[0].createdAt is None
+    assert items[1].preset is None and items[1].createdAt is None
+
+
+def test_get_dataset_info_with_sparse_data_returns_errors_and_warnings(tmp_path: Path) -> None:
+    db_path = tmp_path / "sparse.db"
+    db_path.write_text("", encoding="utf-8")
+
+    db = DummyDb(
+        info={"preset": "primeMarket", "stock_count": "oops", "created_at": "2026-01-01T00:00:00+00:00"},
+        table_counts={
+            "stock_data": 0,
+            "topix_data": 0,
+            "margin_data": 0,
+            "statements": 0,
+            "indices_data": 0,
+        },
+        date_range=None,
+        stock_count=0,
+        stocks_with_quotes=0,
+        stocks_with_margin=0,
+        stocks_with_statements=0,
+        fk_orphans={"stockDataOrphans": 1, "marginDataOrphans": 0, "statementsOrphans": 2},
+        stocks_without_quotes=3,
+    )
+    resolver = DummyResolver(tmp_path, ["sparse"], {"sparse": db})
+
+    info = dataset_service.get_dataset_info(cast(Any, resolver), "sparse")
+    assert info is not None
+    assert info.validation.isValid is False
+    assert "No stocks found" in info.validation.errors
+    assert "No stock data found" in info.validation.errors
+    assert "Foreign key integrity issues detected" in info.validation.errors
+    assert "No stocks have OHLCV data" in info.validation.warnings
+    assert "No TOPIX data" in info.validation.warnings
+    assert "No margin data" in info.validation.warnings
+    assert "No statements data" in info.validation.warnings
+    assert "No sector index data" in info.validation.warnings
+    assert "3 stocks have no OHLCV records" in info.validation.warnings
+    assert info.validation.details is not None
+    assert info.validation.details.stockCountValidation is not None
+    assert info.validation.details.stockCountValidation.expected is None
+    assert info.stats.dateRange.from_ == "-"
+    assert info.stats.dateRange.to == "-"
+    assert info.snapshot.createdAt == "2026-01-01T00:00:00+00:00"
+
+
+def test_get_dataset_info_with_healthy_data_has_no_warnings(tmp_path: Path) -> None:
+    db_path = tmp_path / "healthy.db"
+    db_path.write_text("", encoding="utf-8")
+
+    db = DummyDb(
+        info={"preset": "primeMarket", "stock_count": "2"},
+        table_counts={
+            "stock_data": 20,
+            "topix_data": 10,
+            "margin_data": 10,
+            "statements": 10,
+            "indices_data": 10,
+        },
+        date_range={"min": "2024-01-01", "max": "2024-12-31"},
+        stock_count=2,
+        stocks_with_quotes=2,
+        stocks_with_margin=2,
+        stocks_with_statements=2,
+        fk_orphans={"stockDataOrphans": 0, "marginDataOrphans": 0, "statementsOrphans": 0},
+        stocks_without_quotes=0,
+    )
+    resolver = DummyResolver(tmp_path, ["healthy"], {"healthy": db})
+
+    info = dataset_service.get_dataset_info(cast(Any, resolver), "healthy")
+    assert info is not None
+    assert info.validation.isValid is True
+    assert info.validation.errors == []
+    assert info.validation.warnings == []
+    assert info.validation.details is not None
+    assert info.validation.details.stockCountValidation is not None
+    assert info.validation.details.stockCountValidation.isWithinRange is True
+    assert info.stats.dateRange.from_ == "2024-01-01"
+    assert info.stats.dateRange.to == "2024-12-31"
+    assert info.stats.hasMarginData is True
+    assert info.stats.hasTOPIXData is True
+    assert info.stats.hasSectorData is True
+    assert info.stats.hasStatementsData is True
+
+
+def test_get_dataset_info_without_stock_count_metadata_uses_none_expected(tmp_path: Path) -> None:
+    db_path = tmp_path / "nostockcount.db"
+    db_path.write_text("", encoding="utf-8")
+
+    db = DummyDb(
+        info={},
+        table_counts={
+            "stock_data": 1,
+            "topix_data": 0,
+            "margin_data": 0,
+            "statements": 0,
+            "indices_data": 0,
+        },
+        date_range={"min": "2024-01-01", "max": "2024-01-01"},
+        stock_count=1,
+        stocks_with_quotes=1,
+        stocks_with_margin=0,
+        stocks_with_statements=0,
+        fk_orphans={"stockDataOrphans": 0, "marginDataOrphans": 0, "statementsOrphans": 0},
+        stocks_without_quotes=0,
+    )
+    resolver = DummyResolver(tmp_path, ["nostockcount"], {"nostockcount": db})
+
+    info = dataset_service.get_dataset_info(cast(Any, resolver), "nostockcount")
+    assert info is not None
+    assert info.validation.details is not None
+    assert info.validation.details.stockCountValidation is not None
+    assert info.validation.details.stockCountValidation.expected is None
+    assert "No TOPIX data" in info.validation.warnings
+
+
+def test_search_dataset_deduplicates_exact_and_partial_results() -> None:
+    class SearchDb:
+        def search_stocks(self, term: str, exact: bool, limit: int):
+            if exact:
+                return [
+                    SimpleNamespace(code="7203", company_name="トヨタ"),
+                    SimpleNamespace(code="7203", company_name="トヨタ"),
+                ]
+            return [
+                SimpleNamespace(code="7203", company_name="トヨタ"),
+                SimpleNamespace(code="6758", company_name="ソニー"),
+            ]
+
+    result = dataset_service.search_dataset(cast(Any, SearchDb()), q="ト", limit=50)
+    assert [row.code for row in result.results] == ["7203", "6758"]
+    assert result.results[0].match_type == "exact"
+    assert result.results[1].match_type == "partial"

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -22837,23 +22837,39 @@
         "title": "ErrorResponse",
         "type": "object"
       },
-      "src__server__schemas__portfolio_factor_regression__DateRange": {
+      "src__server__schemas__factor_regression__IndexMatch": {
         "properties": {
-          "from": {
+          "indexCode": {
             "type": "string",
-            "title": "From"
+            "title": "Indexcode"
           },
-          "to": {
+          "indexName": {
             "type": "string",
-            "title": "To"
+            "title": "Indexname"
+          },
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "rSquared": {
+            "type": "number",
+            "title": "Rsquared"
+          },
+          "beta": {
+            "type": "number",
+            "title": "Beta"
           }
         },
         "type": "object",
         "required": [
-          "from",
-          "to"
+          "indexCode",
+          "indexName",
+          "category",
+          "rSquared",
+          "beta"
         ],
-        "title": "DateRange"
+        "title": "IndexMatch",
+        "description": "指数マッチ結果"
       },
       "src__server__schemas__factor_regression__DateRange": {
         "properties": {
@@ -22892,6 +22908,24 @@
         ],
         "title": "DateRange"
       },
+      "src__server__schemas__portfolio_factor_regression__DateRange": {
+        "properties": {
+          "from": {
+            "type": "string",
+            "title": "From"
+          },
+          "to": {
+            "type": "string",
+            "title": "To"
+          }
+        },
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "title": "DateRange"
+      },
       "src__server__schemas__dataset__DateRange": {
         "properties": {
           "min": {
@@ -22909,40 +22943,6 @@
           "max"
         ],
         "title": "DateRange"
-      },
-      "src__server__schemas__factor_regression__IndexMatch": {
-        "properties": {
-          "indexCode": {
-            "type": "string",
-            "title": "Indexcode"
-          },
-          "indexName": {
-            "type": "string",
-            "title": "Indexname"
-          },
-          "category": {
-            "type": "string",
-            "title": "Category"
-          },
-          "rSquared": {
-            "type": "number",
-            "title": "Rsquared"
-          },
-          "beta": {
-            "type": "number",
-            "title": "Beta"
-          }
-        },
-        "type": "object",
-        "required": [
-          "indexCode",
-          "indexName",
-          "category",
-          "rSquared",
-          "beta"
-        ],
-        "title": "IndexMatch",
-        "description": "指数マッチ結果"
       },
       "src__server__schemas__indicators__OHLCVRecord": {
         "properties": {

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -12345,6 +12345,71 @@
         ],
         "title": "DatasetCreateResponse"
       },
+      "DatasetDataCoverage": {
+        "properties": {
+          "totalStocks": {
+            "type": "integer",
+            "title": "Totalstocks",
+            "default": 0
+          },
+          "stocksWithQuotes": {
+            "type": "integer",
+            "title": "Stockswithquotes",
+            "default": 0
+          },
+          "stocksWithStatements": {
+            "type": "integer",
+            "title": "Stockswithstatements",
+            "default": 0
+          },
+          "stocksWithMargin": {
+            "type": "integer",
+            "title": "Stockswithmargin",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "DatasetDataCoverage"
+      },
+      "DatasetExpectedRange": {
+        "properties": {
+          "min": {
+            "type": "integer",
+            "title": "Min"
+          },
+          "max": {
+            "type": "integer",
+            "title": "Max"
+          }
+        },
+        "type": "object",
+        "required": [
+          "min",
+          "max"
+        ],
+        "title": "DatasetExpectedRange"
+      },
+      "DatasetFkIntegrity": {
+        "properties": {
+          "stockDataOrphans": {
+            "type": "integer",
+            "title": "Stockdataorphans",
+            "default": 0
+          },
+          "marginDataOrphans": {
+            "type": "integer",
+            "title": "Margindataorphans",
+            "default": 0
+          },
+          "statementsOrphans": {
+            "type": "integer",
+            "title": "Statementsorphans",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "DatasetFkIntegrity"
+      },
       "DatasetInfoResponse": {
         "properties": {
           "name": {
@@ -12365,6 +12430,12 @@
           },
           "snapshot": {
             "$ref": "#/components/schemas/DatasetSnapshot"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/DatasetStats"
+          },
+          "validation": {
+            "$ref": "#/components/schemas/DatasetValidation"
           }
         },
         "type": "object",
@@ -12373,7 +12444,9 @@
           "path",
           "fileSize",
           "lastModified",
-          "snapshot"
+          "snapshot",
+          "stats",
+          "validation"
         ],
         "title": "DatasetInfoResponse"
       },
@@ -12531,6 +12604,30 @@
             "type": "string",
             "title": "Lastmodified",
             "description": "Last modified ISO datetime"
+          },
+          "preset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preset",
+            "description": "Preset name used to create dataset"
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdat",
+            "description": "Created datetime stored in dataset_info"
           }
         },
         "type": "object",
@@ -12589,20 +12686,34 @@
             "title": "Preset",
             "description": "Preset name used"
           },
+          "createdAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdat",
+            "description": "Dataset created datetime"
+          },
           "totalStocks": {
             "type": "integer",
             "title": "Totalstocks",
-            "description": "Number of stocks"
+            "description": "Number of stocks",
+            "default": 0
           },
           "stocksWithQuotes": {
             "type": "integer",
             "title": "Stockswithquotes",
-            "description": "Stocks with OHLCV data"
+            "description": "Stocks with OHLCV data",
+            "default": 0
           },
           "dateRange": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/src__server__schemas__dataset__DateRange"
+                "$ref": "#/components/schemas/DatasetSnapshotDateRange"
               },
               {
                 "type": "null"
@@ -12610,18 +12721,38 @@
             ]
           },
           "validation": {
-            "$ref": "#/components/schemas/DatasetValidation"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetSnapshotValidation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "DatasetSnapshot"
+      },
+      "DatasetSnapshotDateRange": {
+        "properties": {
+          "min": {
+            "type": "string",
+            "title": "Min"
+          },
+          "max": {
+            "type": "string",
+            "title": "Max"
           }
         },
         "type": "object",
         "required": [
-          "totalStocks",
-          "stocksWithQuotes",
-          "validation"
+          "min",
+          "max"
         ],
-        "title": "DatasetSnapshot"
+        "title": "DatasetSnapshotDateRange"
       },
-      "DatasetValidation": {
+      "DatasetSnapshotValidation": {
         "properties": {
           "isValid": {
             "type": "boolean",
@@ -12646,7 +12777,325 @@
         "required": [
           "isValid"
         ],
+        "title": "DatasetSnapshotValidation"
+      },
+      "DatasetStatementsFieldCoverage": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "totalFY": {
+            "type": "integer",
+            "title": "Totalfy",
+            "default": 0
+          },
+          "totalHalf": {
+            "type": "integer",
+            "title": "Totalhalf",
+            "default": 0
+          },
+          "hasExtendedFields": {
+            "type": "boolean",
+            "title": "Hasextendedfields",
+            "default": false
+          },
+          "hasCashFlowFields": {
+            "type": "boolean",
+            "title": "Hascashflowfields",
+            "default": false
+          },
+          "earningsPerShare": {
+            "type": "integer",
+            "title": "Earningspershare",
+            "default": 0
+          },
+          "profit": {
+            "type": "integer",
+            "title": "Profit",
+            "default": 0
+          },
+          "equity": {
+            "type": "integer",
+            "title": "Equity",
+            "default": 0
+          },
+          "nextYearForecastEps": {
+            "type": "integer",
+            "title": "Nextyearforecasteps",
+            "default": 0
+          },
+          "bps": {
+            "type": "integer",
+            "title": "Bps",
+            "default": 0
+          },
+          "sales": {
+            "type": "integer",
+            "title": "Sales",
+            "default": 0
+          },
+          "operatingProfit": {
+            "type": "integer",
+            "title": "Operatingprofit",
+            "default": 0
+          },
+          "ordinaryProfit": {
+            "type": "integer",
+            "title": "Ordinaryprofit",
+            "default": 0
+          },
+          "operatingCashFlow": {
+            "type": "integer",
+            "title": "Operatingcashflow",
+            "default": 0
+          },
+          "dividendFY": {
+            "type": "integer",
+            "title": "Dividendfy",
+            "default": 0
+          },
+          "forecastEps": {
+            "type": "integer",
+            "title": "Forecasteps",
+            "default": 0
+          },
+          "investingCashFlow": {
+            "type": "integer",
+            "title": "Investingcashflow",
+            "default": 0
+          },
+          "financingCashFlow": {
+            "type": "integer",
+            "title": "Financingcashflow",
+            "default": 0
+          },
+          "cashAndEquivalents": {
+            "type": "integer",
+            "title": "Cashandequivalents",
+            "default": 0
+          },
+          "totalAssets": {
+            "type": "integer",
+            "title": "Totalassets",
+            "default": 0
+          },
+          "sharesOutstanding": {
+            "type": "integer",
+            "title": "Sharesoutstanding",
+            "default": 0
+          },
+          "treasuryShares": {
+            "type": "integer",
+            "title": "Treasuryshares",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "DatasetStatementsFieldCoverage"
+      },
+      "DatasetStats": {
+        "properties": {
+          "totalStocks": {
+            "type": "integer",
+            "title": "Totalstocks",
+            "default": 0
+          },
+          "totalQuotes": {
+            "type": "integer",
+            "title": "Totalquotes",
+            "default": 0
+          },
+          "dateRange": {
+            "$ref": "#/components/schemas/DatasetStatsDateRange"
+          },
+          "hasMarginData": {
+            "type": "boolean",
+            "title": "Hasmargindata",
+            "default": false
+          },
+          "hasTOPIXData": {
+            "type": "boolean",
+            "title": "Hastopixdata",
+            "default": false
+          },
+          "hasSectorData": {
+            "type": "boolean",
+            "title": "Hassectordata",
+            "default": false
+          },
+          "hasStatementsData": {
+            "type": "boolean",
+            "title": "Hasstatementsdata",
+            "default": false
+          },
+          "statementsFieldCoverage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetStatementsFieldCoverage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "dateRange"
+        ],
+        "title": "DatasetStats"
+      },
+      "DatasetStatsDateRange": {
+        "properties": {
+          "from": {
+            "type": "string",
+            "title": "From"
+          },
+          "to": {
+            "type": "string",
+            "title": "To"
+          }
+        },
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "title": "DatasetStatsDateRange"
+      },
+      "DatasetStockCountValidation": {
+        "properties": {
+          "preset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preset"
+          },
+          "expected": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExpectedRange"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "actual": {
+            "type": "integer",
+            "title": "Actual",
+            "default": 0
+          },
+          "isWithinRange": {
+            "type": "boolean",
+            "title": "Iswithinrange",
+            "default": true
+          }
+        },
+        "type": "object",
+        "title": "DatasetStockCountValidation"
+      },
+      "DatasetValidation": {
+        "properties": {
+          "isValid": {
+            "type": "boolean",
+            "title": "Isvalid"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetValidationDetails"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "isValid"
+        ],
         "title": "DatasetValidation"
+      },
+      "DatasetValidationDetails": {
+        "properties": {
+          "dateGapsCount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dategapscount"
+          },
+          "fkIntegrity": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetFkIntegrity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "orphanStocksCount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Orphanstockscount"
+          },
+          "stockCountValidation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetStockCountValidation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "dataCoverage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetDataCoverage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "DatasetValidationDetails"
       },
       "DateRange": {
         "properties": {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -2984,6 +2984,54 @@ export interface components {
             /** Estimatedtime */
             estimatedTime?: string | null;
         };
+        /** DatasetDataCoverage */
+        DatasetDataCoverage: {
+            /**
+             * Totalstocks
+             * @default 0
+             */
+            totalStocks: number;
+            /**
+             * Stockswithquotes
+             * @default 0
+             */
+            stocksWithQuotes: number;
+            /**
+             * Stockswithstatements
+             * @default 0
+             */
+            stocksWithStatements: number;
+            /**
+             * Stockswithmargin
+             * @default 0
+             */
+            stocksWithMargin: number;
+        };
+        /** DatasetExpectedRange */
+        DatasetExpectedRange: {
+            /** Min */
+            min: number;
+            /** Max */
+            max: number;
+        };
+        /** DatasetFkIntegrity */
+        DatasetFkIntegrity: {
+            /**
+             * Stockdataorphans
+             * @default 0
+             */
+            stockDataOrphans: number;
+            /**
+             * Margindataorphans
+             * @default 0
+             */
+            marginDataOrphans: number;
+            /**
+             * Statementsorphans
+             * @default 0
+             */
+            statementsOrphans: number;
+        };
         /** DatasetInfoResponse */
         DatasetInfoResponse: {
             /** Name */
@@ -2995,6 +3043,8 @@ export interface components {
             /** Lastmodified */
             lastModified: string;
             snapshot: components["schemas"]["DatasetSnapshot"];
+            stats: components["schemas"]["DatasetStats"];
+            validation: components["schemas"]["DatasetValidation"];
         };
         /** DatasetJobResponse */
         DatasetJobResponse: {
@@ -3064,6 +3114,16 @@ export interface components {
              * @description Last modified ISO datetime
              */
             lastModified: string;
+            /**
+             * Preset
+             * @description Preset name used to create dataset
+             */
+            preset?: string | null;
+            /**
+             * Createdat
+             * @description Created datetime stored in dataset_info
+             */
+            createdAt?: string | null;
         };
         /** DatasetSampleResponse */
         DatasetSampleResponse: {
@@ -3086,17 +3146,211 @@ export interface components {
              */
             preset?: string | null;
             /**
+             * Createdat
+             * @description Dataset created datetime
+             */
+            createdAt?: string | null;
+            /**
              * Totalstocks
              * @description Number of stocks
+             * @default 0
              */
             totalStocks: number;
             /**
              * Stockswithquotes
              * @description Stocks with OHLCV data
+             * @default 0
              */
             stocksWithQuotes: number;
-            dateRange?: components["schemas"]["src__server__schemas__dataset__DateRange"] | null;
-            validation: components["schemas"]["DatasetValidation"];
+            dateRange?: components["schemas"]["DatasetSnapshotDateRange"] | null;
+            validation?: components["schemas"]["DatasetSnapshotValidation"] | null;
+        };
+        /** DatasetSnapshotDateRange */
+        DatasetSnapshotDateRange: {
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
+        };
+        /** DatasetSnapshotValidation */
+        DatasetSnapshotValidation: {
+            /** Isvalid */
+            isValid: boolean;
+            /** Errors */
+            errors?: string[];
+            /** Warnings */
+            warnings?: string[];
+        };
+        /** DatasetStatementsFieldCoverage */
+        DatasetStatementsFieldCoverage: {
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
+            /**
+             * Totalfy
+             * @default 0
+             */
+            totalFY: number;
+            /**
+             * Totalhalf
+             * @default 0
+             */
+            totalHalf: number;
+            /**
+             * Hasextendedfields
+             * @default false
+             */
+            hasExtendedFields: boolean;
+            /**
+             * Hascashflowfields
+             * @default false
+             */
+            hasCashFlowFields: boolean;
+            /**
+             * Earningspershare
+             * @default 0
+             */
+            earningsPerShare: number;
+            /**
+             * Profit
+             * @default 0
+             */
+            profit: number;
+            /**
+             * Equity
+             * @default 0
+             */
+            equity: number;
+            /**
+             * Nextyearforecasteps
+             * @default 0
+             */
+            nextYearForecastEps: number;
+            /**
+             * Bps
+             * @default 0
+             */
+            bps: number;
+            /**
+             * Sales
+             * @default 0
+             */
+            sales: number;
+            /**
+             * Operatingprofit
+             * @default 0
+             */
+            operatingProfit: number;
+            /**
+             * Ordinaryprofit
+             * @default 0
+             */
+            ordinaryProfit: number;
+            /**
+             * Operatingcashflow
+             * @default 0
+             */
+            operatingCashFlow: number;
+            /**
+             * Dividendfy
+             * @default 0
+             */
+            dividendFY: number;
+            /**
+             * Forecasteps
+             * @default 0
+             */
+            forecastEps: number;
+            /**
+             * Investingcashflow
+             * @default 0
+             */
+            investingCashFlow: number;
+            /**
+             * Financingcashflow
+             * @default 0
+             */
+            financingCashFlow: number;
+            /**
+             * Cashandequivalents
+             * @default 0
+             */
+            cashAndEquivalents: number;
+            /**
+             * Totalassets
+             * @default 0
+             */
+            totalAssets: number;
+            /**
+             * Sharesoutstanding
+             * @default 0
+             */
+            sharesOutstanding: number;
+            /**
+             * Treasuryshares
+             * @default 0
+             */
+            treasuryShares: number;
+        };
+        /** DatasetStats */
+        DatasetStats: {
+            /**
+             * Totalstocks
+             * @default 0
+             */
+            totalStocks: number;
+            /**
+             * Totalquotes
+             * @default 0
+             */
+            totalQuotes: number;
+            dateRange: components["schemas"]["DatasetStatsDateRange"];
+            /**
+             * Hasmargindata
+             * @default false
+             */
+            hasMarginData: boolean;
+            /**
+             * Hastopixdata
+             * @default false
+             */
+            hasTOPIXData: boolean;
+            /**
+             * Hassectordata
+             * @default false
+             */
+            hasSectorData: boolean;
+            /**
+             * Hasstatementsdata
+             * @default false
+             */
+            hasStatementsData: boolean;
+            statementsFieldCoverage?: components["schemas"]["DatasetStatementsFieldCoverage"] | null;
+        };
+        /** DatasetStatsDateRange */
+        DatasetStatsDateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
+        };
+        /** DatasetStockCountValidation */
+        DatasetStockCountValidation: {
+            /** Preset */
+            preset?: string | null;
+            expected?: components["schemas"]["DatasetExpectedRange"] | null;
+            /**
+             * Actual
+             * @default 0
+             */
+            actual: number;
+            /**
+             * Iswithinrange
+             * @default true
+             */
+            isWithinRange: boolean;
         };
         /** DatasetValidation */
         DatasetValidation: {
@@ -3106,6 +3360,17 @@ export interface components {
             errors?: string[];
             /** Warnings */
             warnings?: string[];
+            details?: components["schemas"]["DatasetValidationDetails"] | null;
+        };
+        /** DatasetValidationDetails */
+        DatasetValidationDetails: {
+            /** Dategapscount */
+            dateGapsCount?: number | null;
+            fkIntegrity?: components["schemas"]["DatasetFkIntegrity"] | null;
+            /** Orphanstockscount */
+            orphanStocksCount?: number | null;
+            stockCountValidation?: components["schemas"]["DatasetStockCountValidation"] | null;
+            dataCoverage?: components["schemas"]["DatasetDataCoverage"] | null;
         };
         /** DateRange */
         DateRange: {

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -7927,12 +7927,21 @@ export interface components {
              */
             correlationId: string;
         };
-        /** DateRange */
-        src__server__schemas__portfolio_factor_regression__DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
+        /**
+         * IndexMatch
+         * @description 指数マッチ結果
+         */
+        src__server__schemas__factor_regression__IndexMatch: {
+            /** Indexcode */
+            indexCode: string;
+            /** Indexname */
+            indexName: string;
+            /** Category */
+            category: string;
+            /** Rsquared */
+            rSquared: number;
+            /** Beta */
+            beta: number;
         };
         /**
          * DateRange
@@ -7952,27 +7961,18 @@ export interface components {
             max: string;
         };
         /** DateRange */
+        src__server__schemas__portfolio_factor_regression__DateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
+        };
+        /** DateRange */
         src__server__schemas__dataset__DateRange: {
             /** Min */
             min: string;
             /** Max */
             max: string;
-        };
-        /**
-         * IndexMatch
-         * @description 指数マッチ結果
-         */
-        src__server__schemas__factor_regression__IndexMatch: {
-            /** Indexcode */
-            indexCode: string;
-            /** Indexname */
-            indexName: string;
-            /** Category */
-            category: string;
-            /** Rsquared */
-            rSquared: number;
-            /** Beta */
-            beta: number;
         };
         /**
          * OHLCVRecord

--- a/apps/ts/packages/web/src/components/Backtest/DatasetInfoDialog.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetInfoDialog.test.tsx
@@ -35,15 +35,7 @@ vi.mock('@/components/ui/dialog', () => ({
 }));
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({
-    children,
-    onClick,
-    disabled,
-  }: {
-    children: ReactNode;
-    onClick?: () => void;
-    disabled?: boolean;
-  }) => (
+  Button: ({ children, onClick, disabled }: { children: ReactNode; onClick?: () => void; disabled?: boolean }) => (
     <button type="button" onClick={onClick} disabled={disabled}>
       {children}
     </button>
@@ -153,7 +145,21 @@ describe('DatasetInfoDialog', () => {
         isValid: false,
         errors: ['missing quotes'],
         warnings: ['partial update'],
-        details: {},
+        details: {
+          dateGapsCount: 3,
+          orphanStocksCount: 2,
+          fkIntegrity: {
+            stockDataOrphans: 1,
+            marginDataOrphans: 0,
+            statementsOrphans: 4,
+          },
+          stockCountValidation: {
+            preset: 'quickTesting',
+            expected: { min: 20, max: 20 },
+            actual: 10,
+            isWithinRange: false,
+          },
+        },
       },
     };
 
@@ -161,5 +167,8 @@ describe('DatasetInfoDialog', () => {
 
     expect(screen.getByText('missing quotes')).toBeInTheDocument();
     expect(screen.getByText('partial update')).toBeInTheDocument();
+    expect(screen.getByText('Date gaps')).toBeInTheDocument();
+    expect(screen.getByText('Stocks without quotes')).toBeInTheDocument();
+    expect(screen.getByText('FK integrity')).toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/Backtest/DatasetInfoDialog.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetInfoDialog.tsx
@@ -86,6 +86,12 @@ function StatementsSchemaSection({ info }: { info: DatasetInfoResponse }) {
 }
 
 function ValidationSection({ info }: { info: DatasetInfoResponse }) {
+  const details = info.validation.details;
+  const hasStockCountValidation = !!details?.stockCountValidation;
+  const hasDateGapCount = typeof details?.dateGapsCount === 'number';
+  const hasOrphanStocksCount = typeof details?.orphanStocksCount === 'number';
+  const hasFkIntegrity = !!details?.fkIntegrity;
+
   return (
     <div>
       <h4 className="font-medium mb-2 flex items-center gap-1">
@@ -113,6 +119,42 @@ function ValidationSection({ info }: { info: DatasetInfoResponse }) {
             </li>
           ))}
         </ul>
+      )}
+      {(hasStockCountValidation || hasDateGapCount || hasOrphanStocksCount || hasFkIntegrity) && (
+        <div className="mt-2 grid grid-cols-2 gap-1 text-xs">
+          {hasStockCountValidation && details?.stockCountValidation && (
+            <>
+              <div className="text-muted-foreground">Stock count</div>
+              <div>
+                {details.stockCountValidation.actual.toLocaleString()} /{' '}
+                {details.stockCountValidation.expected
+                  ? `${details.stockCountValidation.expected.min.toLocaleString()}-${details.stockCountValidation.expected.max.toLocaleString()}`
+                  : 'N/A'}
+              </div>
+            </>
+          )}
+          {hasDateGapCount && (
+            <>
+              <div className="text-muted-foreground">Date gaps</div>
+              <div>{details?.dateGapsCount}</div>
+            </>
+          )}
+          {hasOrphanStocksCount && (
+            <>
+              <div className="text-muted-foreground">Stocks without quotes</div>
+              <div>{details?.orphanStocksCount?.toLocaleString() ?? 0}</div>
+            </>
+          )}
+          {hasFkIntegrity && details?.fkIntegrity && (
+            <>
+              <div className="text-muted-foreground">FK integrity</div>
+              <div>
+                stock:{details.fkIntegrity.stockDataOrphans} / margin:{details.fkIntegrity.marginDataOrphans} /
+                statements:{details.fkIntegrity.statementsOrphans}
+              </div>
+            </>
+          )}
+        </div>
       )}
       {info.validation.isValid && info.validation.warnings.length === 0 && (
         <p className="text-xs text-muted-foreground">問題なし</p>


### PR DESCRIPTION
Summary:\n- Fix Backtest Dataset Info crash due to stats shape mismatch\n- Expand bt dataset info API with snapshot + stats + validation(details)\n- Add web legacy normalization for backward compatibility\n- Extend Dataset Info validation diagnostics in UI\n- Add tests and sync OpenAPI generated types\n\nValidation:\n- bt ruff/pyright/pytest + coverage for changed modules\n- web typecheck/tests + targeted coverage\n- shared bt:sync and bt:check