### PR TITLE
fix(bt): unify share-adjusted baseline across loaders and services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ uv run pyright src/              # 型チェック
 - `/api/optimize/jobs/{id}` は `best_score` / `total_combinations` に加えて `best_params` / `worst_score` / `worst_params` を返し、最適化ジョブ結果カードで best/worst 条件を比較表示できる
 - `forward_eps_growth` / `peg_ratio` は FY実績EPSを分母に固定し、`period_type=FY` でも必要時のみ追加取得した四半期 FEPS 修正を forecast 側へ反映する
 - Fundamental signal は `forecast_eps_above_all_actuals`（最新予想EPS > 過去すべての実績EPS）をサポートし、forecast revision 読み込み（screening/lab/optimization/backtest）を有効化する
+- statements の share-adjusted per-share 指標（EPS/BPS/配当/forecast）は latest quarterly baseline shares を共通SoTとし、forecast revision 併用時も `base_df`/`revision_df` を同一 baseline で調整する。fundamentals/ranking も同じ基準解決を使い、比較軸の不整合を防ぐ
 - Fundamental signal system は `cfo_margin` / `simple_fcf_margin`（売上高比マージン判定）をサポートし、`OperatingCashFlow` / `InvestingCashFlow` / `Sales` をデータ要件とする
 - Fundamental signal は `cfo_to_net_profit_ratio`（営業CF/純利益）をサポートし、`consecutive_periods` 判定は比率値同値時でも開示更新（OperatingCashFlow/Profit）を起点に連続判定する
 - Fundamentals は EPS に加えて `dividend_fy` / `forecast_dividend_fy` と `payout_ratio` / `forecast_payout_ratio`（実績/予想）を SoT とし、Charts の Fundamentals panel と Backtest Signal system（`forward_dividend_growth` / `dividend_per_share_growth` / `payout_ratio` / `forward_payout_ratio`）で同一指標を使う。配当性向は API 返却時に percent 単位へ正規化し、decimal スケール値（例: 0.283）を 28.3% として扱う

--- a/apps/bt/src/application/services/fundamentals_service.py
+++ b/apps/bt/src/application/services/fundamentals_service.py
@@ -18,6 +18,10 @@ from src.infrastructure.external_api.jquants_client import JQuantsAPIClient, JQu
 from src.infrastructure.external_api.market_client import MarketAPIClient
 from src.shared.models.types import normalize_period_type
 from src.shared.utils.financial import calc_market_cap_scalar
+from src.shared.utils.share_adjustment import (
+    is_valid_share_count,
+    resolve_latest_quarterly_baseline_shares,
+)
 from src.entrypoints.http.schemas.fundamentals import (
     DailyValuationDataPoint,
     FundamentalDataPoint,
@@ -231,29 +235,11 @@ class FundamentalsService:
 
         Falls back to the latest disclosure of any period type if no quarterly data exists.
         """
-        quarterly_types = ("1Q", "2Q", "3Q")
-
-        def _find_latest_shares(
-            require_quarterly: bool,
-        ) -> float | None:
-            latest_disclosed: str | None = None
-            latest_shares: float | None = None
-            for stmt in statements:
-                if require_quarterly:
-                    period_type = normalize_period_type(stmt.CurPerType)
-                    if period_type not in quarterly_types:
-                        continue
-                shares = stmt.ShOutFY
-                if shares is None or shares == 0:
-                    continue
-                if latest_disclosed is None or stmt.DiscDate > latest_disclosed:
-                    latest_disclosed = stmt.DiscDate
-                    latest_shares = shares
-            return latest_shares
-
-        return _find_latest_shares(require_quarterly=True) or _find_latest_shares(
-            require_quarterly=False
-        )
+        snapshots = [
+            (stmt.CurPerType, stmt.DiscDate, stmt.ShOutFY)
+            for stmt in statements
+        ]
+        return resolve_latest_quarterly_baseline_shares(snapshots)
 
     def _compute_adjusted_value(
         self,
@@ -264,14 +250,12 @@ class FundamentalsService:
         """Compute adjusted value using share count ratio."""
         if (
             value is None
-            or current_shares is None
-            or base_shares is None
-            or current_shares == 0
-            or base_shares == 0
+            or not is_valid_share_count(current_shares)
+            or not is_valid_share_count(base_shares)
         ):
             return None
-        if math.isnan(current_shares) or math.isnan(base_shares):
-            return None
+        assert current_shares is not None
+        assert base_shares is not None
         # Adjust to baseline share count (latest quarterly disclosure) so splits reduce historical EPS/BPS.
         adjusted = value * (current_shares / base_shares)
         return self._round_or_none(adjusted)
@@ -1573,7 +1557,17 @@ class FundamentalsService:
         if q_forecast is None:
             return
 
-        rounded_q_forecast = round(q_forecast, 2)
+        baseline_shares = self._resolve_baseline_shares_from_latest_quarter(statements)
+        adjusted_q_forecast = self._compute_adjusted_value(
+            q_forecast,
+            latest_q.ShOutFY,
+            baseline_shares,
+        )
+        rounded_q_forecast = (
+            adjusted_q_forecast
+            if adjusted_q_forecast is not None
+            else round(q_forecast, 2)
+        )
 
         # Annotate when Q forecast differs from FY forecast
         if latest_fy.forecastEps is None or rounded_q_forecast != latest_fy.forecastEps:

--- a/apps/bt/src/shared/utils/share_adjustment.py
+++ b/apps/bt/src/shared/utils/share_adjustment.py
@@ -1,0 +1,53 @@
+"""Share-based normalization helpers for per-share metrics."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from typing import Any, cast
+
+from src.shared.models.types import normalize_period_type
+
+_QUARTERLY_PERIOD_TYPES = frozenset({"1Q", "2Q", "3Q"})
+
+
+def is_valid_share_count(value: float | int | None) -> bool:
+    """Return True when share count can be used for per-share adjustment."""
+    if value is None:
+        return False
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return False
+    if number == 0:
+        return False
+    return math.isfinite(number)
+
+
+def resolve_latest_quarterly_baseline_shares(
+    snapshots: Iterable[tuple[Any, Any, float | int | None]],
+) -> float | None:
+    """Resolve baseline shares from latest quarterly disclosure, then fallback to latest any."""
+    latest_quarter_key: str | None = None
+    latest_quarter_shares: float | None = None
+    latest_any_key: str | None = None
+    latest_any_shares: float | None = None
+
+    for period_type, disclosed_date, shares in snapshots:
+        if not is_valid_share_count(shares):
+            continue
+
+        normalized_period = normalize_period_type(period_type)
+        disclosed_key = str(disclosed_date) if disclosed_date is not None else ""
+        share_value = float(cast(float | int, shares))
+
+        if normalized_period in _QUARTERLY_PERIOD_TYPES:
+            if latest_quarter_key is None or disclosed_key > latest_quarter_key:
+                latest_quarter_key = disclosed_key
+                latest_quarter_shares = share_value
+
+        if latest_any_key is None or disclosed_key > latest_any_key:
+            latest_any_key = disclosed_key
+            latest_any_shares = share_value
+
+    return latest_quarter_shares if latest_quarter_shares is not None else latest_any_shares


### PR DESCRIPTION
## Summary\n- add shared share-adjustment utility for baseline resolution (latest quarter first, fallback latest disclosure)\n- apply one common baseline across statements base/revision transforms in loaders (single/batch/screening)\n- align fundamentals/ranking baseline resolution and adjust revised forecast EPS to the same baseline\n- add/update tests for shared baseline behavior and screening loader branch paths\n- update AGENTS.md to document baseline consistency rule\n\n## Validation\n- uv run --project apps/bt pytest apps/bt/tests/unit/data/test_statements_loaders.py apps/bt/tests/unit/data/test_multi_asset_loaders.py apps/bt/tests/unit/data/test_data_preparation.py apps/bt/tests/unit/server/services/test_screening_market_loader.py apps/bt/tests/unit/server/services/test_ranking_service.py apps/bt/tests/server/services/test_fundamentals_service.py\n- uv run --project apps/bt ruff check (changed files)\n- uv run --project apps/bt pyright (changed source files)\n- coverage run --branch with above tests; changed target files line/branch >= 80%\n