### PR TITLE
fix(bt): make dataset create resilient for OHLCV and include sector indices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする
 - Dataset API `GET /api/dataset/{name}/info` の SoT は `snapshot` + `stats` + `validation`（`details.dataCoverage` / `details.fkIntegrity` / `details.stockCountValidation` 含む）とし、web 側は legacy `snapshot` 形式を正規化して後方互換を維持する
+- Dataset create/resume（`POST /api/dataset` / `POST /api/dataset/resume`）は `indices_data`（sector index catalog: `0040-0060` / `0080-0090`）を取り込み、`stock_data` は `build_stock_data_row` で欠損OHLCV行をスキップして warning 集約を返す
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Screening API は非同期ジョブ方式（`POST /api/analytics/screening/jobs` / `GET /api/analytics/screening/jobs/{id}` / `POST /api/analytics/screening/jobs/{id}/cancel` / `GET /api/analytics/screening/result/{id}`）を SoT とする。旧 `GET /api/analytics/screening` は 410
 - Screening 実行時のデータ SoT は `market.db`（`stock_data` / `topix_data` / `indices_data` / `stocks`）とし、dataset へのフォールバックを禁止する

--- a/apps/bt/src/application/services/dataset_builder_service.py
+++ b/apps/bt/src/application/services/dataset_builder_service.py
@@ -14,14 +14,16 @@ from typing import Any
 
 from loguru import logger
 
+from src.application.services.dataset_presets import PresetConfig, get_preset
+from src.application.services.dataset_resolver import DatasetResolver
+from src.application.services.fins_summary_mapper import convert_fins_summary_rows
+from src.application.services.generic_job_manager import GenericJobManager, JobInfo
+from src.application.services.index_master_catalog import get_index_catalog_codes
+from src.application.services.stock_data_row_builder import build_stock_data_row
+from src.entrypoints.http.schemas.job import JobProgress
 from src.infrastructure.external_api.clients.jquants_client import JQuantsAsyncClient
 from src.infrastructure.db.dataset_io.dataset_writer import DatasetWriter
 from src.infrastructure.db.market.query_helpers import normalize_stock_code
-from src.entrypoints.http.schemas.job import JobProgress
-from src.application.services.fins_summary_mapper import convert_fins_summary_rows
-from src.application.services.dataset_presets import PresetConfig, get_preset
-from src.application.services.dataset_resolver import DatasetResolver
-from src.application.services.generic_job_manager import GenericJobManager, JobInfo
 
 
 @dataclass
@@ -44,6 +46,8 @@ class DatasetResult:
 
 # Module-level manager instance
 dataset_job_manager: GenericJobManager[DatasetJobData, JobProgress, DatasetResult] = GenericJobManager()
+_TOTAL_STAGES = 7
+_WARNING_SAMPLE_SIZE = 5
 
 
 async def start_dataset_build(
@@ -102,7 +106,7 @@ async def _build_dataset(
         )
 
     # Step 1: 銘柄マスタ取得
-    progress("master", 0, 6, "Fetching stock master data...")
+    progress("master", 0, _TOTAL_STAGES, "Fetching stock master data...")
     if job.cancelled.is_set():
         return DatasetResult(success=False, errors=["Cancelled"])
 
@@ -113,7 +117,7 @@ async def _build_dataset(
         return DatasetResult(success=False, errors=["No stocks matched the preset filters"])
 
     # Step 2: Writer 作成
-    progress("init", 1, 6, f"Creating dataset with {len(filtered)} stocks...")
+    progress("init", 1, _TOTAL_STAGES, f"Creating dataset with {len(filtered)} stocks...")
     writer = DatasetWriter(db_path)
 
     try:
@@ -125,8 +129,10 @@ async def _build_dataset(
         writer.set_dataset_info("stock_count", str(len(filtered)))
 
         # Step 3: 株価データ取得
-        progress("stock_data", 2, 6, "Fetching stock price data...")
+        progress("stock_data", 2, _TOTAL_STAGES, "Fetching stock price data...")
         processed = 0
+        empty_ohlcv_codes: list[str] = []
+        incomplete_ohlcv_codes: list[tuple[str, int, int]] = []
         for i, stock in enumerate(filtered):
             if job.cancelled.is_set():
                 return DatasetResult(success=False, processedStocks=processed, errors=["Cancelled"])
@@ -134,31 +140,54 @@ async def _build_dataset(
             code4 = normalize_stock_code(code5)
             try:
                 data = await jquants_client.get_paginated("/equities/bars/daily", params={"code": code5})
-                rows = [
-                    {
-                        "code": code4,
-                        "date": d.get("Date", ""),
-                        "open": d.get("O", 0),
-                        "high": d.get("H", 0),
-                        "low": d.get("L", 0),
-                        "close": d.get("C", 0),
-                        "volume": d.get("Vo", 0),
-                        "adjustment_factor": d.get("AdjFactor"),
-                        "created_at": datetime.now(UTC).isoformat(),
-                    }
-                    for d in data
-                ]
+                rows: list[dict[str, Any]] = []
+                skipped_rows = 0
+                created_at = datetime.now(UTC).isoformat()
+                for quote in data:
+                    if not isinstance(quote, dict):
+                        skipped_rows += 1
+                        continue
+                    row = build_stock_data_row(
+                        quote,
+                        normalized_code=code4,
+                        created_at=created_at,
+                    )
+                    if row is None:
+                        skipped_rows += 1
+                        continue
+                    rows.append(row)
+                if skipped_rows > 0:
+                    incomplete_ohlcv_codes.append((code4, skipped_rows, len(data)))
                 if rows:
                     await asyncio.to_thread(writer.upsert_stock_data, rows)
+                else:
+                    empty_ohlcv_codes.append(code4)
                 processed += 1
                 if (i + 1) % 10 == 0:
-                    progress("stock_data", 2, 6, f"Stock data: {i + 1}/{len(filtered)}")
+                    progress("stock_data", 2, _TOTAL_STAGES, f"Stock data: {i + 1}/{len(filtered)}")
             except Exception as e:
                 warnings.append(f"Stock {code4}: {e}")
 
+        if empty_ohlcv_codes:
+            warnings.append(
+                "No valid OHLCV rows for "
+                f"{len(empty_ohlcv_codes)} stocks "
+                f"(sample: {_sample_text(empty_ohlcv_codes)})"
+            )
+        if incomplete_ohlcv_codes:
+            warning_samples = [
+                f"{code}({skipped}/{total})"
+                for code, skipped, total in incomplete_ohlcv_codes[:_WARNING_SAMPLE_SIZE]
+            ]
+            warnings.append(
+                "Skipped incomplete OHLCV rows for "
+                f"{len(incomplete_ohlcv_codes)} stocks "
+                f"(sample: {', '.join(warning_samples)})"
+            )
+
         # Step 4: TOPIX
         if preset.include_topix:
-            progress("topix", 3, 6, "Fetching TOPIX data...")
+            progress("topix", 3, _TOTAL_STAGES, "Fetching TOPIX data...")
             if not job.cancelled.is_set():
                 try:
                     topix = await jquants_client.get_paginated("/indices/bars/daily/topix")
@@ -178,10 +207,27 @@ async def _build_dataset(
                 except Exception as e:
                     warnings.append(f"TOPIX: {e}")
 
-        # Step 5: 財務諸表
+        # Step 5: セクター指数
+        if preset.include_sector_indices:
+            progress("indices", 4, _TOTAL_STAGES, "Fetching sector index data...")
+            target_index_codes = sorted(
+                code for code in get_index_catalog_codes() if _is_sector_index_code(code)
+            )
+            for code in target_index_codes:
+                if job.cancelled.is_set():
+                    break
+                try:
+                    data = await jquants_client.get_paginated("/indices/bars/daily", params={"code": code})
+                    rows = _convert_indices_rows(data, fallback_code=code)
+                    if rows:
+                        await asyncio.to_thread(writer.upsert_indices_data, rows)
+                except Exception as e:
+                    warnings.append(f"Indices {code}: {e}")
+
+        # Step 6: 財務諸表
         if preset.include_statements:
-            progress("statements", 4, 6, "Fetching financial statements...")
-            for i, stock in enumerate(filtered):
+            progress("statements", 5, _TOTAL_STAGES, "Fetching financial statements...")
+            for stock in filtered:
                 if job.cancelled.is_set():
                     break
                 code5 = stock.get("Code", "")
@@ -194,10 +240,10 @@ async def _build_dataset(
                 except Exception as e:
                     warnings.append(f"Statements {code4}: {e}")
 
-        # Step 6: 信用取引
+        # Step 7: 信用取引
         if preset.include_margin:
-            progress("margin", 5, 6, "Fetching margin data...")
-            for i, stock in enumerate(filtered):
+            progress("margin", 6, _TOTAL_STAGES, "Fetching margin data...")
+            for stock in filtered:
                 if job.cancelled.is_set():
                     break
                 code5 = stock.get("Code", "")
@@ -218,7 +264,7 @@ async def _build_dataset(
                 except Exception as e:
                     warnings.append(f"Margin {code4}: {e}")
 
-        progress("complete", 6, 6, "Dataset build complete!")
+        progress("complete", _TOTAL_STAGES, _TOTAL_STAGES, "Dataset build complete!")
         return DatasetResult(
             success=True,
             totalStocks=len(filtered),
@@ -229,6 +275,70 @@ async def _build_dataset(
         )
     finally:
         writer.close()
+
+
+def _sample_text(values: list[str]) -> str:
+    sample = values[:_WARNING_SAMPLE_SIZE]
+    suffix = ", ..." if len(values) > _WARNING_SAMPLE_SIZE else ""
+    return ", ".join(sample) + suffix
+
+
+def _normalize_index_code(value: Any) -> str:
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        return ""
+    if text.isdigit() and len(text) < 4:
+        return text.zfill(4)
+    return text.upper()
+
+
+def _is_sector_index_code(code: str) -> bool:
+    normalized = _normalize_index_code(code)
+    try:
+        value = int(normalized, 16)
+    except ValueError:
+        return False
+    return (
+        int("0040", 16) <= value <= int("0060", 16)
+        or int("0080", 16) <= value <= int("0090", 16)
+    )
+
+
+def _extract_index_code(row: dict[str, Any]) -> str:
+    return _normalize_index_code(
+        row.get("Code")
+        or row.get("code")
+        or row.get("indexCode")
+        or row.get("index_code")
+    )
+
+
+def _convert_indices_rows(data: list[dict[str, Any]], *, fallback_code: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    created_at = datetime.now(UTC).isoformat()
+    normalized_fallback = _normalize_index_code(fallback_code)
+
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        code = _extract_index_code(row) or normalized_fallback
+        date = row.get("Date") or row.get("date")
+        if not code or not date:
+            continue
+        rows.append(
+            {
+                "code": code,
+                "date": str(date),
+                "open": row.get("O", row.get("open")),
+                "high": row.get("H", row.get("high")),
+                "low": row.get("L", row.get("low")),
+                "close": row.get("C", row.get("close")),
+                "sector_name": row.get("SectorName", row.get("sector_name")),
+                "created_at": created_at,
+            }
+        )
+
+    return rows
 
 
 def _filter_stocks(stocks: list[dict[str, Any]], preset: PresetConfig) -> list[dict[str, Any]]:
@@ -274,4 +384,3 @@ def _convert_stocks(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
         }
         for d in data
     ]
-

--- a/apps/ts/bun.lock
+++ b/apps/ts/bun.lock
@@ -15,6 +15,13 @@
         "typescript": "^5.9.2",
       },
     },
+    "packages/api-clients": {
+      "name": "@trading25/api-clients",
+      "version": "0.0.1",
+      "dependencies": {
+        "zod": "^4.1.5",
+      },
+    },
     "packages/cli": {
       "name": "@trading25/cli",
       "version": "0.0.1",
@@ -31,13 +38,6 @@
       },
       "devDependencies": {
         "@gunshi/docs": "^0.27.0",
-      },
-    },
-    "packages/api-clients": {
-      "name": "@trading25/api-clients",
-      "version": "0.0.1",
-      "dependencies": {
-        "zod": "^4.1.5",
       },
     },
     "packages/shared": {
@@ -98,6 +98,7 @@
   },
   "overrides": {
     "@redocly/openapi-core": "1.34.5",
+    "rollup": "4.59.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -324,49 +325,55 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.47", "", {}, "sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.53.3", "", { "os": "android", "cpu": "arm" }, "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.53.3", "", { "os": "android", "cpu": "arm64" }, "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.53.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.53.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.53.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.53.3", "", { "os": "linux", "cpu": "arm" }, "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.53.3", "", { "os": "linux", "cpu": "arm" }, "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.53.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.53.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
 
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g=="],
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.53.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw=="],
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A=="],
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.53.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.53.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.53.3", "", { "os": "linux", "cpu": "x64" }, "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
 
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.53.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.53.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.53.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA=="],
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
 
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -422,9 +429,9 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
-    "@trading25/cli": ["@trading25/cli@workspace:packages/cli"],
-
     "@trading25/api-clients": ["@trading25/api-clients@workspace:packages/api-clients"],
+
+    "@trading25/cli": ["@trading25/cli@workspace:packages/cli"],
 
     "@trading25/shared": ["@trading25/shared@workspace:packages/shared"],
 
@@ -878,7 +885,7 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
-    "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
 

--- a/apps/ts/package.json
+++ b/apps/ts/package.json
@@ -47,6 +47,7 @@
     "gunshi": "0.27.0"
   },
   "overrides": {
-    "@redocly/openapi-core": "1.34.5"
+    "@redocly/openapi-core": "1.34.5",
+    "rollup": "4.59.0"
   }
 }


### PR DESCRIPTION
## Summary
- add sector index ingestion (indices_data) to dataset create/resume using catalog-derived sector index codes
- switch dataset stock_data ingestion to build_stock_data_row so incomplete OHLCV rows are skipped instead of failing inserts
- add warning aggregation for empty/incomplete OHLCV coverage by stock
- update AGENTS.md with the new dataset create behavior

## Tests
- NUMBA_DISABLE_JIT=1 NUMBA_CACHE_DIR=/tmp/numba-cache /Users/shinjiroaso/dev/trading25/apps/bt/.venv/bin/python -m pytest tests/unit/server/test_dataset_builder_service_branches.py --cov=src.application.services.dataset_builder_service --cov-branch --cov-report=term-missing
  - 19 passed
  - coverage: 92% (line + branch)
