### PR TITLE
fix: align forecast EPS recent-FY signal semantics across bt/web

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,13 +112,13 @@ uv run pyright src/              # 型チェック
 - Optimization HTML（`notebooks/templates/marimo/optimization_analysis.py`）は、各パラメータ組み合わせの `Trades`（closed trades件数）と Best detail の `Trade Count` を表示する
 - `/api/optimize/jobs/{id}` は `best_score` / `total_combinations` に加えて `best_params` / `worst_score` / `worst_params` を返し、最適化ジョブ結果カードで best/worst 条件を比較表示できる
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
-- Fundamental signal は `forecast_eps_above_all_actuals`（最新予想EPS > 過去すべての実績EPS）をサポートし、forecast revision 読み込み（screening/lab/optimization/backtest）を有効化する
+- Fundamental signal は `forecast_eps_above_recent_fy_actuals`（最新予想EPS > 直近FY X回の実績EPS最大値）をサポートし、`lookback_fy_count` で比較年数を指定できる。forecast revision 読み込み（screening/lab/optimization/backtest）を有効化する
 - Fundamental signal system は `cfo_margin` / `simple_fcf_margin`（売上高比マージン判定）をサポートし、`OperatingCashFlow` / `InvestingCashFlow` / `Sales` をデータ要件とする
 - Fundamental signal は `cfo_to_net_profit_ratio`（営業CF/純利益）をサポートし、`consecutive_periods` 判定は比率値同値時でも開示更新（OperatingCashFlow/Profit）を起点に連続判定する
 - Fundamentals は EPS に加えて `dividend_fy` / `forecast_dividend_fy` と `payout_ratio` / `forecast_payout_ratio`（実績/予想）を SoT とし、Charts の Fundamentals panel と Backtest Signal system（`forward_dividend_growth` / `dividend_per_share_growth` / `payout_ratio` / `forward_payout_ratio`）で同一指標を使う。配当性向は API 返却時に percent 単位へ正規化し、decimal スケール値（例: 0.283）を 28.3% として扱う
 - fundamentals 最新値の forecast EPS は同一期末内で `DiscDate` が新しい開示を優先し、旧開示値の逆転表示を防ぐ
-- Charts Fundamentals panel は `forecastEpsAboveAllHistoricalActuals`（最新予想EPS > 過去すべての実績EPS）を latest metrics で返し、frontend は true/false 表示を行う
-- `/api/analytics/fundamental-ranking` は `market.db`（`statements`/`stocks`/`stock_data`）を SoT とし、`metricKey` と `rankings.ratioHigh` / `rankings.ratioLow` を返す。現在の `metricKey` は `eps_forecast_to_actual`（最新の予想EPS / 最新の実績EPS）で、予想EPSは `revised(四半期) > adjusted FY forecast > raw FY forecast`、実績EPSは最新 FY EPS（share補正）を採用する。`forecastAboveAllActuals=true` で「最新予想EPS > 過去すべての実績EPS」条件を追加フィルタできる。将来の比率指標追加は `metricKey` で識別する
+- Charts Fundamentals panel は `forecastEpsAboveRecentFyActuals`（最新予想EPS > 直近FY X回の実績EPS最大値）を latest metrics で返し、`forecastEpsLookbackFyCount` に応じた true/false を表示する（旧 `forecastEpsAboveAllHistoricalActuals` は互換フィールド）
+- `/api/analytics/fundamental-ranking` は `market.db`（`statements`/`stocks`/`stock_data`）を SoT とし、`metricKey` と `rankings.ratioHigh` / `rankings.ratioLow` を返す。現在の `metricKey` は `eps_forecast_to_actual`（最新の予想EPS / 最新の実績EPS）で、予想EPSは `revised(四半期) > adjusted FY forecast > raw FY forecast`、実績EPSは最新 FY EPS（share補正）を採用する。`forecastAboveRecentFyActuals=true` と `forecastLookbackFyCount` で「最新予想EPS > 直近FY X回の実績EPS最大値」条件を追加フィルタできる（旧 `forecastAboveAllActuals` も互換）。将来の比率指標追加は `metricKey` で識別する
 - Strategy group 再振り分けは `/api/strategies/{strategy_name}/move`（`target_category`: `production` / `experimental` / `legacy`）を SoT とし、web の `Backtest > Strategies` から実行する
 
 主要技術: Python 3.12, vectorbt, pydantic, FastAPI, pandas, ruff, pyright, pytest

--- a/apps/bt/src/application/services/screening_service.py
+++ b/apps/bt/src/application/services/screening_service.py
@@ -1329,7 +1329,7 @@ class ScreeningService:
                 return False
             return bool(
                 fundamental.forward_eps_growth.enabled
-                or fundamental.forecast_eps_above_all_actuals.enabled
+                or fundamental.forecast_eps_above_recent_fy_actuals.enabled
                 or fundamental.peg_ratio.enabled
                 or fundamental.forward_dividend_growth.enabled
                 or fundamental.forward_payout_ratio.enabled

--- a/apps/bt/src/domains/lab_agent/evaluator/batch_executor.py
+++ b/apps/bt/src/domains/lab_agent/evaluator/batch_executor.py
@@ -56,7 +56,10 @@ def _is_forecast_signal_enabled(side_params: dict[str, Any]) -> bool:
     if isinstance(forward, dict) and bool(forward.get("enabled", False)):
         return True
 
-    forecast_vs_actual = fundamental.get("forecast_eps_above_all_actuals")
+    forecast_vs_actual = fundamental.get("forecast_eps_above_recent_fy_actuals")
+    if not isinstance(forecast_vs_actual, dict):
+        # Backward compatibility for legacy key
+        forecast_vs_actual = fundamental.get("forecast_eps_above_all_actuals")
     if isinstance(forecast_vs_actual, dict) and bool(forecast_vs_actual.get("enabled", False)):
         return True
 

--- a/apps/bt/src/domains/optimization/engine.py
+++ b/apps/bt/src/domains/optimization/engine.py
@@ -312,7 +312,7 @@ class ParameterOptimizationEngine:
             fundamental.enabled
             and (
                 fundamental.forward_eps_growth.enabled
-                or fundamental.forecast_eps_above_all_actuals.enabled
+                or fundamental.forecast_eps_above_recent_fy_actuals.enabled
                 or fundamental.peg_ratio.enabled
                 or fundamental.forward_dividend_growth.enabled
                 or fundamental.forward_payout_ratio.enabled
@@ -351,6 +351,8 @@ class ParameterOptimizationEngine:
 
             for signal_name in (
                 "forward_eps_growth",
+                "forecast_eps_above_recent_fy_actuals",
+                # Backward compatibility for legacy key
                 "forecast_eps_above_all_actuals",
                 "peg_ratio",
                 "forward_dividend_growth",
@@ -360,7 +362,10 @@ class ParameterOptimizationEngine:
                 if not isinstance(signal_cfg, dict):
                     continue
 
-                signal_enabled = bool(getattr(base_fundamental, signal_name).enabled)
+                base_signal = getattr(base_fundamental, signal_name, None)
+                signal_enabled = bool(
+                    getattr(base_signal, "enabled", False)
+                )
                 if not signal_enabled:
                     signal_enabled_values = signal_cfg.get("enabled")
                     if isinstance(signal_enabled_values, list):

--- a/apps/bt/src/domains/strategy/core/mixins/data_manager_mixin.py
+++ b/apps/bt/src/domains/strategy/core/mixins/data_manager_mixin.py
@@ -44,7 +44,7 @@ class DataManagerMixin:
                 continue
             if (
                 fundamental.forward_eps_growth.enabled
-                or fundamental.forecast_eps_above_all_actuals.enabled
+                or fundamental.forecast_eps_above_recent_fy_actuals.enabled
                 or fundamental.peg_ratio.enabled
                 or fundamental.forward_dividend_growth.enabled
                 or fundamental.forward_payout_ratio.enabled

--- a/apps/bt/src/domains/strategy/signals/fundamental.py
+++ b/apps/bt/src/domains/strategy/signals/fundamental.py
@@ -38,7 +38,7 @@ from .fundamental_valuation import (
 from .fundamental_growth import (
     is_expected_growth_dividend_per_share,
     is_expected_growth_eps,
-    is_forecast_eps_above_all_actuals,
+    is_forecast_eps_above_recent_fy_actuals,
     is_growing_dividend_per_share,
     is_growing_eps,
     is_growing_profit,
@@ -81,7 +81,7 @@ __all__ = [
     # 成長率系
     "is_growing_eps",
     "is_expected_growth_eps",
-    "is_forecast_eps_above_all_actuals",
+    "is_forecast_eps_above_recent_fy_actuals",
     "is_expected_growth_dividend_per_share",
     "is_growing_profit",
     "is_growing_sales",

--- a/apps/bt/src/domains/strategy/signals/registry.py
+++ b/apps/bt/src/domains/strategy/signals/registry.py
@@ -26,7 +26,7 @@ from .fundamental import (
     cfo_to_net_profit_ratio_threshold,
     is_expected_growth_dividend_per_share,
     is_expected_growth_eps,
-    is_forecast_eps_above_all_actuals,
+    is_forecast_eps_above_recent_fy_actuals,
     is_growing_cfo_yield,
     is_growing_dividend_per_share,
     is_growing_eps,
@@ -812,12 +812,12 @@ SIGNAL_REGISTRY: list[SignalDefinition] = [
         and _has_any_statements_column(d, "ForwardForecastEPS", "NextYearForecastEPS"),
         data_requirements=["statements:EPS", "statements:ForwardForecastEPS"],
     ),
-    # 23-0. 予想EPSが過去実績EPSの最大値を上回るシグナル
+    # 23-0. 予想EPSが直近FY実績EPSの最大値を上回るシグナル
     SignalDefinition(
-        name="予想EPS>過去実績EPS",
-        signal_func=is_forecast_eps_above_all_actuals,
+        name="予想EPS>直近FY実績EPS",
+        signal_func=is_forecast_eps_above_recent_fy_actuals,
         enabled_checker=lambda p: p.fundamental.enabled
-        and p.fundamental.forecast_eps_above_all_actuals.enabled,
+        and p.fundamental.forecast_eps_above_recent_fy_actuals.enabled,
         param_builder=lambda p, d: {
             "actual_eps": d["statements_data"][
                 _select_forward_base_eps_column(p, d)
@@ -825,12 +825,15 @@ SIGNAL_REGISTRY: list[SignalDefinition] = [
             "latest_forecast_eps": d["statements_data"][
                 _select_forward_forecast_eps_column(p, d)
             ],
+            "lookback_fy_count": p.fundamental.forecast_eps_above_recent_fy_actuals.lookback_fy_count,
+            "fy_release_marker": d["statements_data"].get("DisclosedDate"),
+            "fy_period_key": d["statements_data"].get("FYPeriodKey"),
         },
-        entry_purpose="最新予想EPSが過去実績EPSの最大値を更新した銘柄を選定",
-        exit_purpose="最新予想EPSが過去実績EPSの最大値を下回った銘柄を除外",
+        entry_purpose="最新予想EPSが直近FY実績EPSの最大値を更新した銘柄を選定",
+        exit_purpose="最新予想EPSが直近FY実績EPSの最大値を下回った銘柄を除外",
         category="fundamental",
-        description="最新予想EPSが過去すべての実績EPSより大きい条件",
-        param_key="fundamental.forecast_eps_above_all_actuals",
+        description="最新予想EPSが直近FY実績EPS（X年）の最大値より大きい条件",
+        param_key="fundamental.forecast_eps_above_recent_fy_actuals",
         data_checker=lambda d: _has_statements_column(d, "EPS")
         and _has_any_statements_column(d, "ForwardForecastEPS", "NextYearForecastEPS"),
         data_requirements=["statements:EPS", "statements:ForwardForecastEPS"],

--- a/apps/bt/src/entrypoints/http/routes/analytics_jquants.py
+++ b/apps/bt/src/entrypoints/http/routes/analytics_jquants.py
@@ -138,6 +138,12 @@ async def get_fundamentals(
         le=250,
         description="Rolling average period in days for trading value to market cap ratio",
     ),
+    forecastEpsLookbackFyCount: int = Query(
+        3,
+        ge=1,
+        le=20,
+        description="Lookback FY count for forecast EPS vs recent actual EPS comparison",
+    ),
 ) -> FundamentalsComputeResponse:
     """ファンダメンタルズ分析指標を取得"""
     req = FundamentalsComputeRequest(
@@ -147,6 +153,7 @@ async def get_fundamentals(
         period_type=periodType,
         prefer_consolidated=preferConsolidated,
         trading_value_period=tradingValuePeriod,
+        forecast_eps_lookback_fy_count=forecastEpsLookbackFyCount,
     )
     loop = asyncio.get_event_loop()
     result = await loop.run_in_executor(

--- a/apps/bt/src/entrypoints/http/schemas/fundamentals.py
+++ b/apps/bt/src/entrypoints/http/schemas/fundamentals.py
@@ -33,6 +33,12 @@ class FundamentalsComputeRequest(BaseModel):
         le=250,
         description="Rolling period (days) for market cap to trading value ratio",
     )
+    forecast_eps_lookback_fy_count: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description="Lookback FY count for forecast EPS vs recent actual EPS comparison",
+    )
 
 
 class FundamentalDataPoint(BaseModel):
@@ -129,9 +135,13 @@ class FundamentalDataPoint(BaseModel):
     forecastEpsChangeRate: float | None = Field(
         None, description="Forecast EPS change rate (%)"
     )
+    forecastEpsAboveRecentFyActuals: bool | None = Field(
+        None,
+        description="Whether latest forecast EPS is greater than recent FY actual EPS values (lookback window)",
+    )
     forecastEpsAboveAllHistoricalActuals: bool | None = Field(
         None,
-        description="Whether latest forecast EPS is greater than all historical actual EPS values",
+        description="Deprecated: use forecastEpsAboveRecentFyActuals",
     )
 
     # Revised forecast (from latest Q)
@@ -183,5 +193,9 @@ class FundamentalsComputeResponse(BaseModel):
     )
     tradingValuePeriod: int = Field(
         ..., description="Rolling period used for market cap to trading value ratio"
+    )
+    forecastEpsLookbackFyCount: int = Field(
+        default=3,
+        description="Lookback FY count used for forecast EPS comparison indicator",
     )
     lastUpdated: str = Field(..., description="Last updated timestamp (ISO 8601)")

--- a/apps/bt/src/infrastructure/data_access/loaders/statements_loaders.py
+++ b/apps/bt/src/infrastructure/data_access/loaders/statements_loaders.py
@@ -283,6 +283,20 @@ def transform_statements_df(df: pd.DataFrame) -> pd.DataFrame:
             )
 
     _build_forward_eps_columns(df)
+    # 開示イベント判定用に開示日を明示列として保持する
+    df["DisclosedDate"] = pd.to_datetime(df.index)
+    period_types = (
+        df["TypeOfCurrentPeriod"].map(normalize_period_type)
+        if "TypeOfCurrentPeriod" in df.columns
+        else pd.Series("FY", index=df.index)
+    )
+    # 同一FY内の複数開示を1イベントとして扱うためのFY期別キー
+    df["FYPeriodKey"] = (
+        pd.Series(df.index, index=df.index)
+        .dt.strftime("%Y")
+        .where(period_types == "FY")
+        .ffill()
+    )
 
     df["ROE"] = _calc_roe(df)
     df["ROA"] = _calc_roa(df)

--- a/apps/bt/src/shared/models/signals/fundamental.py
+++ b/apps/bt/src/shared/models/signals/fundamental.py
@@ -4,7 +4,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from src.shared.models.types import StatementsPeriodType
 
@@ -88,12 +88,18 @@ class FundamentalSignalParams(BaseSignalParams):
             description="条件（above=閾値以上、below=閾値以下）",
         )
 
-    class ForecastEPSAboveAllActualsParams(BaseModel):
-        """最新予想EPSが過去すべての実績EPSより大きいシグナルパラメータ"""
+    class ForecastEPSAboveRecentFYActualsParams(BaseModel):
+        """最新予想EPSが直近FY実績EPSを上回るシグナルパラメータ"""
 
         enabled: bool = Field(
             default=False,
-            description="最新予想EPS > 過去実績EPSシグナル有効",
+            description="最新予想EPS > 直近FY実績EPSシグナル有効",
+        )
+        lookback_fy_count: int = Field(
+            default=3,
+            ge=1,
+            le=20,
+            description="比較対象に使う直近FY実績EPSの回数（年数）",
         )
 
     class ForwardDividendGrowthParams(BaseModel):
@@ -480,9 +486,13 @@ class FundamentalSignalParams(BaseSignalParams):
     forward_eps_growth: ForwardEPSParams = Field(
         default_factory=ForwardEPSParams, description="Forward EPS成長率シグナル"
     )
-    forecast_eps_above_all_actuals: ForecastEPSAboveAllActualsParams = Field(
-        default_factory=ForecastEPSAboveAllActualsParams,
-        description="最新予想EPSが過去すべての実績EPSより大きいシグナル",
+    forecast_eps_above_recent_fy_actuals: ForecastEPSAboveRecentFYActualsParams = Field(
+        default_factory=ForecastEPSAboveRecentFYActualsParams,
+        description="最新予想EPSが直近FY実績EPSの最大値より大きいシグナル",
+        validation_alias=AliasChoices(
+            "forecast_eps_above_recent_fy_actuals",
+            "forecast_eps_above_all_actuals",
+        ),
     )
     forward_dividend_growth: ForwardDividendGrowthParams = Field(
         default_factory=ForwardDividendGrowthParams,

--- a/apps/bt/tests/server/services/test_fundamentals_service.py
+++ b/apps/bt/tests/server/services/test_fundamentals_service.py
@@ -1841,7 +1841,7 @@ class TestForecastEps:
         assert result is not None
         assert result.forecastEps == 604.0
 
-    def test_apply_forecast_eps_above_all_historical_actuals_true(
+    def test_apply_forecast_eps_above_recent_fy_actuals_true(
         self, service: FundamentalsService
     ):
         metrics = FundamentalDataPoint(
@@ -1868,12 +1868,16 @@ class TestForecastEps:
             ),
         ]
 
-        result = service._apply_forecast_eps_above_all_historical_actuals(metrics, data)
+        result = service._apply_forecast_eps_above_recent_fy_actuals(
+            metrics,
+            data,
+            lookback_fy_count=2,
+        )
 
         assert result is not None
-        assert result.forecastEpsAboveAllHistoricalActuals is True
+        assert result.forecastEpsAboveRecentFyActuals is True
 
-    def test_apply_forecast_eps_above_all_historical_actuals_prefers_revised_forecast_from_fy_row(
+    def test_apply_forecast_eps_above_recent_fy_actuals_prefers_revised_forecast_from_fy_row(
         self, service: FundamentalsService
     ):
         metrics = FundamentalDataPoint(
@@ -1895,12 +1899,16 @@ class TestForecastEps:
             ),
         ]
 
-        result = service._apply_forecast_eps_above_all_historical_actuals(metrics, data)
+        result = service._apply_forecast_eps_above_recent_fy_actuals(
+            metrics,
+            data,
+            lookback_fy_count=1,
+        )
 
         assert result is not None
-        assert result.forecastEpsAboveAllHistoricalActuals is True
+        assert result.forecastEpsAboveRecentFyActuals is True
 
-    def test_apply_forecast_eps_above_all_historical_actuals_returns_none_without_actuals(
+    def test_apply_forecast_eps_above_recent_fy_actuals_returns_none_without_actuals(
         self, service: FundamentalsService
     ):
         metrics = FundamentalDataPoint(
@@ -1920,12 +1928,16 @@ class TestForecastEps:
             ),
         ]
 
-        result = service._apply_forecast_eps_above_all_historical_actuals(metrics, data)
+        result = service._apply_forecast_eps_above_recent_fy_actuals(
+            metrics,
+            data,
+            lookback_fy_count=1,
+        )
 
         assert result is not None
-        assert result.forecastEpsAboveAllHistoricalActuals is None
+        assert result.forecastEpsAboveRecentFyActuals is None
 
-    def test_apply_forecast_eps_above_all_historical_actuals_false_when_below_peak(
+    def test_apply_forecast_eps_above_recent_fy_actuals_false_when_below_peak(
         self, service: FundamentalsService
     ):
         metrics = FundamentalDataPoint(
@@ -1952,12 +1964,16 @@ class TestForecastEps:
             ),
         ]
 
-        result = service._apply_forecast_eps_above_all_historical_actuals(metrics, data)
+        result = service._apply_forecast_eps_above_recent_fy_actuals(
+            metrics,
+            data,
+            lookback_fy_count=2,
+        )
 
         assert result is not None
-        assert result.forecastEpsAboveAllHistoricalActuals is False
+        assert result.forecastEpsAboveRecentFyActuals is False
 
-    def test_apply_forecast_eps_above_all_historical_actuals_returns_none_for_nonfinite_forecast(
+    def test_apply_forecast_eps_above_recent_fy_actuals_returns_none_for_nonfinite_forecast(
         self, service: FundamentalsService
     ):
         metrics = FundamentalDataPoint(
@@ -1977,10 +1993,43 @@ class TestForecastEps:
             ),
         ]
 
-        result = service._apply_forecast_eps_above_all_historical_actuals(metrics, data)
+        result = service._apply_forecast_eps_above_recent_fy_actuals(
+            metrics,
+            data,
+            lookback_fy_count=1,
+        )
 
         assert result is not None
-        assert result.forecastEpsAboveAllHistoricalActuals is None
+        assert result.forecastEpsAboveRecentFyActuals is None
+
+    def test_apply_forecast_eps_above_recent_fy_actuals_returns_none_when_lookback_insufficient(
+        self, service: FundamentalsService
+    ):
+        metrics = FundamentalDataPoint(
+            date="2024-03-31",
+            disclosedDate="2024-05-15",
+            periodType="FY",
+            isConsolidated=True,
+            adjustedForecastEps=320.0,
+        )
+        data = [
+            FundamentalDataPoint(
+                date="2024-03-31",
+                disclosedDate="2024-05-15",
+                periodType="FY",
+                isConsolidated=True,
+                adjustedEps=300.0,
+            ),
+        ]
+
+        result = service._apply_forecast_eps_above_recent_fy_actuals(
+            metrics,
+            data,
+            lookback_fy_count=2,
+        )
+
+        assert result is not None
+        assert result.forecastEpsAboveRecentFyActuals is None
 
 
 class TestFCFYield:

--- a/apps/bt/tests/server/test_signal_reference.py
+++ b/apps/bt/tests/server/test_signal_reference.py
@@ -81,7 +81,7 @@ class TestBuildSignalReference:
         keys = {s["key"] for s in result["signals"]}
         assert "fundamental_forward_dividend_growth" in keys
         assert "fundamental_dividend_per_share_growth" in keys
-        assert "fundamental_forecast_eps_above_all_actuals" in keys
+        assert "fundamental_forecast_eps_above_recent_fy_actuals" in keys
         assert "fundamental_cfo_margin" in keys
         assert "fundamental_simple_fcf_margin" in keys
         assert "fundamental_cfo_to_net_profit_ratio" in keys

--- a/apps/bt/tests/unit/agent/test_batch_executor.py
+++ b/apps/bt/tests/unit/agent/test_batch_executor.py
@@ -184,6 +184,14 @@ class TestForecastRevisionHelpers:
             {
                 "fundamental": {
                     "enabled": True,
+                    "forecast_eps_above_recent_fy_actuals": {"enabled": True},
+                }
+            }
+        ) is True
+        assert _is_forecast_signal_enabled(
+            {
+                "fundamental": {
+                    "enabled": True,
                     "forecast_eps_above_all_actuals": {"enabled": True},
                 }
             }
@@ -207,7 +215,7 @@ class TestForecastRevisionHelpers:
             exit_trigger_params={
                 "fundamental": {
                     "enabled": True,
-                    "forecast_eps_above_all_actuals": {"enabled": True},
+                    "forecast_eps_above_recent_fy_actuals": {"enabled": True},
                 }
             },
         )
@@ -430,7 +438,7 @@ class TestBatchExecutionPaths:
                 entry_filter_params={
                     "fundamental": {
                         "enabled": True,
-                        "forecast_eps_above_all_actuals": {"enabled": True},
+                        "forecast_eps_above_recent_fy_actuals": {"enabled": True},
                     }
                 },
                 exit_trigger_params={},

--- a/apps/bt/tests/unit/optimization/test_engine_metrics.py
+++ b/apps/bt/tests/unit/optimization/test_engine_metrics.py
@@ -114,7 +114,7 @@ def test_engine_should_include_forecast_revision_when_forecast_vs_actual_enabled
     engine = object.__new__(ParameterOptimizationEngine)
     entry = SignalParams()
     entry.fundamental.enabled = True
-    entry.fundamental.forecast_eps_above_all_actuals.enabled = True
+    entry.fundamental.forecast_eps_above_recent_fy_actuals.enabled = True
     engine.base_entry_params = entry
     engine.base_exit_params = SignalParams()
     engine.parameter_ranges = {}
@@ -151,7 +151,7 @@ def test_engine_should_include_forecast_revision_when_grid_can_enable_forecast_v
         "entry_filter_params": {
             "fundamental": {
                 "enabled": [False, True],
-                "forecast_eps_above_all_actuals": {
+                "forecast_eps_above_recent_fy_actuals": {
                     "enabled": [False, True],
                 },
             }
@@ -164,7 +164,7 @@ def test_engine_should_include_forecast_revision_when_grid_can_enable_forecast_v
 def test_engine_forecast_helpers_return_false_when_not_enabled():
     params = SignalParams()
     params.fundamental.enabled = False
-    params.fundamental.forecast_eps_above_all_actuals.enabled = True
+    params.fundamental.forecast_eps_above_recent_fy_actuals.enabled = True
 
     engine = object.__new__(ParameterOptimizationEngine)
     assert engine._is_forecast_signal_enabled(params) is False
@@ -181,7 +181,7 @@ def test_engine_grid_forecast_helpers_return_false_for_non_dict_and_disabled_gri
         "entry_filter_params": {
             "fundamental": {
                 "enabled": [False],
-                "forecast_eps_above_all_actuals": {"enabled": [True]},
+                "forecast_eps_above_recent_fy_actuals": {"enabled": [True]},
             }
         }
     }

--- a/apps/bt/tests/unit/server/routes/test_analytics_complex.py
+++ b/apps/bt/tests/unit/server/routes/test_analytics_complex.py
@@ -336,16 +336,22 @@ class TestFundamentalRanking:
             assert "source" in item
             assert item["source"] in {"fy", "revised"}
 
-    def test_forecast_above_all_actuals_filter(self, analytics_client):
+    def test_forecast_above_recent_fy_actuals_filter(self, analytics_client):
         base_resp = analytics_client.get("/api/analytics/fundamental-ranking")
         assert base_resp.status_code == 200
         base_codes = {item["code"] for item in base_resp.json()["rankings"]["ratioHigh"]}
         assert "33330" in base_codes
 
-        filtered_resp = analytics_client.get("/api/analytics/fundamental-ranking?forecastAboveAllActuals=true")
+        filtered_resp = analytics_client.get(
+            "/api/analytics/fundamental-ranking?forecastAboveRecentFyActuals=true&forecastLookbackFyCount=2"
+        )
         assert filtered_resp.status_code == 200
         filtered_codes = {item["code"] for item in filtered_resp.json()["rankings"]["ratioHigh"]}
         assert "33330" not in filtered_codes
+
+    def test_legacy_forecast_above_all_actuals_param_still_supported(self, analytics_client):
+        filtered_resp = analytics_client.get("/api/analytics/fundamental-ranking?forecastAboveAllActuals=true")
+        assert filtered_resp.status_code == 200
 
     def test_422_unsupported_metric_key(self, analytics_client):
         resp = analytics_client.get("/api/analytics/fundamental-ranking?metricKey=roe_forecast_to_actual")

--- a/apps/bt/tests/unit/server/services/test_screening_service_helpers.py
+++ b/apps/bt/tests/unit/server/services/test_screening_service_helpers.py
@@ -604,11 +604,11 @@ class TestRuntimeEvaluationHelpers:
         assert service._should_include_forecast_revision(entry, exit_)  # noqa: SLF001
 
         entry.fundamental.forward_payout_ratio.enabled = False
-        entry.fundamental.forecast_eps_above_all_actuals.enabled = True
+        entry.fundamental.forecast_eps_above_recent_fy_actuals.enabled = True
         assert service._should_include_forecast_revision(entry, exit_)  # noqa: SLF001
 
         entry.fundamental.enabled = False
-        entry.fundamental.forecast_eps_above_all_actuals.enabled = False
+        entry.fundamental.forecast_eps_above_recent_fy_actuals.enabled = False
         assert not service._should_include_forecast_revision(entry, exit_)  # noqa: SLF001
 
     def test_build_result_item_and_best_strategy_helpers(self):

--- a/apps/bt/tests/unit/server/test_routes_analytics_fundamentals.py
+++ b/apps/bt/tests/unit/server/test_routes_analytics_fundamentals.py
@@ -94,6 +94,7 @@ class TestGetFundamentals:
                 "to": "2024-12-31",
                 "periodType": "FY",
                 "tradingValuePeriod": 20,
+                "forecastEpsLookbackFyCount": 5,
             },
         )
         assert resp.status_code == 200
@@ -102,6 +103,7 @@ class TestGetFundamentals:
         assert call_args.to_date == "2024-12-31"
         assert call_args.period_type == "FY"
         assert call_args.trading_value_period == 20
+        assert call_args.forecast_eps_lookback_fy_count == 5
 
     @patch("src.entrypoints.http.routes.analytics_jquants.fundamentals_service")
     def test_default_params(self, mock_service: MagicMock, client: TestClient) -> None:
@@ -114,6 +116,7 @@ class TestGetFundamentals:
         assert call_args.period_type == "all"
         assert call_args.prefer_consolidated is True
         assert call_args.trading_value_period == 15
+        assert call_args.forecast_eps_lookback_fy_count == 3
 
     @patch("src.entrypoints.http.routes.analytics_jquants.fundamentals_service")
     def test_prefer_consolidated_false(self, mock_service: MagicMock, client: TestClient) -> None:

--- a/apps/bt/tests/unit/strategies/mixins/test_data_manager_mixin_paths.py
+++ b/apps/bt/tests/unit/strategies/mixins/test_data_manager_mixin_paths.py
@@ -165,7 +165,7 @@ class TestDataManagerMixinPaths:
         strategy._should_load_statements_data = lambda: True
         strategy.entry_filter_params = SignalParams()
         strategy.entry_filter_params.fundamental.enabled = True
-        strategy.entry_filter_params.fundamental.forecast_eps_above_all_actuals.enabled = True
+        strategy.entry_filter_params.fundamental.forecast_eps_above_recent_fy_actuals.enabled = True
 
         captured: dict[str, object] = {}
 

--- a/apps/ts/packages/shared/openapi/bt-openapi.json
+++ b/apps/ts/packages/shared/openapi/bt-openapi.json
@@ -2571,8 +2571,20 @@
                 "type": "null"
               }
             ],
-            "description": "Whether latest forecast EPS is greater than all historical actual EPS values",
+            "description": "Deprecated: use forecastEpsAboveRecentFyActuals",
             "title": "Forecastepsaboveallhistoricalactuals"
+          },
+          "forecastEpsAboveRecentFyActuals": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether latest forecast EPS is greater than recent FY actual EPS values (lookback window)",
+            "title": "Forecastepsaboverecentfyactuals"
           },
           "forecastEpsChangeRate": {
             "anyOf": [
@@ -2950,6 +2962,14 @@
       "FundamentalsComputeRequest": {
         "description": "Request body for fundamentals computation.",
         "properties": {
+          "forecast_eps_lookback_fy_count": {
+            "default": 3,
+            "description": "Lookback FY count for forecast EPS vs recent actual EPS comparison",
+            "maximum": 20,
+            "minimum": 1,
+            "title": "Forecast Eps Lookback Fy Count",
+            "type": "integer"
+          },
           "from_date": {
             "anyOf": [
               {
@@ -3053,6 +3073,12 @@
             },
             "title": "Data",
             "type": "array"
+          },
+          "forecastEpsLookbackFyCount": {
+            "default": 3,
+            "description": "Lookback FY count used for forecast EPS comparison indicator",
+            "title": "Forecastepslookbackfycount",
+            "type": "integer"
           },
           "lastUpdated": {
             "description": "Last updated timestamp (ISO 8601)",
@@ -11956,15 +11982,35 @@
             }
           },
           {
-            "description": "If true, return only stocks whose latest forecast EPS is greater than all historical actual EPS.",
+            "description": "If true, return only stocks whose latest forecast EPS is greater than the max actual EPS in recent FY lookback window.",
             "in": "query",
-            "name": "forecastAboveAllActuals",
+            "name": "forecastAboveRecentFyActuals",
             "required": false,
             "schema": {
-              "default": false,
-              "description": "If true, return only stocks whose latest forecast EPS is greater than all historical actual EPS.",
-              "title": "Forecastaboveallactuals",
-              "type": "boolean"
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "If true, return only stocks whose latest forecast EPS is greater than the max actual EPS in recent FY lookback window.",
+              "title": "Forecastaboverecentfyactuals"
+            }
+          },
+          {
+            "description": "Lookback FY count used by forecastAboveRecentFyActuals filter.",
+            "in": "query",
+            "name": "forecastLookbackFyCount",
+            "required": false,
+            "schema": {
+              "default": 3,
+              "description": "Lookback FY count used by forecastAboveRecentFyActuals filter.",
+              "maximum": 20,
+              "minimum": 1,
+              "title": "Forecastlookbackfycount",
+              "type": "integer"
             }
           }
         ],
@@ -12110,6 +12156,20 @@
               "maximum": 250,
               "minimum": 1,
               "title": "Tradingvalueperiod",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Lookback FY count for forecast EPS vs recent actual EPS comparison",
+            "in": "query",
+            "name": "forecastEpsLookbackFyCount",
+            "required": false,
+            "schema": {
+              "default": 3,
+              "description": "Lookback FY count for forecast EPS vs recent actual EPS comparison",
+              "maximum": 20,
+              "minimum": 1,
+              "title": "Forecastepslookbackfycount",
               "type": "integer"
             }
           }

--- a/apps/ts/packages/shared/src/types/api-types.ts
+++ b/apps/ts/packages/shared/src/types/api-types.ts
@@ -247,7 +247,12 @@ export interface ApiFundamentalDataPoint {
   forecastEps?: number | null;
   /** Change rate from actual EPS to forecast EPS (%) */
   forecastEpsChangeRate?: number | null;
+  /** Whether latest forecast EPS exceeds recent FY actual EPS values (lookback window) */
+  forecastEpsAboveRecentFyActuals?: boolean | null;
+  /** Lookback FY count used for forecast-vs-actual EPS comparison */
+  forecastEpsLookbackFyCount?: number;
   /** Whether latest forecast EPS exceeds all historical actual EPS values */
+  /** @deprecated Use forecastEpsAboveRecentFyActuals */
   forecastEpsAboveAllHistoricalActuals?: boolean | null;
   /** Revised forecast EPS from latest quarterly statement (円) */
   revisedForecastEps?: number | null;
@@ -280,6 +285,8 @@ export interface ApiFundamentalsResponse {
   dailyValuation?: ApiDailyValuationDataPoint[];
   /** Rolling average period used for trading value to market cap ratio (days) */
   tradingValuePeriod: number;
+  /** Lookback FY count used for forecast-vs-actual EPS comparison */
+  forecastEpsLookbackFyCount: number;
   /** Last updated timestamp */
   lastUpdated: string;
 }

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.test.tsx
@@ -37,7 +37,11 @@ describe('FundamentalsPanel', () => {
 
     render(<FundamentalsPanel symbol="7203" enabled={false} />);
 
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false, tradingValuePeriod: 15 });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', {
+      enabled: false,
+      tradingValuePeriod: 15,
+      forecastEpsLookbackFyCount: 3,
+    });
   });
 
   it('forwards custom tradingValuePeriod to useFundamentals and summary card', () => {
@@ -69,7 +73,11 @@ describe('FundamentalsPanel', () => {
 
     render(<FundamentalsPanel symbol="7203" tradingValuePeriod={30} />);
 
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: true, tradingValuePeriod: 30 });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', {
+      enabled: true,
+      tradingValuePeriod: 30,
+      forecastEpsLookbackFyCount: 3,
+    });
     expect(mockSummaryCard.mock.calls.at(-1)?.[0]).toMatchObject({ tradingValuePeriod: 30 });
   });
 
@@ -144,7 +152,7 @@ describe('FundamentalsPanel', () => {
           prevCashAndEquivalents: 450,
           cfoToNetProfitRatio: 0.45,
           tradingValueToMarketCapRatio: 33.333333,
-          forecastEpsAboveAllHistoricalActuals: true,
+          forecastEpsAboveRecentFyActuals: true,
         },
         dailyValuation: [{ per: 18, pbr: 1.4, close: 2500, marketCap: 1000000000 }],
         tradingValuePeriod: 20,
@@ -174,7 +182,7 @@ describe('FundamentalsPanel', () => {
     expect(metrics?.stockPrice).toBe(2500);
     expect(metrics?.cfoToNetProfitRatio).toBe(0.45);
     expect(metrics?.tradingValueToMarketCapRatio).toBeCloseTo(33.333333, 5);
-    expect(metrics?.forecastEpsAboveAllHistoricalActuals).toBe(true);
+    expect(metrics?.forecastEpsAboveRecentFyActuals).toBe(true);
     expect(mockSummaryCard.mock.calls.at(-1)?.[0]).toMatchObject({ tradingValuePeriod: 20 });
   });
 
@@ -219,7 +227,7 @@ describe('FundamentalsPanel', () => {
     expect(metrics?.revisedForecastEps).toBe(604);
     expect(metrics?.revisedForecastSource).toBe('1Q');
     expect(metrics?.forecastEpsChangeRate).toBe(504);
-    expect(metrics?.forecastEpsAboveAllHistoricalActuals).toBe(true);
+    expect(metrics?.forecastEpsAboveRecentFyActuals).toBeNull();
   });
 
   it('falls back when latestMetrics is missing and adjusted EPS cannot compute change rate', () => {
@@ -258,6 +266,6 @@ describe('FundamentalsPanel', () => {
     expect(metrics?.per).toBeUndefined();
     expect(metrics?.pbr).toBeUndefined();
     expect(metrics?.stockPrice).toBeUndefined();
-    expect(metrics?.forecastEpsAboveAllHistoricalActuals).toBe(false);
+    expect(metrics?.forecastEpsAboveRecentFyActuals).toBeNull();
   });
 });

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.test.tsx
@@ -46,7 +46,8 @@ const baseMetrics: ApiFundamentalDataPoint = {
   tradingValueToMarketCapRatio: 8.33,
   forecastEps: 350,
   forecastEpsChangeRate: 16.7,
-  forecastEpsAboveAllHistoricalActuals: true,
+  forecastEpsAboveRecentFyActuals: true,
+  forecastEpsLookbackFyCount: 3,
   revisedForecastEps: null,
   revisedForecastSource: null,
   prevCashFlowOperating: null,
@@ -71,7 +72,7 @@ describe('FundamentalsSummaryCard', () => {
     expect(screen.getByText('1.50x')).toBeInTheDocument();
     expect(screen.getByText('8.33x')).toBeInTheDocument();
     expect(screen.getByText('(17.43x)')).toBeInTheDocument();
-    expect(screen.getByText('予想EPS > 過去実績EPS: true')).toBeInTheDocument();
+    expect(screen.getByText('予想EPS > 直近FY3実績EPS: true')).toBeInTheDocument();
   });
 
   it('uses 15-day label by default', () => {
@@ -166,10 +167,21 @@ describe('FundamentalsSummaryCard', () => {
   it('renders false in forecast-vs-historical marker when flag is false', () => {
     const metrics: ApiFundamentalDataPoint = {
       ...baseMetrics,
-      forecastEpsAboveAllHistoricalActuals: false,
+      forecastEpsAboveRecentFyActuals: false,
     };
 
     render(<FundamentalsSummaryCard metrics={metrics} />);
-    expect(screen.getByText('予想EPS > 過去実績EPS: false')).toBeInTheDocument();
+    expect(screen.getByText('予想EPS > 直近FY3実績EPS: false')).toBeInTheDocument();
+  });
+
+  it('renders "-" in forecast-vs-historical marker when flag is unknown', () => {
+    const metrics: ApiFundamentalDataPoint = {
+      ...baseMetrics,
+      forecastEpsAboveRecentFyActuals: null,
+      forecastEpsAboveAllHistoricalActuals: null,
+    };
+
+    render(<FundamentalsSummaryCard metrics={metrics} />);
+    expect(screen.getByText('予想EPS > 直近FY3実績EPS: -')).toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -126,6 +126,15 @@ export function FundamentalsSummaryCard({
   const displayDividendFy = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;
   const displayForecastDividendFy =
     metrics.adjustedForecastDividendFy ?? metrics.forecastDividendFy ?? null;
+  const forecastEpsAboveRecentFyActuals =
+    metrics.forecastEpsAboveRecentFyActuals ?? metrics.forecastEpsAboveAllHistoricalActuals;
+  const forecastEpsLookbackFyCount = metrics.forecastEpsLookbackFyCount ?? 3;
+  const forecastEpsAboveRecentFyActualsLabel =
+    forecastEpsAboveRecentFyActuals == null
+      ? '-'
+      : forecastEpsAboveRecentFyActuals
+        ? 'true'
+        : 'false';
   const visibleMetricOrder = metricOrder.filter((metricId) => metricVisibility[metricId]);
 
   const renderMetric = (metricId: FundamentalMetricId) => {
@@ -262,8 +271,8 @@ export function FundamentalsSummaryCard({
           </span>
         </div>
         <div className="mt-1">
-          予想EPS &gt; 過去実績EPS:{' '}
-          {metrics.forecastEpsAboveAllHistoricalActuals === true ? 'true' : 'false'}
+          予想EPS &gt; 直近FY{forecastEpsLookbackFyCount}実績EPS:{' '}
+          {forecastEpsAboveRecentFyActualsLabel}
         </div>
         {metrics.stockPrice && <div className="mt-1">株価 @ 開示日: {metrics.stockPrice.toLocaleString()}円</div>}
       </div>

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsSummaryCard.tsx
@@ -1,5 +1,5 @@
 import type { ApiFundamentalDataPoint } from '@trading25/shared/types/api-types';
-import { Fragment } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import {
   DEFAULT_FUNDAMENTAL_METRIC_ORDER,
   DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
@@ -105,6 +105,150 @@ function resolveForecastPer(stockPrice: number | null, forecastEps: number | nul
   return Number.isFinite(forecastPer) ? forecastPer : null;
 }
 
+interface MetricRenderContext {
+  metrics: ApiFundamentalDataPoint;
+  displayEps: number | null;
+  displayForecastEps: number | null;
+  displayBps: number | null;
+  displayDividendFy: number | null;
+  displayForecastDividendFy: number | null;
+  displayForecastPer: number | null;
+  tradingValuePeriod: number;
+}
+
+interface SummaryDisplayValues {
+  displayEps: number | null;
+  displayForecastEps: number | null;
+  displayForecastPer: number | null;
+  displayBps: number | null;
+  displayDividendFy: number | null;
+  displayForecastDividendFy: number | null;
+  forecastEpsLookbackFyCount: number;
+  forecastEpsAboveRecentFyActualsLabel: string;
+}
+
+function toBooleanLabel(value: boolean | null | undefined): string {
+  if (value == null) return '-';
+  return value ? 'true' : 'false';
+}
+
+function resolveSummaryDisplayValues(metrics: ApiFundamentalDataPoint): SummaryDisplayValues {
+  const displayEps = metrics.adjustedEps ?? metrics.eps ?? null;
+  const displayForecastEps = metrics.revisedForecastEps ?? metrics.adjustedForecastEps ?? metrics.forecastEps ?? null;
+  const displayForecastPer = resolveForecastPer(metrics.stockPrice, displayForecastEps);
+  const displayBps = metrics.adjustedBps ?? metrics.bps ?? null;
+  const displayDividendFy = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;
+  const displayForecastDividendFy = metrics.adjustedForecastDividendFy ?? metrics.forecastDividendFy ?? null;
+  const forecastEpsAboveRecentFyActuals =
+    metrics.forecastEpsAboveRecentFyActuals ?? metrics.forecastEpsAboveAllHistoricalActuals;
+
+  return {
+    displayEps,
+    displayForecastEps,
+    displayForecastPer,
+    displayBps,
+    displayDividendFy,
+    displayForecastDividendFy,
+    forecastEpsLookbackFyCount: metrics.forecastEpsLookbackFyCount ?? 3,
+    forecastEpsAboveRecentFyActualsLabel: toBooleanLabel(forecastEpsAboveRecentFyActuals),
+  };
+}
+
+function buildMetricCards({
+  metrics,
+  displayEps,
+  displayForecastEps,
+  displayBps,
+  displayDividendFy,
+  displayForecastDividendFy,
+  displayForecastPer,
+  tradingValuePeriod,
+}: MetricRenderContext): Record<FundamentalMetricId, ReactNode> {
+  return {
+    per: <MetricCard label="PER" value={metrics.per} format="times" colorScheme="per" prevValue={displayForecastPer} />,
+    pbr: <MetricCard label="PBR" value={metrics.pbr} format="times" colorScheme="pbr" />,
+    roe: <MetricCard label="ROE" value={metrics.roe} format="percent" colorScheme="roe" />,
+    roa: <MetricCard label="ROA" value={metrics.roa} format="percent" colorScheme="roe" />,
+    eps: (
+      <ForecastMetricCard
+        label="EPS"
+        actualValue={displayEps}
+        forecastValue={displayForecastEps}
+        changeRate={metrics.forecastEpsChangeRate}
+        format="yen"
+      />
+    ),
+    bps: <MetricCard label="BPS" value={displayBps} format="yen" />,
+    dividendPerShare: (
+      <ForecastMetricCard
+        label="1株配当"
+        actualValue={displayDividendFy}
+        forecastValue={displayForecastDividendFy}
+        changeRate={metrics.forecastDividendFyChangeRate}
+        format="yen"
+      />
+    ),
+    payoutRatio: (
+      <ForecastMetricCard
+        label="配当性向"
+        actualValue={metrics.payoutRatio ?? null}
+        forecastValue={metrics.forecastPayoutRatio ?? null}
+        changeRate={metrics.forecastPayoutRatioChangeRate}
+        format="percent"
+      />
+    ),
+    operatingMargin: <MetricCard label="営業利益率" value={metrics.operatingMargin} format="percent" />,
+    netMargin: <MetricCard label="純利益率" value={metrics.netMargin} format="percent" />,
+    cashFlowOperating: (
+      <MetricCard
+        label="営業CF"
+        value={metrics.cashFlowOperating}
+        format="millions"
+        colorScheme="cashFlow"
+        prevValue={metrics.prevCashFlowOperating}
+      />
+    ),
+    cashFlowInvesting: (
+      <MetricCard
+        label="投資CF"
+        value={metrics.cashFlowInvesting}
+        format="millions"
+        prevValue={metrics.prevCashFlowInvesting}
+      />
+    ),
+    cashFlowFinancing: (
+      <MetricCard
+        label="財務CF"
+        value={metrics.cashFlowFinancing}
+        format="millions"
+        prevValue={metrics.prevCashFlowFinancing}
+      />
+    ),
+    cashAndEquivalents: (
+      <MetricCard
+        label="現金"
+        value={metrics.cashAndEquivalents}
+        format="millions"
+        prevValue={metrics.prevCashAndEquivalents}
+      />
+    ),
+    fcf: <MetricCard label="FCF" value={metrics.fcf} format="millions" colorScheme="cashFlow" />,
+    fcfYield: <MetricCard label="FCF利回り" value={metrics.fcfYield} format="percent" colorScheme="fcfYield" />,
+    fcfMargin: <MetricCard label="FCFマージン" value={metrics.fcfMargin} format="percent" colorScheme="fcfMargin" />,
+    cfoYield: <MetricCard label="CFO利回り" value={metrics.cfoYield} format="percent" colorScheme="cfoYield" />,
+    cfoMargin: <MetricCard label="CFOマージン" value={metrics.cfoMargin} format="percent" colorScheme="cfoMargin" />,
+    cfoToNetProfitRatio: <MetricCard label="営業CF/純利益" value={metrics.cfoToNetProfitRatio ?? null} format="times" />,
+    tradingValueToMarketCapRatio: (
+      <MetricCard
+        label={`時価総額/${tradingValuePeriod}日売買代金`}
+        value={metrics.tradingValueToMarketCapRatio ?? null}
+        format="times"
+        decimals={3}
+      />
+    ),
+  };
+}
+
 export function FundamentalsSummaryCard({
   metrics,
   tradingValuePeriod = 15,
@@ -119,139 +263,34 @@ export function FundamentalsSummaryCard({
     );
   }
 
-  const displayEps = metrics.adjustedEps ?? metrics.eps;
-  const displayForecastEps = metrics.revisedForecastEps ?? metrics.adjustedForecastEps ?? metrics.forecastEps;
-  const displayForecastPer = resolveForecastPer(metrics.stockPrice, displayForecastEps ?? null);
-  const displayBps = metrics.adjustedBps ?? metrics.bps;
-  const displayDividendFy = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;
-  const displayForecastDividendFy =
-    metrics.adjustedForecastDividendFy ?? metrics.forecastDividendFy ?? null;
-  const forecastEpsAboveRecentFyActuals =
-    metrics.forecastEpsAboveRecentFyActuals ?? metrics.forecastEpsAboveAllHistoricalActuals;
-  const forecastEpsLookbackFyCount = metrics.forecastEpsLookbackFyCount ?? 3;
-  const forecastEpsAboveRecentFyActualsLabel =
-    forecastEpsAboveRecentFyActuals == null
-      ? '-'
-      : forecastEpsAboveRecentFyActuals
-        ? 'true'
-        : 'false';
+  const {
+    displayEps,
+    displayForecastEps,
+    displayForecastPer,
+    displayBps,
+    displayDividendFy,
+    displayForecastDividendFy,
+    forecastEpsLookbackFyCount,
+    forecastEpsAboveRecentFyActualsLabel,
+  } = resolveSummaryDisplayValues(metrics);
   const visibleMetricOrder = metricOrder.filter((metricId) => metricVisibility[metricId]);
-
-  const renderMetric = (metricId: FundamentalMetricId) => {
-    switch (metricId) {
-      case 'per':
-        return (
-          <MetricCard label="PER" value={metrics.per} format="times" colorScheme="per" prevValue={displayForecastPer} />
-        );
-      case 'pbr':
-        return <MetricCard label="PBR" value={metrics.pbr} format="times" colorScheme="pbr" />;
-      case 'roe':
-        return <MetricCard label="ROE" value={metrics.roe} format="percent" colorScheme="roe" />;
-      case 'roa':
-        return <MetricCard label="ROA" value={metrics.roa} format="percent" colorScheme="roe" />;
-      case 'eps':
-        return (
-          <ForecastMetricCard
-            label="EPS"
-            actualValue={displayEps}
-            forecastValue={displayForecastEps}
-            changeRate={metrics.forecastEpsChangeRate}
-            format="yen"
-          />
-        );
-      case 'bps':
-        return <MetricCard label="BPS" value={displayBps} format="yen" />;
-      case 'dividendPerShare':
-        return (
-          <ForecastMetricCard
-            label="1株配当"
-            actualValue={displayDividendFy}
-            forecastValue={displayForecastDividendFy}
-            changeRate={metrics.forecastDividendFyChangeRate}
-            format="yen"
-          />
-        );
-      case 'payoutRatio':
-        return (
-          <ForecastMetricCard
-            label="配当性向"
-            actualValue={metrics.payoutRatio ?? null}
-            forecastValue={metrics.forecastPayoutRatio ?? null}
-            changeRate={metrics.forecastPayoutRatioChangeRate}
-            format="percent"
-          />
-        );
-      case 'operatingMargin':
-        return <MetricCard label="営業利益率" value={metrics.operatingMargin} format="percent" />;
-      case 'netMargin':
-        return <MetricCard label="純利益率" value={metrics.netMargin} format="percent" />;
-      case 'cashFlowOperating':
-        return (
-          <MetricCard
-            label="営業CF"
-            value={metrics.cashFlowOperating}
-            format="millions"
-            colorScheme="cashFlow"
-            prevValue={metrics.prevCashFlowOperating}
-          />
-        );
-      case 'cashFlowInvesting':
-        return (
-          <MetricCard
-            label="投資CF"
-            value={metrics.cashFlowInvesting}
-            format="millions"
-            prevValue={metrics.prevCashFlowInvesting}
-          />
-        );
-      case 'cashFlowFinancing':
-        return (
-          <MetricCard
-            label="財務CF"
-            value={metrics.cashFlowFinancing}
-            format="millions"
-            prevValue={metrics.prevCashFlowFinancing}
-          />
-        );
-      case 'cashAndEquivalents':
-        return (
-          <MetricCard
-            label="現金"
-            value={metrics.cashAndEquivalents}
-            format="millions"
-            prevValue={metrics.prevCashAndEquivalents}
-          />
-        );
-      case 'fcf':
-        return <MetricCard label="FCF" value={metrics.fcf} format="millions" colorScheme="cashFlow" />;
-      case 'fcfYield':
-        return <MetricCard label="FCF利回り" value={metrics.fcfYield} format="percent" colorScheme="fcfYield" />;
-      case 'fcfMargin':
-        return <MetricCard label="FCFマージン" value={metrics.fcfMargin} format="percent" colorScheme="fcfMargin" />;
-      case 'cfoYield':
-        return <MetricCard label="CFO利回り" value={metrics.cfoYield} format="percent" colorScheme="cfoYield" />;
-      case 'cfoMargin':
-        return <MetricCard label="CFOマージン" value={metrics.cfoMargin} format="percent" colorScheme="cfoMargin" />;
-      case 'cfoToNetProfitRatio':
-        return <MetricCard label="営業CF/純利益" value={metrics.cfoToNetProfitRatio ?? null} format="times" />;
-      case 'tradingValueToMarketCapRatio':
-        return (
-          <MetricCard
-            label={`時価総額/${tradingValuePeriod}日売買代金`}
-            value={metrics.tradingValueToMarketCapRatio ?? null}
-            format="times"
-            decimals={3}
-          />
-        );
-    }
-  };
+  const metricCards = buildMetricCards({
+    metrics,
+    displayEps,
+    displayForecastEps,
+    displayBps,
+    displayDividendFy,
+    displayForecastDividendFy,
+    displayForecastPer,
+    tradingValuePeriod,
+  });
 
   return (
     <div className="h-full min-h-0 flex flex-col">
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="grid grid-cols-8 gap-1.5 p-2">
           {visibleMetricOrder.length > 0 ? (
-            visibleMetricOrder.map((metricId) => <Fragment key={metricId}>{renderMetric(metricId)}</Fragment>)
+            visibleMetricOrder.map((metricId) => <Fragment key={metricId}>{metricCards[metricId]}</Fragment>)
           ) : (
             <div className="col-span-full py-8 text-center text-sm text-muted-foreground">
               表示する指標をサイドバーで選択してください

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx
@@ -7,7 +7,8 @@ describe('FundamentalRankingFilters', () => {
   const defaultParams: FundamentalRankingParams = {
     markets: 'prime',
     limit: 20,
-    forecastAboveAllActuals: false,
+    forecastAboveRecentFyActuals: false,
+    forecastLookbackFyCount: 3,
   };
 
   it('renders filter card with title', () => {
@@ -23,5 +24,10 @@ describe('FundamentalRankingFilters', () => {
   it('renders eps condition control', () => {
     render(<FundamentalRankingFilters params={defaultParams} onChange={vi.fn()} />);
     expect(screen.getByText('EPS Condition')).toBeInTheDocument();
+  });
+
+  it('renders lookback control', () => {
+    render(<FundamentalRankingFilters params={defaultParams} onChange={vi.fn()} />);
+    expect(screen.getByText('Recent FY lookback')).toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.tsx
@@ -20,10 +20,18 @@ const LIMIT_OPTIONS = [
 const EPS_FILTER_OPTIONS = [
   { value: 'all', label: 'All stocks' },
   {
-    value: 'forecastAboveAllActuals',
-    label: 'Latest Forecast EPS > All Actual EPS',
+    value: 'forecastAboveRecentFyActuals',
+    label: 'Latest Forecast EPS > Recent FY Actual EPS',
   },
 ] as const;
+
+const LOOKBACK_FY_COUNT_OPTIONS = [
+  { value: 1, label: '1 FY' },
+  { value: 2, label: '2 FY' },
+  { value: 3, label: '3 FY' },
+  { value: 5, label: '5 FY' },
+  { value: 10, label: '10 FY' },
+];
 
 interface FundamentalRankingFiltersProps {
   params: FundamentalRankingParams;
@@ -34,7 +42,9 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
   const updateParam = <K extends keyof FundamentalRankingParams>(key: K, value: FundamentalRankingParams[K]) => {
     onChange({ ...params, [key]: value });
   };
-  const epsFilterValue = params.forecastAboveAllActuals ? 'forecastAboveAllActuals' : 'all';
+  const forecastFilterEnabled = params.forecastAboveRecentFyActuals ?? params.forecastAboveAllActuals ?? false;
+  const epsFilterValue = forecastFilterEnabled ? 'forecastAboveRecentFyActuals' : 'all';
+  const lookbackFyCount = params.forecastLookbackFyCount ?? 3;
 
   return (
     <Card className="glass-panel">
@@ -54,7 +64,7 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
           </Label>
           <Select
             value={epsFilterValue}
-            onValueChange={(value) => updateParam('forecastAboveAllActuals', value === 'forecastAboveAllActuals')}
+            onValueChange={(value) => updateParam('forecastAboveRecentFyActuals', value === 'forecastAboveRecentFyActuals')}
           >
             <SelectTrigger id="fundamental-ranking-eps-condition" className="h-8 text-xs">
               <SelectValue />
@@ -68,6 +78,13 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
             </SelectContent>
           </Select>
         </div>
+        <NumberSelect
+          value={lookbackFyCount}
+          onChange={(v) => updateParam('forecastLookbackFyCount', v)}
+          options={LOOKBACK_FY_COUNT_OPTIONS}
+          id="fundamental-ranking-lookback-fy-count"
+          label="Recent FY lookback"
+        />
         <NumberSelect
           value={params.limit || 20}
           onChange={(v) => updateParam('limit', v)}

--- a/apps/ts/packages/web/src/hooks/useFundamentalRanking.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useFundamentalRanking.test.tsx
@@ -23,12 +23,22 @@ describe('useFundamentalRanking', () => {
   it('fetches fundamental ranking data when enabled', async () => {
     vi.mocked(apiGet).mockResolvedValueOnce({ rankings: {} });
     const { wrapper } = createTestWrapper();
-    const params = { limit: 20, markets: 'prime', forecastAboveAllActuals: true };
+    const params = {
+      limit: 20,
+      markets: 'prime',
+      forecastAboveRecentFyActuals: true,
+      forecastLookbackFyCount: 5,
+    };
     const { result } = renderHook(() => useFundamentalRanking(params, true), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiGet).toHaveBeenCalledWith(
       '/api/analytics/fundamental-ranking',
-      expect.objectContaining({ limit: 20, markets: 'prime', forecastAboveAllActuals: true })
+      expect.objectContaining({
+        limit: 20,
+        markets: 'prime',
+        forecastAboveRecentFyActuals: true,
+        forecastLookbackFyCount: 5,
+      })
     );
   });
 

--- a/apps/ts/packages/web/src/hooks/useFundamentalRanking.ts
+++ b/apps/ts/packages/web/src/hooks/useFundamentalRanking.ts
@@ -3,11 +3,20 @@ import { apiGet } from '@/lib/api-client';
 import type { FundamentalRankingParams, MarketFundamentalRankingResponse } from '@/types/fundamentalRanking';
 import { logger } from '@/utils/logger';
 
+function normalizeLookbackFyCount(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 3;
+  return Math.min(20, Math.max(1, Math.trunc(value)));
+}
+
 function fetchFundamentalRanking(params: FundamentalRankingParams): Promise<MarketFundamentalRankingResponse> {
+  const forecastAboveRecentFyActuals = params.forecastAboveRecentFyActuals ?? params.forecastAboveAllActuals ?? false;
+  const forecastLookbackFyCount = normalizeLookbackFyCount(params.forecastLookbackFyCount);
+
   return apiGet<MarketFundamentalRankingResponse>('/api/analytics/fundamental-ranking', {
     limit: params.limit,
     markets: params.markets,
-    forecastAboveAllActuals: params.forecastAboveAllActuals,
+    forecastAboveRecentFyActuals,
+    forecastLookbackFyCount,
   });
 }
 

--- a/apps/ts/packages/web/src/hooks/useFundamentals.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useFundamentals.test.tsx
@@ -27,16 +27,21 @@ describe('useFundamentals', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
       tradingValuePeriod: 15,
+      forecastEpsLookbackFyCount: 3,
     });
   });
 
   it('uses custom trading value period', async () => {
     vi.mocked(apiGet).mockResolvedValueOnce({ roe: 10, per: 15 });
     const { wrapper } = createTestWrapper();
-    const { result } = renderHook(() => useFundamentals('7203', { tradingValuePeriod: 30 }), { wrapper });
+    const { result } = renderHook(
+      () => useFundamentals('7203', { tradingValuePeriod: 30, forecastEpsLookbackFyCount: 5 }),
+      { wrapper }
+    );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
       tradingValuePeriod: 30,
+      forecastEpsLookbackFyCount: 5,
     });
   });
 
@@ -47,6 +52,7 @@ describe('useFundamentals', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
       tradingValuePeriod: 15,
+      forecastEpsLookbackFyCount: 3,
     });
   });
 
@@ -57,6 +63,7 @@ describe('useFundamentals', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiGet).toHaveBeenCalledWith('/api/analytics/fundamentals/7203', {
       tradingValuePeriod: 1,
+      forecastEpsLookbackFyCount: 3,
     });
   });
 

--- a/apps/ts/packages/web/src/hooks/useFundamentals.ts
+++ b/apps/ts/packages/web/src/hooks/useFundamentals.ts
@@ -7,28 +7,52 @@ function normalizeTradingValuePeriod(period: number): number {
   return Math.max(1, Math.trunc(period));
 }
 
-function fetchFundamentals(symbol: string, tradingValuePeriod: number): Promise<ApiFundamentalsResponse> {
+function normalizeForecastEpsLookbackFyCount(count: number): number {
+  if (!Number.isFinite(count)) return 3;
+  return Math.min(20, Math.max(1, Math.trunc(count)));
+}
+
+function fetchFundamentals(
+  symbol: string,
+  tradingValuePeriod: number,
+  forecastEpsLookbackFyCount: number
+): Promise<ApiFundamentalsResponse> {
   return apiGet<ApiFundamentalsResponse>(`/api/analytics/fundamentals/${symbol}`, {
     tradingValuePeriod,
+    forecastEpsLookbackFyCount,
   });
 }
 
 interface UseFundamentalsOptions {
   enabled?: boolean;
   tradingValuePeriod?: number;
+  forecastEpsLookbackFyCount?: number;
 }
 
 const FUNDAMENTALS_QUERY_KEY_VERSION = 'v2';
 
 export function useFundamentals(symbol: string | null, options: UseFundamentalsOptions = {}) {
-  const { enabled = true, tradingValuePeriod = 15 } = options;
+  const { enabled = true, tradingValuePeriod = 15, forecastEpsLookbackFyCount = 3 } = options;
   const normalizedTradingValuePeriod = normalizeTradingValuePeriod(tradingValuePeriod);
+  const normalizedForecastEpsLookbackFyCount = normalizeForecastEpsLookbackFyCount(
+    forecastEpsLookbackFyCount
+  );
 
   return useQuery({
-    queryKey: ['fundamentals', FUNDAMENTALS_QUERY_KEY_VERSION, symbol, normalizedTradingValuePeriod],
+    queryKey: [
+      'fundamentals',
+      FUNDAMENTALS_QUERY_KEY_VERSION,
+      symbol,
+      normalizedTradingValuePeriod,
+      normalizedForecastEpsLookbackFyCount,
+    ],
     queryFn: () => {
       if (!symbol) throw new Error('Symbol is required');
-      return fetchFundamentals(symbol, normalizedTradingValuePeriod);
+      return fetchFundamentals(
+        symbol,
+        normalizedTradingValuePeriod,
+        normalizedForecastEpsLookbackFyCount
+      );
     },
     enabled: !!symbol && enabled,
     staleTime: 10 * 60 * 1000, // 10 minutes (financial data changes infrequently)

--- a/apps/ts/packages/web/src/stores/analysisStore.test.ts
+++ b/apps/ts/packages/web/src/stores/analysisStore.test.ts
@@ -90,12 +90,14 @@ describe('analysisStore', () => {
       ...DEFAULT_FUNDAMENTAL_RANKING_PARAMS,
       markets: 'prime,standard',
       limit: 50,
-      forecastAboveAllActuals: true,
+      forecastAboveRecentFyActuals: true,
+      forecastLookbackFyCount: 5,
     });
 
     const state = useAnalysisStore.getState();
     expect(state.fundamentalRankingParams.markets).toBe('prime,standard');
     expect(state.fundamentalRankingParams.limit).toBe(50);
-    expect(state.fundamentalRankingParams.forecastAboveAllActuals).toBe(true);
+    expect(state.fundamentalRankingParams.forecastAboveRecentFyActuals).toBe(true);
+    expect(state.fundamentalRankingParams.forecastLookbackFyCount).toBe(5);
   });
 });

--- a/apps/ts/packages/web/src/stores/analysisStore.ts
+++ b/apps/ts/packages/web/src/stores/analysisStore.ts
@@ -24,7 +24,8 @@ export const DEFAULT_RANKING_PARAMS: RankingParams = {
 export const DEFAULT_FUNDAMENTAL_RANKING_PARAMS: FundamentalRankingParams = {
   markets: 'prime',
   limit: 20,
-  forecastAboveAllActuals: false,
+  forecastAboveRecentFyActuals: false,
+  forecastLookbackFyCount: 3,
 };
 
 interface AnalysisState {

--- a/apps/ts/packages/web/src/types/fundamentalRanking.ts
+++ b/apps/ts/packages/web/src/types/fundamentalRanking.ts
@@ -13,5 +13,8 @@ export type {
 export interface FundamentalRankingParams {
   limit?: number;
   markets?: string;
+  forecastAboveRecentFyActuals?: boolean;
+  forecastLookbackFyCount?: number;
+  /** @deprecated Use forecastAboveRecentFyActuals */
   forecastAboveAllActuals?: boolean;
 }


### PR DESCRIPTION
## Summary
- rename the fundamental signal to `forecast_eps_above_recent_fy_actuals` and expose `lookback_fy_count`
- count lookback by unique FY cycles (not disclosure rows) in ranking and signal evaluation paths
- propagate API/type/UI updates for chart and fundamental ranking, including tri-state chart display (`true/false/-`)

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/application/services/ranking_service.py apps/bt/src/domains/strategy/signals/fundamental_growth.py apps/bt/src/domains/strategy/signals/registry.py apps/bt/src/infrastructure/data_access/loaders/statements_loaders.py apps/bt/tests/unit/server/services/test_ranking_service.py apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/strategies/signals/test_registry.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pyright apps/bt/src/application/services/ranking_service.py apps/bt/src/domains/strategy/signals/fundamental_growth.py apps/bt/src/domains/strategy/signals/registry.py apps/bt/src/infrastructure/data_access/loaders/statements_loaders.py apps/bt/tests/unit/server/services/test_ranking_service.py apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/strategies/signals/test_registry.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/server/services/test_fundamentals_service.py apps/bt/tests/unit/server/services/test_ranking_service.py apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/strategies/signals/test_registry.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/server/services/test_fundamentals_service.py apps/bt/tests/server/test_signal_reference.py apps/bt/tests/unit/agent/test_batch_executor.py apps/bt/tests/unit/optimization/test_engine_metrics.py apps/bt/tests/unit/server/routes/test_analytics_complex.py apps/bt/tests/unit/server/services/test_ranking_service.py apps/bt/tests/unit/server/services/test_screening_service_helpers.py apps/bt/tests/unit/server/test_routes_analytics_fundamentals.py apps/bt/tests/unit/strategies/mixins/test_data_manager_mixin_paths.py apps/bt/tests/unit/strategies/signals/test_fundamental.py apps/bt/tests/unit/strategies/signals/test_registry.py`
- `bun run --filter @trading25/web test -- src/components/Chart/FundamentalsPanel.test.tsx src/components/Chart/FundamentalsSummaryCard.test.tsx src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx src/hooks/useFundamentalRanking.test.tsx src/hooks/useFundamentals.test.tsx src/stores/analysisStore.test.ts`
- `bun run --filter @trading25/web typecheck`