### PR TITLE
fix: DuckDB SoT sync defaults and missing-date validation

### DIFF
--- a/apps/bt/src/application/services/db_validation_service.py
+++ b/apps/bt/src/application/services/db_validation_service.py
@@ -8,39 +8,99 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from typing import Any
 from typing import Literal
 
+from src.domains.strategy.signals.registry import SIGNAL_REGISTRY
 from src.infrastructure.db.market.market_db import METADATA_KEYS, MarketDb
+from src.infrastructure.db.market.time_series_store import (
+    MarketTimeSeriesStore,
+    TimeSeriesInspection,
+)
 from src.entrypoints.http.schemas.db import (
     AdjustmentEvent,
     DateRange,
     FundamentalsValidation,
+    IntegrityIssue,
     MarketValidationResponse,
     StockDataValidation,
     StockStats,
     TopixStats,
 )
 
+_SIGNAL_REQUIREMENTS = sorted(
+    {
+        requirement
+        for signal_def in SIGNAL_REGISTRY
+        for requirement in signal_def.data_requirements
+        if requirement
+    }
+)
 
-def validate_market_db(market_db: MarketDb) -> MarketValidationResponse:
+_STATEMENT_REQUIREMENT_COLUMN_ALTERNATIVES: dict[str, tuple[tuple[str, ...], ...]] = {
+    "EPS": (("earnings_per_share",),),
+    "BPS": (("bps",),),
+    "ROE": (("profit", "equity"),),
+    "ROA": (("profit", "total_assets"),),
+    "ForwardForecastEPS": (
+        ("forecast_eps",),
+        ("next_year_forecast_earnings_per_share",),
+    ),
+    "DividendFY": (("dividend_fy",),),
+    "ForwardForecastDividendFY": (
+        ("forecast_dividend_fy",),
+        ("next_year_forecast_dividend_fy",),
+    ),
+    "PayoutRatio": (("payout_ratio",),),
+    "ForwardForecastPayoutRatio": (
+        ("forecast_payout_ratio",),
+        ("next_year_forecast_payout_ratio",),
+    ),
+    "Profit": (("profit",),),
+    "Sales": (("sales",),),
+    "OperatingMargin": (("operating_profit", "sales"),),
+    "OperatingCashFlow": (("operating_cash_flow",),),
+    "InvestingCashFlow": (("investing_cash_flow",),),
+    "SharesOutstanding": (("shares_outstanding",),),
+}
+
+_SIGNAL_STATEMENT_COLUMNS = sorted(
+    {
+        column
+        for requirement, alternatives in _STATEMENT_REQUIREMENT_COLUMN_ALTERNATIVES.items()
+        if f"statements:{requirement}" in _SIGNAL_REQUIREMENTS
+        for option in alternatives
+        for column in option
+    }
+)
+
+
+def validate_market_db(
+    market_db: MarketDb,
+    time_series_store: MarketTimeSeriesStore | None = None,
+) -> MarketValidationResponse:
     """market.db の整合性検証"""
     initialized = market_db.is_initialized()
     last_sync = market_db.get_sync_metadata(METADATA_KEYS["LAST_SYNC_DATE"])
     last_refresh = market_db.get_sync_metadata(METADATA_KEYS["LAST_STOCKS_REFRESH"])
 
     basic = market_db.get_stats()
-    topix_range = market_db.get_topix_date_range()
+    inspection = _resolve_time_series_inspection(market_db, basic, time_series_store)
     by_market = market_db.get_stock_count_by_market()
-    statement_codes = market_db.get_statement_codes()
-    latest_disclosed = market_db.get_latest_statement_disclosed_date()
-    prime_coverage = market_db.get_prime_statement_coverage(limit_missing=20)
-
-    # Missing dates
-    missing_dates = market_db.get_missing_stock_data_dates()
-
-    # stock_data date info
-    sd_date_count = market_db.get_stock_data_unique_date_count()
-    stock_data_range = market_db.get_stock_data_date_range()
+    statement_codes = set(inspection.statement_codes)
+    latest_disclosed = inspection.latest_statement_disclosed_date
+    prime_coverage = _build_prime_statement_coverage(
+        market_db,
+        statement_codes,
+        limit_missing=20,
+    )
+    missing_prime_count = int(prime_coverage.get("missingCount", 0) or 0)
+    missing_prime_codes = [
+        str(code) for code in prime_coverage.get("missingCodes", [])
+    ]
+    missing_dates = list(inspection.missing_stock_dates)
+    missing_dates_count = _resolve_missing_dates_count(inspection)
+    sd_date_count = inspection.stock_date_count
 
     # Adjustment events
     adjustment_events = market_db.get_adjustment_events(limit=20)
@@ -63,20 +123,21 @@ def validate_market_db(market_db: MarketDb) -> MarketValidationResponse:
         market_db,
         METADATA_KEYS["FUNDAMENTALS_FAILED_CODES"],
     )
+    integrity_issues, readiness_recommendations = _build_readiness_issues(inspection)
 
     # Recommendations
     recommendations: list[str] = []
     if not initialized:
         recommendations.append("Run initial sync to populate the database")
-    if missing_dates:
-        recommendations.append(f"Run incremental sync to fill {len(missing_dates)} missing dates")
+    if missing_dates_count > 0:
+        recommendations.append(f"Run incremental sync to fill {missing_dates_count} missing dates")
     if all_needing:
         recommendations.append(f"Run stock refresh for {len(all_needing)} stocks with adjustment events")
     if failed_dates:
         recommendations.append(f"Retry {len(failed_dates)} failed sync dates")
-    if prime_coverage.get("missingCount", 0) > 0:
+    if missing_prime_count > 0:
         recommendations.append(
-            f"Backfill fundamentals for {prime_coverage['missingCount']} Prime stocks"
+            f"Backfill fundamentals for {missing_prime_count} Prime stocks"
         )
     if fundamentals_failed_dates:
         recommendations.append(
@@ -86,24 +147,31 @@ def validate_market_db(market_db: MarketDb) -> MarketValidationResponse:
         recommendations.append(
             f"Retry {len(fundamentals_failed_codes)} failed fundamentals codes"
         )
+    recommendations.extend(readiness_recommendations)
 
     # Status determination
     status: Literal["healthy", "warning", "error"] = "healthy"
     if not initialized:
         status = "error"
     elif (
-        missing_dates
+        missing_dates_count > 0
         or failed_dates
         or all_needing
-        or prime_coverage.get("missingCount", 0) > 0
+        or missing_prime_count > 0
         or fundamentals_failed_dates
         or fundamentals_failed_codes
+        or integrity_issues
     ):
         status = "warning"
 
     topix = TopixStats(
-        count=topix_range["count"] if topix_range else 0,
-        dateRange=DateRange(min=topix_range["min"], max=topix_range["max"]) if topix_range else None,
+        count=inspection.topix_count,
+        dateRange=DateRange(
+            min=inspection.topix_min,
+            max=inspection.topix_max,
+        )
+        if inspection.topix_min and inspection.topix_max
+        else None,
     )
 
     stocks_stats = StockStats(
@@ -113,17 +181,22 @@ def validate_market_db(market_db: MarketDb) -> MarketValidationResponse:
 
     stock_data_val = StockDataValidation(
         count=sd_date_count,
-        dateRange=DateRange(min=stock_data_range["min"], max=stock_data_range["max"]) if stock_data_range else None,
+        dateRange=DateRange(
+            min=inspection.stock_min,
+            max=inspection.stock_max,
+        )
+        if inspection.stock_min and inspection.stock_max
+        else None,
         missingDates=missing_dates[:20],
-        missingDatesCount=len(missing_dates),
+        missingDatesCount=missing_dates_count,
     )
 
     fundamentals_val = FundamentalsValidation(
-        count=basic.get("statements", 0),
+        count=inspection.statements_count,
         uniqueStockCount=len(statement_codes),
         latestDisclosedDate=latest_disclosed,
-        missingPrimeStocksCount=prime_coverage.get("missingCount", 0),
-        missingPrimeStocks=prime_coverage.get("missingCodes", []),
+        missingPrimeStocksCount=missing_prime_count,
+        missingPrimeStocks=missing_prime_codes,
         failedDatesCount=len(fundamentals_failed_dates),
         failedCodesCount=len(fundamentals_failed_codes),
     )
@@ -145,9 +218,176 @@ def validate_market_db(market_db: MarketDb) -> MarketValidationResponse:
         adjustmentEventsCount=len(adjustment_events),
         stocksNeedingRefresh=all_needing[:20],
         stocksNeedingRefreshCount=len(all_needing),
+        integrityIssues=integrity_issues,
+        integrityIssuesCount=len(integrity_issues),
         recommendations=recommendations,
         lastUpdated=datetime.now(UTC).isoformat(),
     )
+
+
+def _resolve_time_series_inspection(
+    market_db: MarketDb,
+    basic_stats: dict[str, int],
+    time_series_store: MarketTimeSeriesStore | None,
+) -> TimeSeriesInspection:
+    if time_series_store is not None:
+        try:
+            return time_series_store.inspect(
+                missing_stock_dates_limit=100,
+                statement_non_null_columns=_SIGNAL_STATEMENT_COLUMNS,
+            )
+        except Exception:
+            # 検証は継続し、SQLite統計へフォールバックする
+            pass
+
+    topix_range = market_db.get_topix_date_range() or {}
+    stock_range = market_db.get_stock_data_date_range() or {}
+    indices_range = market_db.get_indices_data_range() or {}
+    statement_codes = market_db.get_statement_codes()
+
+    return TimeSeriesInspection(
+        source="sqlite-market-db",
+        topix_count=int(topix_range.get("count") or 0),
+        topix_min=topix_range.get("min"),
+        topix_max=topix_range.get("max"),
+        stock_count=int(stock_range.get("count") or 0),
+        stock_min=stock_range.get("min"),
+        stock_max=stock_range.get("max"),
+        stock_date_count=int(stock_range.get("dateCount") or 0),
+        missing_stock_dates=market_db.get_missing_stock_data_dates(limit=100),
+        missing_stock_dates_count=market_db.get_missing_stock_data_dates_count(),
+        indices_count=int(indices_range.get("dataCount") or 0),
+        latest_indices_dates=market_db.get_latest_indices_data_dates(),
+        statements_count=int(basic_stats.get("statements", 0)),
+        latest_statement_disclosed_date=market_db.get_latest_statement_disclosed_date(),
+        statement_codes=statement_codes,
+        statement_non_null_counts=market_db.get_statement_non_null_counts(
+            _SIGNAL_STATEMENT_COLUMNS
+        ),
+    )
+
+
+def _build_prime_statement_coverage(
+    market_db: MarketDb,
+    statement_codes: set[str],
+    *,
+    limit_missing: int = 20,
+) -> dict[str, Any]:
+    prime_codes = market_db.get_prime_codes()
+    covered_codes = sorted(prime_codes & statement_codes)
+    missing_codes = sorted(prime_codes - statement_codes)
+    prime_count = len(prime_codes)
+    covered_count = len(covered_codes)
+
+    coverage_ratio = round((covered_count / prime_count), 4) if prime_count > 0 else 0.0
+    return {
+        "primeCount": prime_count,
+        "coveredCount": covered_count,
+        "missingCount": len(missing_codes),
+        "coverageRatio": coverage_ratio,
+        "missingCodes": missing_codes[: max(limit_missing, 0)],
+    }
+
+
+def _build_readiness_issues(
+    inspection: TimeSeriesInspection,
+) -> tuple[list[IntegrityIssue], list[str]]:
+    issues: list[IntegrityIssue] = []
+    recommendations: list[str] = []
+    missing_stock_dates_count = _resolve_missing_dates_count(inspection)
+
+    if inspection.topix_count <= 0:
+        issues.append(IntegrityIssue(code="chart.topix_data.missing", count=1))
+        recommendations.append("Chart readiness: topix_data is missing in market time-series store")
+    if inspection.stock_count <= 0:
+        issues.append(IntegrityIssue(code="chart.stock_data.missing", count=1))
+        recommendations.append("Chart readiness: stock_data is missing in market time-series store")
+    if inspection.indices_count <= 0:
+        issues.append(IntegrityIssue(code="chart.indices_data.missing", count=1))
+        recommendations.append("Chart readiness: indices_data is missing in market time-series store")
+    if missing_stock_dates_count > 0:
+        issues.append(
+            IntegrityIssue(
+                code="chart.stock_data.missing_dates",
+                count=missing_stock_dates_count,
+            )
+        )
+        recommendations.append(
+            "Chart readiness: stock_data is missing trading dates; run incremental sync to backfill"
+        )
+
+    missing_signal_requirements = _collect_missing_signal_requirements(inspection)
+    if missing_signal_requirements:
+        issues.append(
+            IntegrityIssue(
+                code="backtest.signal_requirements.missing",
+                count=len(missing_signal_requirements),
+            )
+        )
+        sample = ", ".join(missing_signal_requirements[:6])
+        suffix = " ..." if len(missing_signal_requirements) > 6 else ""
+        recommendations.append(
+            f"Backtest signal readiness: unmet requirements ({sample}{suffix})"
+        )
+
+    if "margin" in _SIGNAL_REQUIREMENTS:
+        recommendations.append(
+            "Margin signal readiness depends on margin data source and is excluded from this check"
+        )
+
+    return issues, recommendations
+
+
+def _collect_missing_signal_requirements(inspection: TimeSeriesInspection) -> list[str]:
+    missing: list[str] = []
+
+    for requirement in _SIGNAL_REQUIREMENTS:
+        if requirement == "margin":
+            continue
+
+        if requirement in {"ohlc", "volume"}:
+            if inspection.stock_count <= 0:
+                missing.append(requirement)
+            continue
+
+        if requirement == "benchmark":
+            if inspection.topix_count <= 0:
+                missing.append(requirement)
+            continue
+
+        if requirement == "sector":
+            if inspection.indices_count <= 0:
+                missing.append(requirement)
+            continue
+
+        if requirement.startswith("statements:"):
+            metric = requirement.split(":", 1)[1]
+            if not _is_statement_requirement_satisfied(
+                metric,
+                inspection.statements_count,
+                inspection.statement_non_null_counts,
+            ):
+                missing.append(requirement)
+
+    return sorted(set(missing))
+
+
+def _is_statement_requirement_satisfied(
+    metric: str,
+    statements_count: int,
+    statement_non_null_counts: dict[str, int],
+) -> bool:
+    if statements_count <= 0:
+        return False
+
+    alternatives = _STATEMENT_REQUIREMENT_COLUMN_ALTERNATIVES.get(metric)
+    if not alternatives:
+        return True
+
+    for option in alternatives:
+        if all(statement_non_null_counts.get(column, 0) > 0 for column in option):
+            return True
+    return False
 
 
 def _load_metadata_list(market_db: MarketDb, key: str) -> list[str]:
@@ -161,3 +401,10 @@ def _load_metadata_list(market_db: MarketDb, key: str) -> list[str]:
     if not isinstance(loaded, list):
         return []
     return [str(v) for v in loaded if isinstance(v, str)]
+
+
+def _resolve_missing_dates_count(inspection: TimeSeriesInspection) -> int:
+    return max(
+        inspection.missing_stock_dates_count,
+        len(inspection.missing_stock_dates),
+    )

--- a/apps/bt/src/entrypoints/http/routes/db.py
+++ b/apps/bt/src/entrypoints/http/routes/db.py
@@ -77,7 +77,11 @@ def get_db_stats(request: Request) -> MarketStatsResponse:
 )
 def get_db_validate(request: Request) -> MarketValidationResponse:
     market_db = _get_market_db(request)
-    return db_validation_service.validate_market_db(market_db)
+    time_series_store = getattr(request.app.state, "market_time_series_store", None)
+    return db_validation_service.validate_market_db(
+        market_db,
+        time_series_store=time_series_store,
+    )
 
 
 # --- Sync ---

--- a/apps/bt/tests/unit/server/db/test_market_db.py
+++ b/apps/bt/tests/unit/server/db/test_market_db.py
@@ -345,6 +345,7 @@ class TestMarketDbAnalyticsAndValidation:
         ])
 
         assert market_db.get_missing_stock_data_dates() == ["2024-01-15"]
+        assert market_db.get_missing_stock_data_dates_count() == 1
         events = market_db.get_adjustment_events()
         assert len(events) == 2
         assert {event["eventType"] for event in events} == {"stock_split", "reverse_split"}

--- a/apps/bt/tests/unit/server/db/test_time_series_store.py
+++ b/apps/bt/tests/unit/server/db/test_time_series_store.py
@@ -22,6 +22,13 @@ def _stock_row() -> dict[str, object]:
     }
 
 
+def _topix_rows() -> list[dict[str, object]]:
+    return [
+        {"date": "2026-02-10", "open": 1.0, "high": 2.0, "low": 1.0, "close": 2.0},
+        {"date": "2026-02-11", "open": 2.0, "high": 3.0, "low": 2.0, "close": 3.0},
+    ]
+
+
 def test_create_time_series_store_falls_back_to_sqlite_mirror_when_duckdb_unavailable(tmp_path: Path) -> None:
     market_db = MarketDb(str(tmp_path / "market.db"), read_only=False)
     store = create_time_series_store(
@@ -82,4 +89,184 @@ def test_create_time_series_store_can_disable_sqlite_fallback(
     )
 
     assert store is None
+    market_db.close()
+
+
+def test_sqlite_mirror_store_inspect_reports_core_stats(tmp_path: Path) -> None:
+    market_db = MarketDb(str(tmp_path / "market.db"), read_only=False)
+    market_db.upsert_topix_data(_topix_rows())
+    market_db.upsert_stock_data([_stock_row()])
+    market_db.upsert_statements(
+        [
+            {
+                "code": "7203",
+                "disclosed_date": "2026-02-10",
+                "earnings_per_share": 120.0,
+            },
+            {
+                "code": "7203",
+                "disclosed_date": "2026-02-11",
+                "earnings_per_share": 122.0,
+            },
+        ]
+    )
+
+    store = create_time_series_store(
+        backend="sqlite",
+        duckdb_path=str(tmp_path / "market-timeseries" / "market.duckdb"),
+        parquet_dir=str(tmp_path / "market-timeseries" / "parquet"),
+        sqlite_mirror=True,
+        market_db=market_db,
+    )
+
+    assert store is not None
+    inspection = store.inspect(
+        missing_stock_dates_limit=10,
+        statement_non_null_columns=["earnings_per_share"],
+    )
+
+    assert inspection.source == "sqlite-mirror"
+    assert inspection.topix_count == 2
+    assert inspection.stock_count == 1
+    assert inspection.stock_date_count == 1
+    assert inspection.missing_stock_dates == ["2026-02-11"]
+    assert inspection.missing_stock_dates_count == 1
+    assert inspection.statements_count == 2
+    assert inspection.statement_codes == {"7203"}
+    assert inspection.statement_non_null_counts["earnings_per_share"] == 2
+
+    store.close()
+    market_db.close()
+
+
+def test_duckdb_store_inspect_reports_core_stats(tmp_path: Path) -> None:
+    market_db = MarketDb(str(tmp_path / "market.db"), read_only=False)
+    store = create_time_series_store(
+        backend="duckdb-parquet",
+        duckdb_path=str(tmp_path / "market-timeseries" / "market.duckdb"),
+        parquet_dir=str(tmp_path / "market-timeseries" / "parquet"),
+        sqlite_mirror=False,
+        market_db=market_db,
+        allow_sqlite_fallback=False,
+    )
+
+    assert store is not None
+    store.publish_topix_data(_topix_rows())
+    store.publish_stock_data([_stock_row()])
+    store.publish_indices_data(
+        [
+            {
+                "code": "0000",
+                "date": "2026-02-10",
+                "open": 1.0,
+                "high": 2.0,
+                "low": 1.0,
+                "close": 2.0,
+                "sector_name": "TOPIX",
+            }
+        ]
+    )
+    store.publish_statements(
+        [
+            {
+                "code": "7203",
+                "disclosed_date": "2026-02-10",
+                "earnings_per_share": 120.0,
+                "profit": 1000.0,
+            },
+            {
+                "code": "7203",
+                "disclosed_date": "2026-02-11",
+                "earnings_per_share": 122.0,
+            },
+        ]
+    )
+    store.index_topix_data()
+    store.index_stock_data()
+    store.index_indices_data()
+    store.index_statements()
+
+    inspection = store.inspect(
+        missing_stock_dates_limit=10,
+        statement_non_null_columns=["earnings_per_share", "profit", "unknown_column"],
+    )
+
+    assert inspection.source == "duckdb-parquet"
+    assert inspection.topix_count == 2
+    assert inspection.stock_count == 1
+    assert inspection.stock_date_count == 1
+    assert inspection.indices_count == 1
+    assert inspection.missing_stock_dates == ["2026-02-11"]
+    assert inspection.missing_stock_dates_count == 1
+    assert inspection.statements_count == 2
+    assert inspection.statement_non_null_counts["earnings_per_share"] == 2
+    assert inspection.statement_non_null_counts["profit"] == 1
+    assert inspection.statement_non_null_counts["unknown_column"] == 0
+
+    store.close()
+    market_db.close()
+
+
+def test_composite_store_inspect_merges_statement_codes_from_duckdb_and_sqlite(tmp_path: Path) -> None:
+    market_db = MarketDb(str(tmp_path / "market.db"), read_only=False)
+    market_db.upsert_statements(
+        [
+            {
+                "code": "1301",
+                "disclosed_date": "2026-02-09",
+                "earnings_per_share": 90.0,
+            }
+        ]
+    )
+
+    store = create_time_series_store(
+        backend="duckdb-parquet",
+        duckdb_path=str(tmp_path / "market-timeseries" / "market.duckdb"),
+        parquet_dir=str(tmp_path / "market-timeseries" / "parquet"),
+        sqlite_mirror=True,
+        market_db=market_db,
+        allow_sqlite_fallback=False,
+    )
+
+    assert store is not None
+    store.publish_topix_data([_topix_rows()[0]])
+    store.publish_stock_data([_stock_row()])
+    store.publish_indices_data(
+        [
+            {
+                "code": "0040",
+                "date": "2026-02-10",
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "sector_name": "sector33",
+            }
+        ]
+    )
+    store.publish_statements(
+        [
+            {
+                "code": "7203",
+                "disclosed_date": "2026-02-10",
+                "earnings_per_share": 120.0,
+            }
+        ]
+    )
+    store.index_topix_data()
+    store.index_stock_data()
+    store.index_indices_data()
+    store.index_statements()
+
+    inspection = store.inspect(
+        missing_stock_dates_limit=10,
+        statement_non_null_columns=["earnings_per_share"],
+    )
+
+    assert "duckdb" in inspection.source
+    assert inspection.statement_codes == {"1301", "7203"}
+    assert inspection.statements_count >= 2
+    assert inspection.latest_indices_dates["0040"] == "2026-02-10"
+
+    store.close()
     market_db.close()

--- a/apps/bt/tests/unit/server/services/test_db_validation_service.py
+++ b/apps/bt/tests/unit/server/services/test_db_validation_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.application.services.db_validation_service import validate_market_db
+from src.infrastructure.db.market.time_series_store import TimeSeriesInspection
+
+
+class DummyTimeSeriesStore:
+    def __init__(self, inspection: TimeSeriesInspection) -> None:
+        self._inspection = inspection
+
+    def inspect(
+        self,
+        *,
+        missing_stock_dates_limit: int = 0,
+        statement_non_null_columns: list[str] | None = None,
+    ) -> TimeSeriesInspection:
+        del missing_stock_dates_limit, statement_non_null_columns
+        return self._inspection
+
+
+class DummyMarketDb:
+    def __init__(self) -> None:
+        self._metadata = {
+            "init_completed": "true",
+            "last_sync_date": "2026-02-28T00:00:00+00:00",
+            "last_stocks_refresh": "2026-02-28T00:00:00+00:00",
+        }
+
+    def is_initialized(self) -> bool:
+        return True
+
+    def get_sync_metadata(self, key: str) -> str | None:
+        return self._metadata.get(key)
+
+    def get_stats(self) -> dict[str, int]:
+        return {"stocks": 2, "statements": 4}
+
+    def get_stock_count_by_market(self) -> dict[str, int]:
+        return {"プライム": 2}
+
+    def get_adjustment_events(self, limit: int = 20) -> list[dict[str, Any]]:
+        del limit
+        return []
+
+    def get_stocks_needing_refresh(self, limit: int = 100) -> list[str]:
+        del limit
+        return []
+
+    def get_prime_codes(self) -> set[str]:
+        return {"1301", "7203"}
+
+
+def test_validate_market_db_uses_missing_dates_total_count_from_inspection() -> None:
+    market_db = DummyMarketDb()
+    store = DummyTimeSeriesStore(
+        TimeSeriesInspection(
+            source="duckdb-parquet",
+            topix_count=3000,
+            topix_min="2016-02-29",
+            topix_max="2026-02-27",
+            stock_count=1,
+            stock_min="2016-02-29",
+            stock_max="2016-03-04",
+            stock_date_count=5,
+            missing_stock_dates=["2026-02-27"],
+            missing_stock_dates_count=2438,
+            indices_count=100,
+            latest_indices_dates={"0000": "2026-02-27"},
+            statements_count=10,
+            latest_statement_disclosed_date="2026-02-27",
+            statement_codes={"1301", "7203"},
+        )
+    )
+
+    result = validate_market_db(  # type: ignore[arg-type]
+        market_db=market_db,
+        time_series_store=store,  # type: ignore[arg-type]
+    )
+
+    assert result.stockData.missingDatesCount == 2438
+    issue = next(
+        (item for item in result.integrityIssues if item.code == "chart.stock_data.missing_dates"),
+        None,
+    )
+    assert issue is not None
+    assert issue.count == 2438
+    assert any("fill 2438 missing dates" in rec for rec in result.recommendations)

--- a/apps/ts/packages/web/src/components/Settings/SyncDataPlaneOptions.tsx
+++ b/apps/ts/packages/web/src/components/Settings/SyncDataPlaneOptions.tsx
@@ -12,9 +12,9 @@ interface SyncDataPlaneOptionsProps {
 }
 
 const DATA_BACKEND_OPTIONS: { value: SyncDataBackend; label: string; description: string }[] = [
-  { value: 'default', label: 'Server Default', description: 'Use backend from backend env settings' },
-  { value: 'duckdb-parquet', label: 'DuckDB + Parquet', description: 'Phase 2 data plane backend' },
-  { value: 'sqlite', label: 'SQLite (Legacy)', description: 'Write to sqlite market.db only' },
+  { value: 'default', label: 'Server Default', description: 'Use backend configured on FastAPI (DuckDB SoT by default)' },
+  { value: 'duckdb-parquet', label: 'DuckDB + Parquet', description: 'Primary SoT for market time-series' },
+  { value: 'sqlite', label: 'SQLite Compatibility', description: 'Legacy fallback only (not recommended for SoT)' },
 ];
 
 export function SyncDataPlaneOptions({
@@ -54,8 +54,8 @@ export function SyncDataPlaneOptions({
             <Label htmlFor="sync-sqlite-mirror">SQLite Mirror</Label>
             <p className="text-xs text-muted-foreground">
               {backend === 'default'
-                ? 'Server default is used unless backend is explicitly overridden.'
-                : 'Also write synced rows to sqlite market.db for compatibility.'}
+                ? 'Mirror behavior follows FastAPI server defaults when backend is not overridden.'
+                : 'Also mirror writes to sqlite market.db for compatibility only.'}
             </p>
           </div>
           <Switch

--- a/apps/ts/packages/web/src/components/Settings/SyncModeSelect.tsx
+++ b/apps/ts/packages/web/src/components/Settings/SyncModeSelect.tsx
@@ -9,10 +9,10 @@ interface SyncModeSelectProps {
 }
 
 const SYNC_MODE_OPTIONS: { value: SyncMode; label: string; description: string }[] = [
-  { value: 'auto', label: 'Auto', description: 'Detect based on database state' },
-  { value: 'initial', label: 'Initial', description: 'Full sync (2 years, ~552 API calls)' },
-  { value: 'incremental', label: 'Incremental', description: 'Update only new data' },
-  { value: 'indices-only', label: 'Indices Only', description: 'Sync indices only (~52 API calls)' },
+  { value: 'auto', label: 'Auto', description: 'Detect initial/incremental from DuckDB SoT state' },
+  { value: 'initial', label: 'Initial', description: 'Rebuild DuckDB SoT from scratch' },
+  { value: 'incremental', label: 'Incremental', description: 'Backfill missing dates and append latest market data' },
+  { value: 'indices-only', label: 'Indices Only', description: 'Resync index series only (indices_data)' },
 ];
 
 export function SyncModeSelect({ value, onChange, disabled }: SyncModeSelectProps) {

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -10,8 +10,8 @@ import type { StartSyncRequest, SyncDataBackend, SyncMode } from '@/types/sync';
 
 export function SettingsPage() {
   const [syncMode, setSyncMode] = useState<SyncMode>('auto');
-  const [dataBackend, setDataBackend] = useState<SyncDataBackend>('default');
-  const [sqliteMirror, setSqliteMirror] = useState(true);
+  const [dataBackend, setDataBackend] = useState<SyncDataBackend>('duckdb-parquet');
+  const [sqliteMirror, setSqliteMirror] = useState(false);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
 
   const startSync = useStartSync();
@@ -50,7 +50,9 @@ export function SettingsPage() {
             <Database className="h-5 w-5" />
             <CardTitle>Database Sync</CardTitle>
           </div>
-          <CardDescription>Synchronize market data from JQuants API</CardDescription>
+          <CardDescription>
+            Synchronize J-Quants market data into DuckDB SoT. Use incremental to resume interrupted syncs.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <SyncModeSelect value={syncMode} onChange={setSyncMode} disabled={isRunning || startSync.isPending} />


### PR DESCRIPTION
## Summary
- switch Settings Database Sync defaults/copy to DuckDB SoT mode (duckdb-parquet + sqlite mirror off)
- update sync mode/data plane descriptions to DuckDB SoT wording and remove legacy 2-year phrasing
- fix market DB validation to use total missing stock-date count (not sampled rows) across sqlite/duckdb inspections
- add regression tests for validation count propagation and duckdb/sqlite inspection merge behavior

## Verification
- uv run --project apps/bt pytest apps/bt/tests/unit/server/db/test_market_db.py apps/bt/tests/unit/server/db/test_time_series_store.py apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/services/test_db_validation_service.py
- bun run --filter @trading25/web test src/pages/SettingsPage.test.tsx src/hooks/useDbSync.test.tsx
- bun run --filter @trading25/web typecheck