### PR TITLE
fix(web): clarify fundamental ranking lookback filter behavior

### DIFF
--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { FundamentalRankingParams } from '@/types/fundamentalRanking';
 import { FundamentalRankingFilters } from './FundamentalRankingFilters';
@@ -29,5 +30,81 @@ describe('FundamentalRankingFilters', () => {
   it('renders lookback control', () => {
     render(<FundamentalRankingFilters params={defaultParams} onChange={vi.fn()} />);
     expect(screen.getByText('Recent FY lookback')).toBeInTheDocument();
+  });
+
+  it('disables lookback control when EPS condition is all stocks', () => {
+    render(<FundamentalRankingFilters params={defaultParams} onChange={vi.fn()} />);
+    expect(screen.getByRole('combobox', { name: 'Recent FY lookback' })).toBeDisabled();
+    expect(
+      screen.getByText('Enabled only when EPS Condition is "Latest Forecast EPS > Recent FY Actual EPS".')
+    ).toBeInTheDocument();
+  });
+
+  it('enables lookback control when forecast filter is enabled', () => {
+    render(
+      <FundamentalRankingFilters params={{ ...defaultParams, forecastAboveRecentFyActuals: true }} onChange={vi.fn()} />
+    );
+    expect(screen.getByRole('combobox', { name: 'Recent FY lookback' })).toBeEnabled();
+    expect(
+      screen.queryByText('Enabled only when EPS Condition is "Latest Forecast EPS > Recent FY Actual EPS".')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onChange when market and EPS condition are updated', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<FundamentalRankingFilters params={defaultParams} onChange={onChange} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Markets' }));
+    await user.click(screen.getByText('Standard'));
+    expect(onChange).toHaveBeenCalledWith({ ...defaultParams, markets: 'standard' });
+
+    await user.click(screen.getByRole('combobox', { name: 'EPS Condition' }));
+    await user.click(screen.getByText('Latest Forecast EPS > Recent FY Actual EPS'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...defaultParams,
+      forecastAboveRecentFyActuals: true,
+    });
+  });
+
+  it('calls onChange when lookback and limit are updated', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const enabledParams = { ...defaultParams, forecastAboveRecentFyActuals: true };
+
+    render(<FundamentalRankingFilters params={enabledParams} onChange={onChange} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Recent FY lookback' }));
+    await user.click(screen.getByText('5 FY'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...enabledParams,
+      forecastLookbackFyCount: 5,
+    });
+
+    await user.click(screen.getByRole('combobox', { name: 'Results per ranking' }));
+    await user.click(screen.getByText('50'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...enabledParams,
+      limit: 50,
+    });
+  });
+
+  it('uses fallback defaults when markets, lookback, and limit are omitted', () => {
+    render(<FundamentalRankingFilters params={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByRole('combobox', { name: 'Markets' })).toHaveTextContent('Prime');
+    expect(screen.getByRole('combobox', { name: 'Recent FY lookback' })).toHaveTextContent('3 FY');
+    expect(screen.getByRole('combobox', { name: 'Results per ranking' })).toHaveTextContent('20');
+  });
+
+  it('enables lookback when legacy forecastAboveAllActuals is true', () => {
+    render(
+      <FundamentalRankingFilters
+        params={{ ...defaultParams, forecastAboveRecentFyActuals: undefined, forecastAboveAllActuals: true }}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: 'Recent FY lookback' })).toBeEnabled();
   });
 });

--- a/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.tsx
+++ b/apps/ts/packages/web/src/components/FundamentalRanking/FundamentalRankingFilters.tsx
@@ -45,6 +45,11 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
   const forecastFilterEnabled = params.forecastAboveRecentFyActuals ?? params.forecastAboveAllActuals ?? false;
   const epsFilterValue = forecastFilterEnabled ? 'forecastAboveRecentFyActuals' : 'all';
   const lookbackFyCount = params.forecastLookbackFyCount ?? 3;
+  const selectedMarkets = params.markets || 'prime';
+  const selectedLimit = params.limit || 20;
+  const lookbackDescription = forecastFilterEnabled
+    ? undefined
+    : 'Enabled only when EPS Condition is "Latest Forecast EPS > Recent FY Actual EPS".';
 
   return (
     <Card className="glass-panel">
@@ -53,7 +58,7 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
       </CardHeader>
       <CardContent className="space-y-4">
         <MarketsSelect
-          value={params.markets || 'prime'}
+          value={selectedMarkets}
           onChange={(v) => updateParam('markets', v)}
           options={FUNDAMENTAL_RANKING_MARKET_OPTIONS}
           id="fundamental-ranking-markets"
@@ -64,7 +69,9 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
           </Label>
           <Select
             value={epsFilterValue}
-            onValueChange={(value) => updateParam('forecastAboveRecentFyActuals', value === 'forecastAboveRecentFyActuals')}
+            onValueChange={(value) =>
+              updateParam('forecastAboveRecentFyActuals', value === 'forecastAboveRecentFyActuals')
+            }
           >
             <SelectTrigger id="fundamental-ranking-eps-condition" className="h-8 text-xs">
               <SelectValue />
@@ -84,9 +91,11 @@ export function FundamentalRankingFilters({ params, onChange }: FundamentalRanki
           options={LOOKBACK_FY_COUNT_OPTIONS}
           id="fundamental-ranking-lookback-fy-count"
           label="Recent FY lookback"
+          disabled={!forecastFilterEnabled}
+          description={lookbackDescription}
         />
         <NumberSelect
-          value={params.limit || 20}
+          value={selectedLimit}
           onChange={(v) => updateParam('limit', v)}
           options={LIMIT_OPTIONS}
           id="fundamental-ranking-limit"

--- a/apps/ts/packages/web/src/components/shared/filters/NumberSelect.test.tsx
+++ b/apps/ts/packages/web/src/components/shared/filters/NumberSelect.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { NumberSelect } from './NumberSelect';
+
+describe('NumberSelect', () => {
+  it('calls onChange with selected numeric value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <NumberSelect
+        value={2}
+        onChange={onChange}
+        options={[
+          { value: 1, label: 'One' },
+          { value: 2, label: 'Two' },
+        ]}
+        id="number-select"
+        label="Number"
+      />
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'Number' }));
+    await user.click(screen.getByText('One'));
+
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('supports disabled and description props', () => {
+    render(
+      <NumberSelect
+        value={2}
+        onChange={vi.fn()}
+        options={[
+          { value: 1, label: 'One' },
+          { value: 2, label: 'Two' },
+        ]}
+        id="number-select-disabled"
+        label="Disabled Number"
+        disabled
+        description="Selection is disabled"
+      />
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Disabled Number' })).toBeDisabled();
+    expect(screen.getByText('Selection is disabled')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/shared/filters/NumberSelect.tsx
+++ b/apps/ts/packages/web/src/components/shared/filters/NumberSelect.tsx
@@ -12,15 +12,25 @@ interface NumberSelectProps {
   options: NumberOption[];
   id: string;
   label: string;
+  disabled?: boolean;
+  description?: string;
 }
 
-export function NumberSelect({ value, onChange, options, id, label }: NumberSelectProps) {
+export function NumberSelect({
+  value,
+  onChange,
+  options,
+  id,
+  label,
+  disabled = false,
+  description,
+}: NumberSelectProps) {
   return (
     <div className="space-y-2">
       <Label htmlFor={id} className="text-xs">
         {label}
       </Label>
-      <Select value={String(value)} onValueChange={(v) => onChange(Number(v))}>
+      <Select value={String(value)} onValueChange={(v) => onChange(Number(v))} disabled={disabled}>
         <SelectTrigger id={id} className="h-8 text-xs">
           <SelectValue />
         </SelectTrigger>
@@ -32,6 +42,7 @@ export function NumberSelect({ value, onChange, options, id, label }: NumberSele
           ))}
         </SelectContent>
       </Select>
+      {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
     </div>
   );
 }

--- a/apps/ts/packages/web/src/hooks/useFundamentalRanking.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useFundamentalRanking.test.tsx
@@ -47,4 +47,107 @@ describe('useFundamentalRanking', () => {
     const { result } = renderHook(() => useFundamentalRanking({}, false), { wrapper });
     expect(result.current.fetchStatus).toBe('idle');
   });
+
+  it('omits lookback parameter when forecast filter is disabled', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ rankings: {} });
+    const { wrapper } = createTestWrapper();
+    const params = {
+      limit: 20,
+      markets: 'prime',
+      forecastAboveRecentFyActuals: false,
+      forecastLookbackFyCount: 10,
+    };
+    const { result } = renderHook(() => useFundamentalRanking(params, true), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/analytics/fundamental-ranking',
+      expect.objectContaining({
+        limit: 20,
+        markets: 'prime',
+        forecastAboveRecentFyActuals: false,
+      })
+    );
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/analytics/fundamental-ranking',
+      expect.not.objectContaining({
+        forecastLookbackFyCount: 10,
+      })
+    );
+  });
+
+  it('uses default lookback count when filter is enabled and lookback is missing', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ rankings: {} });
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(
+      () => useFundamentalRanking({ markets: 'prime', forecastAboveRecentFyActuals: true }, true),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/analytics/fundamental-ranking',
+      expect.objectContaining({
+        markets: 'prime',
+        forecastAboveRecentFyActuals: true,
+        forecastLookbackFyCount: 3,
+      })
+    );
+  });
+
+  it('clamps lookback count to supported range when filter is enabled', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ rankings: {} });
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useFundamentalRanking(
+          {
+            markets: 'prime',
+            forecastAboveRecentFyActuals: true,
+            forecastLookbackFyCount: 100,
+          },
+          true
+        ),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/analytics/fundamental-ranking',
+      expect.objectContaining({
+        markets: 'prime',
+        forecastAboveRecentFyActuals: true,
+        forecastLookbackFyCount: 20,
+      })
+    );
+  });
+
+  it('supports legacy forecastAboveAllActuals flag when new flag is absent', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ rankings: {} });
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useFundamentalRanking(
+          {
+            markets: 'prime',
+            forecastAboveAllActuals: true,
+            forecastLookbackFyCount: 2,
+          },
+          true
+        ),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/analytics/fundamental-ranking',
+      expect.objectContaining({
+        markets: 'prime',
+        forecastAboveRecentFyActuals: true,
+        forecastLookbackFyCount: 2,
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary\n- disable Fundamental Ranking lookback selector unless `EPS Condition` is enabled\n- avoid sending `forecastLookbackFyCount` when the forecast filter is disabled\n- add targeted tests for filter behavior, legacy flag handling, and NumberSelect disabled/description support\n\n## Validation\n- bun run --filter @trading25/web test src/components/shared/filters/NumberSelect.test.tsx src/hooks/useFundamentalRanking.test.tsx src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx\n- bunx vitest run src/hooks/useFundamentalRanking.test.tsx src/components/FundamentalRanking/FundamentalRankingFilters.test.tsx src/components/shared/filters/NumberSelect.test.tsx --coverage --coverage.include='src/hooks/useFundamentalRanking.ts' --coverage.include='src/components/FundamentalRanking/FundamentalRankingFilters.tsx'\n- bunx vitest run src/components/shared/filters/NumberSelect.test.tsx --coverage --coverage.include='src/components/shared/filters/NumberSelect.tsx' --coverage.exclude='src/**/*.test.{ts,tsx}' --coverage.exclude='src/**/*.spec.{ts,tsx}'