### PR TITLE
fix: migrate fundamental ranking response to ratio contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ uv run pyright src/              # 型チェック
 - Fundamental signal は `cfo_to_net_profit_ratio`（営業CF/純利益）をサポートし、`consecutive_periods` 判定は比率値同値時でも開示更新（OperatingCashFlow/Profit）を起点に連続判定する
 - Fundamentals は EPS に加えて `dividend_fy` / `forecast_dividend_fy` と `payout_ratio` / `forecast_payout_ratio`（実績/予想）を SoT とし、Charts の Fundamentals panel と Backtest Signal system（`forward_dividend_growth` / `dividend_per_share_growth` / `payout_ratio` / `forward_payout_ratio`）で同一指標を使う。配当性向は API 返却時に percent 単位へ正規化し、decimal スケール値（例: 0.283）を 28.3% として扱う
 - fundamentals 最新値の forecast EPS は同一期末内で `DiscDate` が新しい開示を優先し、旧開示値の逆転表示を防ぐ
-- `/api/analytics/fundamental-ranking` は `market.db`（`statements`/`stocks`/`stock_data`）を SoT とし、`forecastHigh`/`forecastLow`/`actualHigh`/`actualLow` を返す。予想EPSは `revised(四半期) > adjusted FY forecast > raw FY forecast`、実績EPSは最新 FY EPS（share補正）を採用する
+- `/api/analytics/fundamental-ranking` は `market.db`（`statements`/`stocks`/`stock_data`）を SoT とし、`metricKey` と `rankings.ratioHigh` / `rankings.ratioLow` を返す。現在の `metricKey` は `eps_forecast_to_actual`（最新の予想EPS / 最新の実績EPS）で、予想EPSは `revised(四半期) > adjusted FY forecast > raw FY forecast`、実績EPSは最新 FY EPS（share補正）を採用する。将来の比率指標追加は `metricKey` で識別する
 - Strategy group 再振り分けは `/api/strategies/{strategy_name}/move`（`target_category`: `production` / `experimental` / `legacy`）を SoT とし、web の `Backtest > Strategies` から実行する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ GET /api/analytics/screening/result/{job_id}
 ```bash
 GET /api/analytics/fundamental-ranking?markets=prime&limit=20
 ```
-- `fundamental-ranking` は `forecastHigh/forecastLow/actualHigh/actualLow` を返し、予想EPSは `revised > adjusted FY forecast > raw FY forecast` 優先で算出する
+- `fundamental-ranking` は `metricKey` と `rankings.ratioHigh` / `rankings.ratioLow` を返す。現在の `metricKey` は `eps_forecast_to_actual`（最新の予想EPS / 最新の実績EPS）で、予想EPSは `revised > adjusted FY forecast > raw FY forecast` 優先、実績EPSは最新 FY EPS（share補正）を採用する。将来の比率指標追加は `metricKey` で識別する
 
 ## Monorepo Commands (root)
 

--- a/apps/bt/src/entrypoints/http/routes/analytics_complex.py
+++ b/apps/bt/src/entrypoints/http/routes/analytics_complex.py
@@ -96,14 +96,15 @@ async def get_ranking(
     response_model=MarketFundamentalRankingResponse,
     summary="Get market fundamental rankings",
     description=(
-        "Get fundamental rankings including high/low stocks by latest forecast EPS "
-        "and actual EPS."
+        "Get fundamental rankings by ratio (high/low). "
+        "Use metricKey to select ratio metric (currently: eps_forecast_to_actual)."
     ),
 )
 async def get_fundamental_ranking(
     request: Request,
     limit: int = Query(20, ge=1, le=100),
     markets: str = Query("prime"),
+    metricKey: str = Query("eps_forecast_to_actual"),
 ) -> MarketFundamentalRankingResponse:
     """ファンダメンタルランキングを取得"""
     from src.application.services.ranking_service import RankingService
@@ -114,7 +115,7 @@ async def get_fundamental_ranking(
 
     service = RankingService(reader)
     try:
-        return service.get_fundamental_rankings(limit=limit, markets=markets)
+        return service.get_fundamental_rankings(limit=limit, markets=markets, metric_key=metricKey)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:

--- a/apps/bt/src/entrypoints/http/schemas/ranking.py
+++ b/apps/bt/src/entrypoints/http/schemas/ranking.py
@@ -61,19 +61,17 @@ class FundamentalRankingItem(BaseModel):
     sector33Name: str
     currentPrice: float
     volume: float
-    epsValue: float
+    epsValue: float  # latest forecast EPS / latest actual EPS
     disclosedDate: str
     periodType: str
     source: Literal["revised", "fy"]
 
 
 class FundamentalRankings(BaseModel):
-    """4種類のファンダメンタルランキング"""
+    """比率ベースのファンダメンタルランキング"""
 
-    forecastHigh: list[FundamentalRankingItem] = Field(default_factory=list)
-    forecastLow: list[FundamentalRankingItem] = Field(default_factory=list)
-    actualHigh: list[FundamentalRankingItem] = Field(default_factory=list)
-    actualLow: list[FundamentalRankingItem] = Field(default_factory=list)
+    ratioHigh: list[FundamentalRankingItem] = Field(default_factory=list)
+    ratioLow: list[FundamentalRankingItem] = Field(default_factory=list)
 
 
 class MarketFundamentalRankingResponse(BaseModel):
@@ -81,5 +79,6 @@ class MarketFundamentalRankingResponse(BaseModel):
 
     date: str
     markets: list[str]
+    metricKey: str
     rankings: FundamentalRankings
     lastUpdated: str

--- a/apps/bt/tests/unit/server/routes/test_analytics_complex.py
+++ b/apps/bt/tests/unit/server/routes/test_analytics_complex.py
@@ -286,34 +286,35 @@ class TestFundamentalRanking:
         data = resp.json()
         assert "date" in data
         assert "markets" in data
+        assert data["metricKey"] == "eps_forecast_to_actual"
         assert "rankings" in data
         assert "lastUpdated" in data
         rankings = data["rankings"]
-        assert "forecastHigh" in rankings
-        assert "forecastLow" in rankings
-        assert "actualHigh" in rankings
-        assert "actualLow" in rankings
+        assert "ratioHigh" in rankings
+        assert "ratioLow" in rankings
 
     def test_with_limit(self, analytics_client):
         resp = analytics_client.get("/api/analytics/fundamental-ranking?limit=1")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data["rankings"]["forecastHigh"]) <= 1
-        assert len(data["rankings"]["forecastLow"]) <= 1
-        assert len(data["rankings"]["actualHigh"]) <= 1
-        assert len(data["rankings"]["actualLow"]) <= 1
+        assert len(data["rankings"]["ratioHigh"]) <= 1
+        assert len(data["rankings"]["ratioLow"]) <= 1
 
     def test_item_shape(self, analytics_client):
         resp = analytics_client.get("/api/analytics/fundamental-ranking")
         assert resp.status_code == 200
         data = resp.json()
-        if data["rankings"]["forecastHigh"]:
-            item = data["rankings"]["forecastHigh"][0]
+        if data["rankings"]["ratioHigh"]:
+            item = data["rankings"]["ratioHigh"][0]
             assert "code" in item
             assert "companyName" in item
             assert "epsValue" in item
             assert "source" in item
             assert item["source"] in {"fy", "revised"}
+
+    def test_422_unsupported_metric_key(self, analytics_client):
+        resp = analytics_client.get("/api/analytics/fundamental-ranking?metricKey=roe_forecast_to_actual")
+        assert resp.status_code == 422
 
     def test_422_no_db(self):
         app = create_app()

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -6473,7 +6473,7 @@
           "Analytics"
         ],
         "summary": "Get market fundamental rankings",
-        "description": "Get fundamental rankings including high/low stocks by latest forecast EPS and actual EPS.",
+        "description": "Get fundamental rankings by ratio (high/low). Use metricKey to select ratio metric (currently: eps_forecast_to_actual).",
         "operationId": "get_fundamental_ranking_api_analytics_fundamental_ranking_get",
         "parameters": [
           {
@@ -6496,6 +6496,16 @@
               "type": "string",
               "default": "prime",
               "title": "Markets"
+            }
+          },
+          {
+            "name": "metricKey",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "eps_forecast_to_actual",
+              "title": "Metrickey"
             }
           }
         ],
@@ -14014,38 +14024,24 @@
       },
       "FundamentalRankings": {
         "properties": {
-          "forecastHigh": {
+          "ratioHigh": {
             "items": {
               "$ref": "#/components/schemas/FundamentalRankingItem"
             },
             "type": "array",
-            "title": "Forecasthigh"
+            "title": "Ratiohigh"
           },
-          "forecastLow": {
+          "ratioLow": {
             "items": {
               "$ref": "#/components/schemas/FundamentalRankingItem"
             },
             "type": "array",
-            "title": "Forecastlow"
-          },
-          "actualHigh": {
-            "items": {
-              "$ref": "#/components/schemas/FundamentalRankingItem"
-            },
-            "type": "array",
-            "title": "Actualhigh"
-          },
-          "actualLow": {
-            "items": {
-              "$ref": "#/components/schemas/FundamentalRankingItem"
-            },
-            "type": "array",
-            "title": "Actuallow"
+            "title": "Ratiolow"
           }
         },
         "type": "object",
         "title": "FundamentalRankings",
-        "description": "4種類のファンダメンタルランキング"
+        "description": "比率ベースのファンダメンタルランキング"
       },
       "FundamentalsComputeRequest": {
         "properties": {
@@ -16501,6 +16497,10 @@
             "type": "array",
             "title": "Markets"
           },
+          "metricKey": {
+            "type": "string",
+            "title": "Metrickey"
+          },
           "rankings": {
             "$ref": "#/components/schemas/FundamentalRankings"
           },
@@ -16513,6 +16513,7 @@
         "required": [
           "date",
           "markets",
+          "metricKey",
           "rankings",
           "lastUpdated"
         ],
@@ -22890,6 +22891,51 @@
         "title": "DateRange",
         "description": "分析期間"
       },
+      "src__server__schemas__indicators__OHLCVRecord": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date",
+            "description": "日付 (YYYY-MM-DD)"
+          },
+          "open": {
+            "type": "number",
+            "title": "Open",
+            "description": "始値"
+          },
+          "high": {
+            "type": "number",
+            "title": "High",
+            "description": "高値"
+          },
+          "low": {
+            "type": "number",
+            "title": "Low",
+            "description": "安値"
+          },
+          "close": {
+            "type": "number",
+            "title": "Close",
+            "description": "終値"
+          },
+          "volume": {
+            "type": "number",
+            "title": "Volume",
+            "description": "出来高"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume"
+        ],
+        "title": "OHLCVRecord",
+        "description": "OHLCVレコード"
+      },
       "src__server__schemas__db__DateRange": {
         "properties": {
           "min": {
@@ -22943,51 +22989,6 @@
           "max"
         ],
         "title": "DateRange"
-      },
-      "src__server__schemas__indicators__OHLCVRecord": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date",
-            "description": "日付 (YYYY-MM-DD)"
-          },
-          "open": {
-            "type": "number",
-            "title": "Open",
-            "description": "始値"
-          },
-          "high": {
-            "type": "number",
-            "title": "High",
-            "description": "高値"
-          },
-          "low": {
-            "type": "number",
-            "title": "Low",
-            "description": "安値"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close",
-            "description": "終値"
-          },
-          "volume": {
-            "type": "number",
-            "title": "Volume",
-            "description": "出来高"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "open",
-          "high",
-          "low",
-          "close",
-          "volume"
-        ],
-        "title": "OHLCVRecord",
-        "description": "OHLCVレコード"
       }
     }
   },

--- a/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/shared/src/clients/backtest/generated/bt-api-types.ts
@@ -1609,7 +1609,7 @@ export interface paths {
         };
         /**
          * Get market fundamental rankings
-         * @description Get fundamental rankings including high/low stocks by latest forecast EPS and actual EPS.
+         * @description Get fundamental rankings by ratio (high/low). Use metricKey to select ratio metric (currently: eps_forecast_to_actual).
          */
         get: operations["get_fundamental_ranking_api_analytics_fundamental_ranking_get"];
         put?: never;
@@ -3788,17 +3788,13 @@ export interface components {
         };
         /**
          * FundamentalRankings
-         * @description 4種類のファンダメンタルランキング
+         * @description 比率ベースのファンダメンタルランキング
          */
         FundamentalRankings: {
-            /** Forecasthigh */
-            forecastHigh?: components["schemas"]["FundamentalRankingItem"][];
-            /** Forecastlow */
-            forecastLow?: components["schemas"]["FundamentalRankingItem"][];
-            /** Actualhigh */
-            actualHigh?: components["schemas"]["FundamentalRankingItem"][];
-            /** Actuallow */
-            actualLow?: components["schemas"]["FundamentalRankingItem"][];
+            /** Ratiohigh */
+            ratioHigh?: components["schemas"]["FundamentalRankingItem"][];
+            /** Ratiolow */
+            ratioLow?: components["schemas"]["FundamentalRankingItem"][];
         };
         /**
          * FundamentalsComputeRequest
@@ -5140,6 +5136,8 @@ export interface components {
             date: string;
             /** Markets */
             markets: string[];
+            /** Metrickey */
+            metricKey: string;
             rankings: components["schemas"]["FundamentalRankings"];
             /** Lastupdated */
             lastUpdated: string;
@@ -7953,27 +7951,6 @@ export interface components {
             /** To */
             to: string;
         };
-        /** DateRange */
-        src__server__schemas__db__DateRange: {
-            /** Min */
-            min: string;
-            /** Max */
-            max: string;
-        };
-        /** DateRange */
-        src__server__schemas__portfolio_factor_regression__DateRange: {
-            /** From */
-            from: string;
-            /** To */
-            to: string;
-        };
-        /** DateRange */
-        src__server__schemas__dataset__DateRange: {
-            /** Min */
-            min: string;
-            /** Max */
-            max: string;
-        };
         /**
          * OHLCVRecord
          * @description OHLCVレコード
@@ -8009,6 +7986,27 @@ export interface components {
              * @description 出来高
              */
             volume: number;
+        };
+        /** DateRange */
+        src__server__schemas__db__DateRange: {
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
+        };
+        /** DateRange */
+        src__server__schemas__portfolio_factor_regression__DateRange: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
+        };
+        /** DateRange */
+        src__server__schemas__dataset__DateRange: {
+            /** Min */
+            min: string;
+            /** Max */
+            max: string;
         };
     };
     responses: never;
@@ -12612,6 +12610,7 @@ export interface operations {
             query?: {
                 limit?: number;
                 markets?: string;
+                metricKey?: string;
             };
             header?: never;
             path?: never;

--- a/apps/ts/packages/shared/src/index.ts
+++ b/apps/ts/packages/shared/src/index.ts
@@ -179,6 +179,7 @@ export type {
   DatasetListItem,
   DatasetListResponse,
   FundamentalRankingItem,
+  FundamentalRankingMetricKey,
   FundamentalRankingSource,
   FundamentalRankings,
   IndexDataPoint,

--- a/apps/ts/packages/shared/src/types/api-response-types.ts
+++ b/apps/ts/packages/shared/src/types/api-response-types.ts
@@ -43,6 +43,7 @@ export interface MarketRankingResponse {
 export type RankingType = 'tradingValue' | 'gainers' | 'losers' | 'periodHigh' | 'periodLow';
 
 export type FundamentalRankingSource = 'revised' | 'fy';
+export type FundamentalRankingMetricKey = string;
 
 export interface FundamentalRankingItem {
   rank: number;
@@ -52,22 +53,21 @@ export interface FundamentalRankingItem {
   sector33Name: string;
   currentPrice: number;
   volume: number;
-  epsValue: number;
+  epsValue: number; // latest forecast EPS / latest actual EPS
   disclosedDate: string;
   periodType: string;
   source: FundamentalRankingSource;
 }
 
 export interface FundamentalRankings {
-  forecastHigh: FundamentalRankingItem[];
-  forecastLow: FundamentalRankingItem[];
-  actualHigh: FundamentalRankingItem[];
-  actualLow: FundamentalRankingItem[];
+  ratioHigh: FundamentalRankingItem[];
+  ratioLow: FundamentalRankingItem[];
 }
 
 export interface MarketFundamentalRankingResponse {
   date: string;
   markets: string[];
+  metricKey: FundamentalRankingMetricKey;
   rankings: FundamentalRankings;
   lastUpdated: string;
 }

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingSummary.test.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingSummary.test.tsx
@@ -17,12 +17,11 @@ const baseItem = {
 const mockData: MarketFundamentalRankingResponse = {
   date: '2025-01-30',
   markets: ['prime', 'standard'],
+  metricKey: 'eps_forecast_to_actual',
   lastUpdated: '2025-01-30T12:00:00Z',
   rankings: {
-    forecastHigh: [{ ...baseItem, code: '7203', companyName: 'Toyota', epsValue: 520 }],
-    forecastLow: [{ ...baseItem, code: '6502', companyName: 'Toshiba', epsValue: -12 }],
-    actualHigh: [{ ...baseItem, code: '6758', companyName: 'Sony', epsValue: 480 }],
-    actualLow: [{ ...baseItem, code: '8306', companyName: 'MUFG', epsValue: -18 }],
+    ratioHigh: [{ ...baseItem, code: '7203', companyName: 'Toyota', epsValue: 1.48 }],
+    ratioLow: [{ ...baseItem, code: '6502', companyName: 'Toshiba', epsValue: 0.72 }],
   },
 };
 
@@ -36,13 +35,25 @@ describe('FundamentalRankingSummary', () => {
     render(<FundamentalRankingSummary data={mockData} />);
     expect(screen.getByText('2025-01-30')).toBeInTheDocument();
     expect(screen.getByText('prime, standard')).toBeInTheDocument();
+    expect(screen.getByText('Metric: eps_forecast_to_actual')).toBeInTheDocument();
   });
 
-  it('renders forecast and actual codes', () => {
+  it('renders high/low ratio codes', () => {
     render(<FundamentalRankingSummary data={mockData} />);
     expect(screen.getByText('7203')).toBeInTheDocument();
     expect(screen.getByText('6502')).toBeInTheDocument();
-    expect(screen.getByText('6758')).toBeInTheDocument();
-    expect(screen.getByText('8306')).toBeInTheDocument();
+  });
+
+  it('renders fallback values when ranking items are missing', () => {
+    const emptyData: MarketFundamentalRankingResponse = {
+      ...mockData,
+      rankings: {
+        ratioHigh: [],
+        ratioLow: [],
+      },
+    };
+
+    render(<FundamentalRankingSummary data={emptyData} />);
+    expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingSummary.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingSummary.tsx
@@ -6,21 +6,19 @@ interface FundamentalRankingSummaryProps {
   data: MarketFundamentalRankingResponse | undefined;
 }
 
-function formatEps(value: number | undefined): string {
+function formatRatio(value: number | undefined): string {
   if (value === undefined || !Number.isFinite(value)) return '-';
-  return `${value.toLocaleString('ja-JP', { maximumFractionDigits: 2 })}円`;
+  return `${value.toLocaleString('ja-JP', { maximumFractionDigits: 4 })}x`;
 }
 
 export function FundamentalRankingSummary({ data }: FundamentalRankingSummaryProps) {
   if (!data) return null;
 
-  const forecastHigh = data.rankings.forecastHigh[0];
-  const forecastLow = data.rankings.forecastLow[0];
-  const actualHigh = data.rankings.actualHigh[0];
-  const actualLow = data.rankings.actualLow[0];
+  const ratioHigh = data.rankings.ratioHigh[0];
+  const ratioLow = data.rankings.ratioLow[0];
 
   return (
-    <div className="grid grid-cols-5 gap-3 mb-4">
+    <div className="grid grid-cols-1 gap-3 mb-4 md:grid-cols-3">
       <Card className="glass-panel">
         <CardContent className="p-3">
           <div className="flex items-center gap-2 text-muted-foreground mb-1">
@@ -29,6 +27,7 @@ export function FundamentalRankingSummary({ data }: FundamentalRankingSummaryPro
           </div>
           <p className="text-sm font-bold">{data.date}</p>
           <p className="text-xs text-muted-foreground mt-1">{data.markets.join(', ')}</p>
+          <p className="text-xs text-muted-foreground mt-1">Metric: {data.metricKey}</p>
         </CardContent>
       </Card>
 
@@ -36,10 +35,10 @@ export function FundamentalRankingSummary({ data }: FundamentalRankingSummaryPro
         <CardContent className="p-3">
           <div className="flex items-center gap-2 text-muted-foreground mb-1">
             <TrendingUp className="h-4 w-4 text-green-500" />
-            <span className="text-xs">Top Forecast</span>
+            <span className="text-xs">High Ratio</span>
           </div>
-          <p className="text-sm font-bold">{formatEps(forecastHigh?.epsValue)}</p>
-          <p className="text-xs text-muted-foreground mt-1">{forecastHigh?.code || '-'}</p>
+          <p className="text-sm font-bold">{formatRatio(ratioHigh?.epsValue)}</p>
+          <p className="text-xs text-muted-foreground mt-1">{ratioHigh?.code || '-'}</p>
         </CardContent>
       </Card>
 
@@ -47,32 +46,10 @@ export function FundamentalRankingSummary({ data }: FundamentalRankingSummaryPro
         <CardContent className="p-3">
           <div className="flex items-center gap-2 text-muted-foreground mb-1">
             <TrendingDown className="h-4 w-4 text-red-500" />
-            <span className="text-xs">Low Forecast</span>
+            <span className="text-xs">Low Ratio</span>
           </div>
-          <p className="text-sm font-bold">{formatEps(forecastLow?.epsValue)}</p>
-          <p className="text-xs text-muted-foreground mt-1">{forecastLow?.code || '-'}</p>
-        </CardContent>
-      </Card>
-
-      <Card className="glass-panel">
-        <CardContent className="p-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <TrendingUp className="h-4 w-4 text-green-500" />
-            <span className="text-xs">Top Actual</span>
-          </div>
-          <p className="text-sm font-bold">{formatEps(actualHigh?.epsValue)}</p>
-          <p className="text-xs text-muted-foreground mt-1">{actualHigh?.code || '-'}</p>
-        </CardContent>
-      </Card>
-
-      <Card className="glass-panel">
-        <CardContent className="p-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <TrendingDown className="h-4 w-4 text-red-500" />
-            <span className="text-xs">Low Actual</span>
-          </div>
-          <p className="text-sm font-bold">{formatEps(actualLow?.epsValue)}</p>
-          <p className="text-xs text-muted-foreground mt-1">{actualLow?.code || '-'}</p>
+          <p className="text-sm font-bold">{formatRatio(ratioLow?.epsValue)}</p>
+          <p className="text-xs text-muted-foreground mt-1">{ratioLow?.code || '-'}</p>
         </CardContent>
       </Card>
     </div>

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingTable.test.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingTable.test.tsx
@@ -16,10 +16,8 @@ const baseItem = {
 };
 
 const rankings: FundamentalRankings = {
-  forecastHigh: [{ ...baseItem, code: '7203', companyName: 'Toyota', epsValue: 500 }],
-  forecastLow: [{ ...baseItem, code: '6502', companyName: 'Toshiba', epsValue: -20 }],
-  actualHigh: [{ ...baseItem, code: '6758', companyName: 'Sony', epsValue: 450 }],
-  actualLow: [{ ...baseItem, code: '8306', companyName: 'MUFG', epsValue: -15 }],
+  ratioHigh: [{ ...baseItem, code: '7203', companyName: 'Toyota', epsValue: 1.5 }],
+  ratioLow: [{ ...baseItem, code: '6502', companyName: 'Toshiba', epsValue: 0.72 }],
 };
 
 describe('FundamentalRankingTable', () => {
@@ -31,14 +29,14 @@ describe('FundamentalRankingTable', () => {
   it('switches tab and renders selected rows', async () => {
     const user = userEvent.setup();
     render(<FundamentalRankingTable rankings={rankings} isLoading={false} error={null} onStockClick={vi.fn()} />);
-    await user.click(screen.getByRole('button', { name: 'Actual Low' }));
-    expect(screen.getByText('MUFG')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Ratio Low' }));
+    expect(screen.getByText('Toshiba')).toBeInTheDocument();
   });
 
   it('shows empty state when no data', () => {
     render(
       <FundamentalRankingTable
-        rankings={{ forecastHigh: [], forecastLow: [], actualHigh: [], actualLow: [] }}
+        rankings={{ ratioHigh: [], ratioLow: [] }}
         isLoading={false}
         error={null}
         onStockClick={vi.fn()}

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingTable.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingTable.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownCircle, ArrowUpCircle, TrendingDown, TrendingUp } from 'lucide-react';
+import { ArrowDownCircle, ArrowUpCircle, TrendingUp } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -14,18 +14,16 @@ interface FundamentalRankingTableProps {
   onStockClick: (code: string) => void;
 }
 
-type FundamentalRankingType = 'forecastHigh' | 'forecastLow' | 'actualHigh' | 'actualLow';
+type FundamentalRankingType = 'ratioHigh' | 'ratioLow';
 
 const rankingTabs: { id: FundamentalRankingType; label: string; icon: typeof TrendingUp }[] = [
-  { id: 'forecastHigh', label: 'Forecast High', icon: ArrowUpCircle },
-  { id: 'forecastLow', label: 'Forecast Low', icon: ArrowDownCircle },
-  { id: 'actualHigh', label: 'Actual High', icon: TrendingUp },
-  { id: 'actualLow', label: 'Actual Low', icon: TrendingDown },
+  { id: 'ratioHigh', label: 'Ratio High', icon: ArrowUpCircle },
+  { id: 'ratioLow', label: 'Ratio Low', icon: ArrowDownCircle },
 ];
 
-function formatEps(value: number): string {
+function formatRatio(value: number): string {
   if (!Number.isFinite(value)) return '-';
-  return value.toLocaleString('ja-JP', { maximumFractionDigits: 2 });
+  return `${value.toLocaleString('ja-JP', { maximumFractionDigits: 4 })}x`;
 }
 
 function FundamentalRankingRow({
@@ -45,7 +43,7 @@ function FundamentalRankingRow({
       <td className="p-2 truncate max-w-[180px]">{item.companyName}</td>
       <td className="p-2 truncate max-w-[100px] text-muted-foreground">{item.sector33Name}</td>
       <td className="p-2 text-right tabular-nums">{formatPriceJPY(item.currentPrice)}</td>
-      <td className="p-2 text-right tabular-nums">{formatEps(item.epsValue)}</td>
+      <td className="p-2 text-right tabular-nums">{formatRatio(item.epsValue)}</td>
       <td className="p-2 text-muted-foreground tabular-nums">
         {item.disclosedDate}
         <span className="ml-1 text-[10px] uppercase">{item.source}</span>
@@ -55,7 +53,7 @@ function FundamentalRankingRow({
 }
 
 export function FundamentalRankingTable({ rankings, isLoading, error, onStockClick }: FundamentalRankingTableProps) {
-  const [activeRankingType, setActiveRankingType] = useState<FundamentalRankingType>('forecastHigh');
+  const [activeRankingType, setActiveRankingType] = useState<FundamentalRankingType>('ratioHigh');
   const currentItems = rankings?.[activeRankingType] ?? [];
 
   return (
@@ -105,7 +103,7 @@ export function FundamentalRankingTable({ rankings, isLoading, error, onStockCli
                 <th className="text-left p-2">Company</th>
                 <th className="text-left p-2 w-24">Sector</th>
                 <th className="text-right p-2 w-24">Price</th>
-                <th className="text-right p-2 w-24">EPS</th>
+                <th className="text-right p-2 w-36">Forecast/Actual EPS</th>
                 <th className="text-left p-2 w-36">Disclosed</th>
               </tr>
             </thead>

--- a/apps/ts/packages/web/src/pages/AnalysisPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/AnalysisPage.test.tsx
@@ -96,7 +96,7 @@ vi.mock('@/hooks/useRanking', () => ({
 
 vi.mock('@/hooks/useFundamentalRanking', () => ({
   useFundamentalRanking: () => ({
-    data: { rankings: { forecastHigh: [], forecastLow: [], actualHigh: [], actualLow: [] } },
+    data: { metricKey: 'eps_forecast_to_actual', rankings: { ratioHigh: [], ratioLow: [] } },
     isLoading: false,
     error: null,
   }),


### PR DESCRIPTION
## Summary
- replace legacy fundamental ranking keys (forecastHigh/forecastLow/actualHigh/actualLow) with explicit ratio keys (ratioHigh/ratioLow)
- add metricKey to the response contract and validate supported metric key (eps_forecast_to_actual) on backend
- update web components, shared API types, generated OpenAPI/types, and related tests to align with the new contract
- update README/AGENTS docs to reflect the ratio-based contract and future metric expansion via metricKey

## Validation
- bun run --filter @trading25/shared bt:sync
- uv run --project /Users/shinjiroaso/.codex/worktrees/0b3f/trading25/apps/bt pytest apps/bt/tests/unit/server/services/test_ranking_service.py apps/bt/tests/unit/server/routes/test_analytics_complex.py
- bun run --filter @trading25/web test src/components/FundamentalRanking/FundamentalRankingTable.test.tsx src/components/FundamentalRanking/FundamentalRankingSummary.test.tsx src/pages/AnalysisPage.test.tsx
- bun typecheck:all
- uv run --project /Users/shinjiroaso/.codex/worktrees/0b3f/trading25/apps/bt ruff check apps/bt/src/application/services/ranking_service.py apps/bt/src/entrypoints/http/routes/analytics_complex.py apps/bt/src/entrypoints/http/schemas/ranking.py apps/bt/tests/unit/server/routes/test_analytics_complex.py apps/bt/tests/unit/server/services/test_ranking_service.py
