### PR TITLE
fix: dataset resume incremental + timeout propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ SQLite (market.db / portfolio.db
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする
 - Dataset API `GET /api/dataset/{name}/info` の SoT は `snapshot` + `stats` + `validation`（`details.dataCoverage` / `details.fkIntegrity` / `details.stockCountValidation` 含む）とし、web 側は legacy `snapshot` 形式を正規化して後方互換を維持する
-- Dataset create/resume（`POST /api/dataset` / `POST /api/dataset/resume`）は `indices_data`（sector index catalog: `0040-0060` / `0080-0090`）を取り込み、`stock_data` は `build_stock_data_row` で欠損OHLCV行をスキップして warning 集約を返す
+- Dataset create/resume（`POST /api/dataset` / `POST /api/dataset/resume`）は `indices_data`（sector index catalog: `0040-0060` / `0080-0090`）を取り込み、`stock_data` は `build_stock_data_row` で欠損OHLCV行をスキップして warning 集約を返す。`resume` は既存 `stock_data` / `topix_data` / `indices_data` / `statements` / `margin_data` を再利用して不足分のみ取得し、`timeoutMinutes` は backend job timeout として create/resume の双方で適用する（web/cli から伝播）
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Screening API は非同期ジョブ方式（`POST /api/analytics/screening/jobs` / `GET /api/analytics/screening/jobs/{id}` / `POST /api/analytics/screening/jobs/{id}/cancel` / `GET /api/analytics/screening/result/{id}`）を SoT とする。旧 `GET /api/analytics/screening` は 410
 - Screening 実行時のデータ SoT は `market.db`（`stock_data` / `topix_data` / `indices_data` / `stocks`）とし、dataset へのフォールバックを禁止する

--- a/apps/bt/src/entrypoints/http/routes/dataset.py
+++ b/apps/bt/src/entrypoints/http/routes/dataset.py
@@ -234,7 +234,12 @@ async def create_dataset(request: Request, body: DatasetCreateRequest) -> JSONRe
             detail=f'Dataset "{name_stem}" already exists. Use overwrite=true to replace.',
         )
 
-    data = DatasetJobData(name=name_stem, preset=body.preset, overwrite=body.overwrite)
+    data = DatasetJobData(
+        name=name_stem,
+        preset=body.preset,
+        overwrite=body.overwrite,
+        timeout_minutes=body.timeoutMinutes,
+    )
     job = await start_dataset_build(data, resolver, jquants_client)
     if job is None:
         raise HTTPException(status_code=409, detail="Another dataset build job is already running")
@@ -279,7 +284,12 @@ async def resume_dataset(request: Request, body: DatasetCreateRequest) -> JSONRe
     if not os.path.exists(db_path):
         raise HTTPException(status_code=404, detail=f'Dataset "{name_stem}" not found')
 
-    data = DatasetJobData(name=name_stem, preset=body.preset, resume=True)
+    data = DatasetJobData(
+        name=name_stem,
+        preset=body.preset,
+        resume=True,
+        timeout_minutes=body.timeoutMinutes,
+    )
     job = await start_dataset_build(data, resolver, jquants_client)
     if job is None:
         raise HTTPException(status_code=409, detail="Another dataset build job is already running")

--- a/apps/bt/src/infrastructure/db/dataset_io/dataset_writer.py
+++ b/apps/bt/src/infrastructure/db/dataset_io/dataset_writer.py
@@ -124,3 +124,28 @@ class DatasetWriter(BaseDbAccess):
     def get_stock_data_count(self) -> int:
         with self.engine.connect() as conn:
             return conn.execute(select(func.count()).select_from(ds_stock_data)).scalar() or 0
+
+    def get_existing_stock_data_codes(self) -> set[str]:
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(ds_stock_data.c.code).distinct()).fetchall()
+        return {str(row[0]) for row in rows if row and row[0] is not None}
+
+    def has_topix_data(self) -> bool:
+        with self.engine.connect() as conn:
+            count = conn.execute(select(func.count()).select_from(ds_topix_data)).scalar() or 0
+        return count > 0
+
+    def get_existing_index_codes(self) -> set[str]:
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(ds_indices_data.c.code).distinct()).fetchall()
+        return {str(row[0]) for row in rows if row and row[0] is not None}
+
+    def get_existing_margin_codes(self) -> set[str]:
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(margin_data.c.code).distinct()).fetchall()
+        return {str(row[0]) for row in rows if row and row[0] is not None}
+
+    def get_existing_statement_codes(self) -> set[str]:
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(statements.c.code).distinct()).fetchall()
+        return {str(row[0]) for row in rows if row and row[0] is not None}

--- a/apps/bt/tests/unit/server/test_dataset_builder_service.py
+++ b/apps/bt/tests/unit/server/test_dataset_builder_service.py
@@ -175,6 +175,7 @@ def test_dataset_job_data() -> None:
     d = DatasetJobData(name="test", preset="quickTesting")
     assert d.overwrite is False
     assert d.resume is False
+    assert d.timeout_minutes == 35
 
 
 def test_dataset_job_data_resume() -> None:

--- a/apps/bt/tests/unit/server/test_dataset_writer.py
+++ b/apps/bt/tests/unit/server/test_dataset_writer.py
@@ -100,3 +100,60 @@ def test_upsert_indices_data(writer: DatasetWriter) -> None:
          "low": 990, "close": 1005, "created_at": "2024-01-04"},
     ])
     assert count == 1
+
+
+def test_upsert_empty_rows_return_zero(writer: DatasetWriter) -> None:
+    assert writer.upsert_stock_data([]) == 0
+    assert writer.upsert_topix_data([]) == 0
+    assert writer.upsert_indices_data([]) == 0
+    assert writer.upsert_margin_data([]) == 0
+    assert writer.upsert_statements([]) == 0
+
+
+def test_existing_code_helpers_and_topix_presence(writer: DatasetWriter) -> None:
+    assert writer.get_existing_stock_data_codes() == set()
+    assert writer.get_existing_index_codes() == set()
+    assert writer.get_existing_margin_codes() == set()
+    assert writer.get_existing_statement_codes() == set()
+    assert writer.has_topix_data() is False
+
+    writer.upsert_stock_data([
+        {
+            "code": "7203",
+            "date": "2024-01-04",
+            "open": 100,
+            "high": 110,
+            "low": 90,
+            "close": 105,
+            "volume": 1000,
+            "created_at": "2024-01-04",
+        },
+        {
+            "code": "9984",
+            "date": "2024-01-04",
+            "open": 200,
+            "high": 210,
+            "low": 190,
+            "close": 205,
+            "volume": 2000,
+            "created_at": "2024-01-04",
+        },
+    ])
+    writer.upsert_topix_data([
+        {"date": "2024-01-04", "open": 2500, "high": 2520, "low": 2480, "close": 2510, "created_at": "2024-01-04"},
+    ])
+    writer.upsert_indices_data([
+        {"code": "0040", "date": "2024-01-04", "open": 1000, "high": 1010, "low": 990, "close": 1005},
+    ])
+    writer.upsert_margin_data([
+        {"code": "7203", "date": "2024-01-04", "long_margin_volume": 50000, "short_margin_volume": 30000},
+    ])
+    writer.upsert_statements([
+        {"code": "7203", "disclosed_date": "2024-03-15", "earnings_per_share": 250.0},
+    ])
+
+    assert writer.get_existing_stock_data_codes() == {"7203", "9984"}
+    assert writer.has_topix_data() is True
+    assert writer.get_existing_index_codes() == {"0040"}
+    assert writer.get_existing_margin_codes() == {"7203"}
+    assert writer.get_existing_statement_codes() == {"7203"}

--- a/apps/ts/packages/cli/src/commands/dataset/create.test.ts
+++ b/apps/ts/packages/cli/src/commands/dataset/create.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const startDatasetCreateMock = mock();
+const startDatasetResumeMock = mock();
+const getDatasetJobStatusMock = mock();
+const cancelDatasetJobMock = mock();
+
+mock.module('chalk', () => {
+  const identity = (text: string) => text;
+  const bold = Object.assign((text: string) => text, {
+    white: identity,
+    cyan: identity,
+    yellow: identity,
+    green: identity,
+    red: identity,
+    magenta: identity,
+    blue: identity,
+  });
+  return {
+    default: {
+      red: identity,
+      green: identity,
+      yellow: identity,
+      cyan: identity,
+      white: identity,
+      gray: identity,
+      dim: identity,
+      magenta: identity,
+      blue: identity,
+      bold,
+    },
+  };
+});
+
+mock.module('ora', () => {
+  return {
+    default: (text?: string) => {
+      return {
+        text: text ?? '',
+        start() {
+          return this;
+        },
+        succeed() {
+          return this;
+        },
+        fail() {
+          return this;
+        },
+        warn() {
+          return this;
+        },
+        stop() {
+          return this;
+        },
+      };
+    },
+  };
+});
+
+mock.module('../../utils/api-client.js', () => {
+  class MockApiClient {
+    dataset = {
+      startDatasetCreate: startDatasetCreateMock,
+      startDatasetResume: startDatasetResumeMock,
+      getDatasetJobStatus: getDatasetJobStatusMock,
+      cancelDatasetJob: cancelDatasetJobMock,
+    };
+  }
+
+  return {
+    ApiClient: MockApiClient,
+  };
+});
+
+import { createCommand } from './create.js';
+
+type CreateCtx = Parameters<typeof createCommand.run>[0];
+
+function createCtx(values: Record<string, unknown>): CreateCtx {
+  return { values } as CreateCtx;
+}
+
+function completedJob(name: string) {
+  return {
+    jobId: 'dataset-job-1',
+    status: 'completed',
+    preset: 'quickTesting',
+    name,
+    startedAt: new Date().toISOString(),
+    progress: {
+      stage: 'complete',
+      current: 7,
+      total: 7,
+      percentage: 100,
+      message: 'done',
+    },
+    result: {
+      success: true,
+      totalStocks: 3,
+      processedStocks: 3,
+      warnings: [],
+      errors: [],
+      outputPath: `/tmp/${name}`,
+    },
+  };
+}
+
+describe('dataset create command timeout propagation', () => {
+  beforeEach(() => {
+    startDatasetCreateMock.mockReset();
+    startDatasetResumeMock.mockReset();
+    getDatasetJobStatusMock.mockReset();
+    cancelDatasetJobMock.mockReset();
+  });
+
+  it('passes timeout to create API call', async () => {
+    startDatasetCreateMock.mockResolvedValueOnce({
+      jobId: 'dataset-job-1',
+      status: 'pending',
+      preset: 'quickTesting',
+      name: 'test.db',
+      message: 'started',
+    });
+    getDatasetJobStatusMock.mockResolvedValueOnce(completedJob('test.db'));
+
+    await createCommand.run(
+      createCtx({
+        output: 'test.db',
+        preset: 'quickTesting',
+        overwrite: true,
+        resume: false,
+        timeout: 90,
+        debug: false,
+      })
+    );
+
+    expect(startDatasetCreateMock).toHaveBeenCalledWith('test.db', 'quickTesting', true, 90);
+    expect(startDatasetResumeMock).toHaveBeenCalledTimes(0);
+    expect(getDatasetJobStatusMock).toHaveBeenCalledWith('dataset-job-1');
+  });
+
+  it('passes timeout to resume API call', async () => {
+    startDatasetResumeMock.mockResolvedValueOnce({
+      jobId: 'dataset-job-1',
+      status: 'pending',
+      preset: 'quickTesting',
+      name: 'resume.db',
+      message: 'started',
+    });
+    getDatasetJobStatusMock.mockResolvedValueOnce(completedJob('resume.db'));
+
+    await createCommand.run(
+      createCtx({
+        output: 'resume.db',
+        preset: 'quickTesting',
+        overwrite: false,
+        resume: true,
+        timeout: 120,
+        debug: false,
+      })
+    );
+
+    expect(startDatasetResumeMock).toHaveBeenCalledWith('resume.db', 'quickTesting', 120);
+    expect(startDatasetCreateMock).toHaveBeenCalledTimes(0);
+    expect(getDatasetJobStatusMock).toHaveBeenCalledWith('dataset-job-1');
+  });
+});

--- a/apps/ts/packages/cli/src/commands/dataset/create.ts
+++ b/apps/ts/packages/cli/src/commands/dataset/create.ts
@@ -357,8 +357,8 @@ EXAMPLES:
     try {
       spinner.text = isResume ? 'Starting dataset resume job...' : 'Starting dataset creation job...';
       const createResponse = isResume
-        ? await datasetClient.startDatasetResume(output, normalizedPreset)
-        : await datasetClient.startDatasetCreate(output, normalizedPreset, overwrite ?? false);
+        ? await datasetClient.startDatasetResume(output, normalizedPreset, timeoutMinutes)
+        : await datasetClient.startDatasetCreate(output, normalizedPreset, overwrite ?? false, timeoutMinutes);
 
       logDebug(isDebug, `Job ID: ${createResponse.jobId}, Estimated: ${createResponse.estimatedTime || 'unknown'}`);
 

--- a/apps/ts/packages/cli/src/utils/api-clients/dataset-client.ts
+++ b/apps/ts/packages/cli/src/utils/api-clients/dataset-client.ts
@@ -13,20 +13,29 @@ export class DatasetClient extends BaseApiClient {
   /**
    * Start a dataset creation job
    */
-  async startDatasetCreate(name: string, preset: DatasetPreset, overwrite = false): Promise<DatasetCreateJobResponse> {
+  async startDatasetCreate(
+    name: string,
+    preset: DatasetPreset,
+    overwrite = false,
+    timeoutMinutes?: number
+  ): Promise<DatasetCreateJobResponse> {
     return this.request<DatasetCreateJobResponse>('/api/dataset', {
       method: 'POST',
-      body: JSON.stringify({ name, preset, overwrite }),
+      body: JSON.stringify({ name, preset, overwrite, ...(timeoutMinutes !== undefined ? { timeoutMinutes } : {}) }),
     });
   }
 
   /**
    * Start a dataset resume job (fetch missing data for existing dataset)
    */
-  async startDatasetResume(name: string, preset: DatasetPreset): Promise<DatasetCreateJobResponse> {
+  async startDatasetResume(
+    name: string,
+    preset: DatasetPreset,
+    timeoutMinutes?: number
+  ): Promise<DatasetCreateJobResponse> {
     return this.request<DatasetCreateJobResponse>('/api/dataset/resume', {
       method: 'POST',
-      body: JSON.stringify({ name, preset }),
+      body: JSON.stringify({ name, preset, ...(timeoutMinutes !== undefined ? { timeoutMinutes } : {}) }),
     });
   }
 

--- a/apps/ts/packages/cli/src/utils/api-clients/domain-clients.test.ts
+++ b/apps/ts/packages/cli/src/utils/api-clients/domain-clients.test.ts
@@ -196,7 +196,7 @@ describe('Domain API clients', () => {
     const client = new DatasetClient('http://localhost:3002');
     bindRequest(client);
 
-    await client.startDatasetCreate('dataset-v2', 'primeMarket', true);
+    await client.startDatasetCreate('dataset-v2', 'primeMarket', true, 90);
     expect(getLastCall()).toEqual({
       endpoint: '/api/dataset',
       options: {
@@ -205,11 +205,12 @@ describe('Domain API clients', () => {
           name: 'dataset-v2',
           preset: 'primeMarket',
           overwrite: true,
+          timeoutMinutes: 90,
         }),
       },
     });
 
-    await client.startDatasetResume('dataset-v2', 'primeMarket');
+    await client.startDatasetResume('dataset-v2', 'primeMarket', 120);
     expect(getLastCall()).toEqual({
       endpoint: '/api/dataset/resume',
       options: {
@@ -217,6 +218,7 @@ describe('Domain API clients', () => {
         body: JSON.stringify({
           name: 'dataset-v2',
           preset: 'primeMarket',
+          timeoutMinutes: 120,
         }),
       },
     });

--- a/apps/ts/packages/web/src/components/Backtest/DatasetCreateForm.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetCreateForm.test.tsx
@@ -167,7 +167,7 @@ describe('DatasetCreateForm', () => {
         name: 'quickTesting.db',
         preset: 'quickTesting',
         overwrite: false,
-        timeoutMinutes: 30,
+        timeoutMinutes: 35,
       },
       expect.any(Object)
     );
@@ -188,7 +188,7 @@ describe('DatasetCreateForm', () => {
       {
         name: 'quickTesting.db',
         preset: 'quickTesting',
-        timeoutMinutes: 30,
+        timeoutMinutes: 35,
       },
       expect.any(Object)
     );

--- a/apps/ts/packages/web/src/components/Backtest/DatasetCreateForm.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetCreateForm.tsx
@@ -14,7 +14,7 @@ export function DatasetCreateForm() {
   const [selectedPreset, setSelectedPreset] = useState('quickTesting');
   const [filename, setFilename] = useState('quickTesting.db');
   const [overwrite, setOverwrite] = useState(false);
-  const [timeoutMinutes, setTimeoutMinutes] = useState(30);
+  const [timeoutMinutes, setTimeoutMinutes] = useState(35);
 
   const { activeDatasetJobId, setActiveDatasetJobId } = useBacktestStore();
   const createDataset = useCreateDataset();

--- a/apps/ts/packages/web/src/components/Backtest/DatasetList.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetList.test.tsx
@@ -173,7 +173,6 @@ describe('DatasetList', () => {
       {
         name: 'alpha.db',
         preset: 'primeMarket',
-        timeoutMinutes: 30,
       },
       expect.objectContaining({
         onSuccess: expect.any(Function),

--- a/apps/ts/packages/web/src/components/Backtest/DatasetList.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetList.tsx
@@ -66,7 +66,7 @@ export function DatasetList() {
   const handleResume = (item: DatasetListItem) => {
     if (!item.preset) return;
     resumeDataset.mutate(
-      { name: item.name, preset: item.preset, timeoutMinutes: 30 },
+      { name: item.name, preset: item.preset },
       {
         onSuccess: (resp) => {
           setActiveDatasetJobId(resp.jobId);


### PR DESCRIPTION
## Summary
- make dataset job timeout honor request timeoutMinutes instead of fixed 35 minutes
- implement true resume behavior by skipping already-populated stock_data/topix_data/indices_data/statements/margin_data
- propagate timeoutMinutes from ts/web and ts/cli to backend create/resume endpoints
- add regression tests for backend service/routes/writer and cli/web callers
- update AGENTS.md to document resume/timeout SoT behavior

## Validation
- uv run --project apps/bt pytest apps/bt/tests/unit/server/test_dataset_writer.py apps/bt/tests/unit/server/test_dataset_builder_service.py apps/bt/tests/unit/server/test_dataset_builder_service_branches.py apps/bt/tests/unit/server/test_routes_dataset.py apps/bt/tests/unit/server/test_routes_dataset_jobs.py
- apps/bt/.venv/bin/coverage run --branch -m pytest tests/unit/server/test_routes_dataset.py tests/unit/server/test_routes_dataset_jobs.py tests/unit/server/test_dataset_writer.py tests/unit/server/test_dataset_builder_service.py tests/unit/server/test_dataset_builder_service_branches.py
- bun run --filter @trading25/web test src/components/Backtest/DatasetCreateForm.test.tsx src/components/Backtest/DatasetList.test.tsx
- bun run --filter @trading25/cli test src/commands/dataset/create.test.ts src/utils/api-clients/domain-clients.test.ts