### PR TITLE
fix(bt): finalize dataset manifest checksum and fail fast

### DIFF
--- a/.codex/skills/bt-market-sync-strategies/SKILL.md
+++ b/.codex/skills/bt-market-sync-strategies/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: bt-market-sync-strategies
+description: bt の market 同期（initial/incremental/indices-only）と J-Quants fetch 戦略を扱うスキル。`/api/db/sync`、`sync_service`、`sync_strategies`、watermark/failed_dates の実装変更・レビュー時に使用する。
+---
+
+# bt-market-sync-strategies
+
+## Source of Truth
+
+- API route: `apps/bt/src/entrypoints/http/routes/db.py`
+- Job orchestration: `apps/bt/src/application/services/sync_service.py`
+- Sync logic: `apps/bt/src/application/services/sync_strategies.py`
+- Metadata keys / persistence: `apps/bt/src/infrastructure/db/market/market_db.py`
+- OHLCV row normalization: `apps/bt/src/application/services/stock_data_row_builder.py`
+- Tests: `apps/bt/tests/unit/server/services/test_sync_strategies.py`
+
+## Mode Semantics
+
+1. `initial`
+   - `topix` 全量 -> `equities/master` -> Prime fundamentals（code指定） -> `stock_data`（topix取引日ごと日付指定） -> `indices` -> metadata更新。
+2. `incremental`
+   - `last_sync_date` が必須。アンカーは `latest_stock_data_date` 優先（なければ `latest_trading_date`）。
+   - `topix` を `from=anchor` で取得し、`new_dates` のみ `equities/bars/daily?date=...` を取得。
+   - `indices` は code指定増分 + date指定補完で新規コードを回収。
+   - fundamentals は `disclosed_date` 増分 + missing prime code backfill。
+3. `indices-only`
+   - index master catalog seed + 各 index code の時系列同期のみ実施。
+
+## J-Quants Fetch Rules
+
+- OHLCV bulk fetch は `equities/bars/daily` の **date 指定**を基本にする（codeループで置き換えない）。
+- 取引日カレンダーは `indices/bars/daily/topix` を SoT として扱う。
+- `/fins/summary` は pagination を前提にし、date 指定と code 指定を使い分ける。
+- OHLCV 欠損行は `build_stock_data_row` で skip し、warning を集約する。
+
+## Guardrails
+
+- 冪等性を壊さない（同日再取得で重複/欠落を作らない）。
+- `last_sync_date` / `failed_dates` / fundamentals 系 metadata の更新規約を維持する。
+- `auto` mode の解決規則（`last_sync_date` 有無で `initial|incremental`）を変更しない。
+- `indices_data` は master 補完（placeholder backfill）前提を維持する。
+- 変更時は `/api/db/sync` 契約と進捗ステージ名の互換性を確認する。
+
+## Verification
+
+- `uv run --project apps/bt pytest tests/unit/server/services/test_sync_strategies.py`
+- `uv run --project apps/bt pytest tests/unit/server/test_routes_db_sync.py`
+- `uv run --project apps/bt ruff check src/application/services/sync_service.py src/application/services/sync_strategies.py`
+- `uv run --project apps/bt pyright src/application/services/sync_service.py src/application/services/sync_strategies.py`

--- a/docs/greenfield-implementation-checklist.md
+++ b/docs/greenfield-implementation-checklist.md
@@ -15,16 +15,16 @@
 
 ### Checklist
 
-- [ ] 現行 SoT を固定する（`FastAPI only`, `OpenAPI contract`, `contracts/` ガバナンス）。
-- [ ] 移行対象機能を確定する（dataset / screening / backtest / optimize / fundamentals）。
-- [ ] 非機能要件を数値化する（screening p95, backtest runtime, build throughput）。
-- [ ] 成果物命名規約を確定する（artifact path, manifest schema version）。
-- [ ] 監視項目を確定する（logs, metrics, correlationId trace）。
+- [x] 現行 SoT を固定する（`FastAPI only`, `OpenAPI contract`, `contracts/` ガバナンス）。
+- [x] 移行対象機能を確定する（dataset / screening / backtest / optimize / fundamentals）。
+- [x] 非機能要件を数値化する（screening p95, backtest runtime, build throughput）。
+- [x] 成果物命名規約を確定する（artifact path, manifest schema version）。
+- [x] 監視項目を確定する（logs, metrics, correlationId trace）。
 
 ### Exit Criteria
 
-- [ ] プロジェクト憲章 1ページが合意されている。
-- [ ] 90日スコープ外の項目が明文化されている（意図的非採用）。
+- [x] プロジェクト憲章 1ページが合意されている。
+- [x] 90日スコープ外の項目が明文化されている（意図的非採用）。
 
 ---
 
@@ -32,25 +32,25 @@
 
 ### Checklist
 
-- [ ] `apps/bt` で layers を明確化する（`domains/application/infrastructure/entrypoints`）。
-- [ ] middleware/order/error format を固定する（`RequestLogger -> CorrelationId -> CORS`）。
-- [ ] OpenAPI 生成と ts 型同期パイプラインを固定する（`bt:sync` を標準運用化）。
+- [x] `apps/bt` で layers を明確化する（`domains/application/infrastructure/entrypoints`）。
+- [x] middleware/order/error format を固定する（`RequestLogger -> CorrelationId -> CORS`）。
+- [x] OpenAPI 生成と ts 型同期パイプラインを固定する（`bt:sync` を標準運用化）。
 - [x] `jobs` テーブル（queue metadata）を定義する。
-- [ ] `portfolio/watchlist/settings` と `jobs` の OLTP スキーマを整備する。
-- [ ] 最小 worker runtime（`enqueue -> run -> status`）を用意する。
-- [ ] artifact 保存先とメタ情報保存方式を定義する。
+- [x] `portfolio/watchlist/settings` と `jobs` の OLTP スキーマを整備する。
+- [x] 最小 worker runtime（`enqueue -> run -> status`）を用意する。
+- [x] artifact 保存先とメタ情報保存方式を定義する。
 
 ### Validation
 
-- [ ] `uv run ruff check src/`
-- [ ] `uv run pyright src/`
-- [ ] `bun run --filter @trading25/shared bt:sync`
-- [ ] API サーバ起動で `/doc` に契約が反映される。
+- [x] `uv run ruff check src/`
+- [x] `uv run pyright src/`
+- [x] `bun run --filter @trading25/shared bt:sync`
+- [x] API サーバ起動で `/doc` に契約が反映される。
 
 ### Exit Criteria
 
-- [ ] 非同期 job 1本（dummy で可）が create/status/cancel/result まで通る。
-- [ ] `x-correlation-id` が API/内部呼び出し/ログで追跡できる。
+- [x] 非同期 job 1本（dummy で可）が create/status/cancel/result まで通る。
+- [x] `x-correlation-id` が API/内部呼び出し/ログで追跡できる。
 
 ---
 
@@ -61,16 +61,16 @@
 - [ ] market 時系列の保存先を DuckDB + Parquet に切り分ける。
 - [ ] portfolio/jobs は SQLite 維持とし、責務境界をコードで固定する。
 - [ ] ingestion pipeline を `fetch -> normalize -> validate -> publish -> index` に分離する。
-- [ ] statements upsert の非NULL優先 merge を共通処理化する。
-- [ ] 欠損 OHLCV の skip + warning 集約を標準化する。
-- [ ] dataset snapshot manifest v1（counts/checksums/coverage/schemaVersion）を実装する。
-- [ ] `GET /api/dataset/{name}/info` を `snapshot + stats + validation` SoT に固定する。
+- [x] statements upsert の非NULL優先 merge を共通処理化する。
+- [x] 欠損 OHLCV の skip + warning 集約を標準化する。
+- [x] dataset snapshot manifest v1（counts/checksums/coverage/schemaVersion）を実装する。
+- [x] `GET /api/dataset/{name}/info` を `snapshot + stats + validation` SoT に固定する。
 
 ### Validation
 
-- [ ] dataset create/resume で既存データ再利用が機能する。
-- [ ] legacy snapshot 読み取りで必須列不足のみ fail し、他は null 補完で継続する。
-- [ ] 代表銘柄セットで data coverage / fk integrity が取得できる。
+- [x] dataset create/resume で既存データ再利用が機能する。
+- [x] legacy snapshot 読み取りで必須列不足のみ fail し、他は null 補完で継続する。
+- [x] 代表銘柄セットで data coverage / fk integrity が取得できる。
 
 ### Exit Criteria
 

--- a/docs/greenfield-project-charter.md
+++ b/docs/greenfield-project-charter.md
@@ -1,0 +1,72 @@
+# trading25 Greenfield プロジェクト憲章（90日）
+
+作成日: 2026-02-27  
+参照: `docs/greenfield-architecture-blueprint.md`, `docs/greenfield-implementation-checklist.md`
+
+## 1. 目的
+
+greenfield 方針で `apps/bt`（FastAPI + worker）と `apps/ts`（web/cli）を再編し、同一入力で同一結果を再現できる実行基盤を 90 日で完成させる。
+
+## 2. 固定する SoT（Phase 0 合意）
+
+- Backend SoT: **FastAPI のみ**（`:3002`）。
+- API 契約 SoT: **OpenAPI**（変更時は `bt:sync` と契約更新を必須化）。
+- 安定契約 SoT: **`contracts/` ガバナンス**（additive/breaking を version で管理）。
+- ドメイン計算 SoT: **`apps/bt/src/domains/*`**。
+- Error/Tracing SoT: 統一エラー形式 + `x-correlation-id` 伝播。
+
+## 3. 90日スコープ（対象）
+
+- dataset
+- screening
+- backtest
+- optimize
+- fundamentals
+
+上記に加えて、job orchestration（create/status/cancel/result）、artifact-first 再解決、typed client 同期を実装対象に含める。
+
+## 4. 90日スコープ外（意図的非採用）
+
+- マイクロサービス分割
+- 複数 backend 併存運用
+- frontend 側の独自計算ロジック肥大化
+- mutable dataset snapshot（不変性を崩す運用）
+- 本番前提のインフラ拡張（Postgres/Redis/Object Storage への即時移行）
+
+## 5. 非機能要件（数値目標・暫定）
+
+| 項目 | 目標 |
+|---|---|
+| Screening runtime p95 | <= 120 秒（代表 universe + 標準戦略） |
+| Backtest runtime median | <= 180 秒（5年日足、標準戦略） |
+| Dataset build throughput | >= 50,000 rows/分（OHLCV + benchmark） |
+| API status/result p95 | <= 300 ms（job status/result endpoint） |
+
+注記: 上記は Phase 0 の暫定受入基準。Phase 6 で実測 baseline を記録し、必要に応じて閾値を改訂する。
+
+## 6. 成果物命名規約（artifact + manifest）
+
+- 共有ルート: `~/.local/share/trading25/`
+- 命名原則:
+  - job 系: `{domain}/{jobId}/`
+  - dataset 系: `datasets/{datasetName}/...`
+  - manifest: `manifest.v1.json`
+  - metrics: `*.metrics.json`
+- schemaVersion:
+  - manifest は `schemaVersion: 1` を必須とする
+  - 将来 breaking 変更時は `manifest.v2.json` を新設し並存期間を設ける
+
+## 7. 監視項目（logs/metrics/trace）
+
+- Structured logs（必須キー）:
+  - `event`, `correlationId`, `jobId`, `status`, `durationMs`
+- Metrics（最小セット）:
+  - API latency（p50/p95）, error rate
+  - job duration（type/state 別）, queue depth, timeout/cancel/retry 件数
+- Trace:
+  - `x-correlation-id` を API -> internal client -> worker -> artifact metadata まで伝播
+
+## 8. 合意運用
+
+- 本憲章を greenfield 実装の判断基準とする。
+- 変更時は PR で本ドキュメントと `docs/greenfield-implementation-checklist.md` を同時更新する。


### PR DESCRIPTION
## Summary
- generate dataset manifest after closing the writer so checksum/counts match final DB bytes
- make manifest generation fail-fast instead of silently warning
- add/extend dataset builder tests for checksum integrity and manifest failure path
- add greenfield charter doc and market sync skill doc, and update implementation checklist progress

## Validation
- .venv/bin/ruff check src/application/services/dataset_builder_service.py tests/unit/server/test_dataset_builder_service_branches.py
- .venv/bin/pytest tests/unit/server/test_dataset_builder_service_branches.py -q
- uv run --project apps/bt pyright src/application/services/dataset_builder_service.py tests/unit/server/test_dataset_builder_service_branches.py
- python3 scripts/skills/audit_skills.py