### PR TITLE
feat(bt): minimize sync requests with bulk-rest hybrid planner

### DIFF
--- a/.codex/skills/bt-market-sync-strategies/SKILL.md
+++ b/.codex/skills/bt-market-sync-strategies/SKILL.md
@@ -32,6 +32,9 @@ description: bt の market 同期（initial/incremental/indices-only）と J-Qua
 - 取引日カレンダーは `indices/bars/daily/topix` を SoT として扱う。
 - `/fins/summary` は pagination を前提にし、date 指定と code 指定を使い分ける。
 - OHLCV 欠損行は `build_stock_data_row` で skip し、warning を集約する。
+- stage ごとに `Bulk+REST hybrid` を動的選択し、予測外部request数の小さい手法を採用する（bulk 失敗時は stage 単位で REST fallback）。
+- `totalApiCalls` は pagination 内部ページ数に加えて `/bulk/list`・`/bulk/get`・signed URL download を実カウントする。
+- `incremental` で DuckDB inspection が空（topix/stock/indices）かつアンカー不在のときは cold-start bootstrap を選ぶ。
 
 ## Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `POST /api/db/sync` の `dataPlane` override は `backend=duckdb-parquet` のみ受け付ける
 - `GET /api/db/stats` / `GET /api/db/validate` の時系列スナップショット SoT は DuckDB inspection（`timeSeriesSource` を返却）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
+- `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする
@@ -78,6 +79,7 @@ bun run --filter @trading25/shared bt:sync   # bt の OpenAPI → TS型生成
   - `/markets/margin-interest`: 5分
   - `/fins/summary`（`/statements` / `/statements/raw` で共有）: 15分
 - 実外部呼び出しは `event="jquants_fetch"`、キャッシュ状態は `event="jquants_proxy_cache"` で構造化ログ出力
+- market sync の fetch planner は `event="sync_fetch_strategy"` を出力し、各 stage の選択結果（bulk/rest, 推定request数, 実request数, cache hit/miss）を観測可能にする
 
 ## ミドルウェア構成（FastAPI）
 

--- a/apps/bt/src/application/services/jquants_bulk_service.py
+++ b/apps/bt/src/application/services/jquants_bulk_service.py
@@ -1,0 +1,355 @@
+"""J-Quants bulk download service.
+
+This service wraps `/bulk/list` + `/bulk/get` + signed-url download and provides
+CSV(gzip) parsing with local cache.
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+import httpx
+from loguru import logger
+
+from src.infrastructure.external_api.clients.jquants_client import JQuantsAsyncClient
+from src.shared.observability.metrics import metrics_recorder
+from src.shared.paths import get_cache_dir
+
+
+@dataclass(frozen=True)
+class BulkFileInfo:
+    key: str
+    last_modified: str
+    size: int
+    range_start: date | None
+    range_end: date | None
+
+
+@dataclass(frozen=True)
+class BulkFetchPlan:
+    endpoint: str
+    files: list[BulkFileInfo]
+    list_api_calls: int
+    estimated_api_calls: int
+    estimated_cache_hits: int
+    estimated_cache_misses: int
+
+
+@dataclass
+class BulkFetchResult:
+    rows: list[dict[str, Any]]
+    api_calls: int
+    cache_hits: int
+    cache_misses: int
+    selected_files: int
+
+
+class JQuantsBulkService:
+    """Bulk API helper used by sync strategies."""
+
+    def __init__(
+        self,
+        client: JQuantsAsyncClient,
+        *,
+        cache_dir: Path | None = None,
+        downloader: Callable[[str], Awaitable[bytes]] | None = None,
+    ) -> None:
+        self._client = client
+        self._cache_dir = cache_dir or (get_cache_dir() / "jquants-bulk")
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._downloader = downloader or self._download_bytes
+
+    async def build_plan(
+        self,
+        *,
+        endpoint: str,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        exact_dates: list[str] | None = None,
+    ) -> BulkFetchPlan:
+        body = await self._client.get("/bulk/list", params={"endpoint": endpoint})
+        list_api_calls = 1
+
+        files = self._extract_files(body)
+        selected_files = self._select_files(
+            files,
+            date_from=date_from,
+            date_to=date_to,
+            exact_dates=exact_dates,
+        )
+
+        estimated_cache_hits = 0
+        estimated_cache_misses = 0
+        for file_info in selected_files:
+            if self._is_cache_fresh(file_info):
+                estimated_cache_hits += 1
+            else:
+                estimated_cache_misses += 1
+
+        estimated_api_calls = list_api_calls + (estimated_cache_misses * 2)
+
+        return BulkFetchPlan(
+            endpoint=endpoint,
+            files=selected_files,
+            list_api_calls=list_api_calls,
+            estimated_api_calls=estimated_api_calls,
+            estimated_cache_hits=estimated_cache_hits,
+            estimated_cache_misses=estimated_cache_misses,
+        )
+
+    async def fetch_with_plan(self, plan: BulkFetchPlan) -> BulkFetchResult:
+        rows: list[dict[str, Any]] = []
+        api_calls = 0
+        cache_hits = 0
+        cache_misses = 0
+
+        for file_info in plan.files:
+            cache_path = self._data_cache_path(file_info.key)
+            if self._is_cache_fresh(file_info):
+                cache_hits += 1
+            else:
+                cache_misses += 1
+                body = await self._client.get("/bulk/get", params={"key": file_info.key})
+                api_calls += 1
+                signed_url = body.get("url")
+                if not isinstance(signed_url, str) or not signed_url:
+                    raise RuntimeError(f"bulk/get did not return a valid url for key={file_info.key}")
+
+                try:
+                    payload = await self._downloader(signed_url)
+                except Exception as exc:  # noqa: BLE001 - preserve original cause
+                    raise RuntimeError(f"bulk signed-url download failed for key={file_info.key}") from exc
+                api_calls += 1
+                cache_path.write_bytes(payload)
+                self._write_cache_meta(file_info)
+
+            rows.extend(self._read_csv_gzip_rows(cache_path))
+
+        return BulkFetchResult(
+            rows=rows,
+            api_calls=api_calls,
+            cache_hits=cache_hits,
+            cache_misses=cache_misses,
+            selected_files=len(plan.files),
+        )
+
+    async def plan_and_fetch(
+        self,
+        *,
+        endpoint: str,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        exact_dates: list[str] | None = None,
+    ) -> tuple[BulkFetchPlan, BulkFetchResult]:
+        plan = await self.build_plan(
+            endpoint=endpoint,
+            date_from=date_from,
+            date_to=date_to,
+            exact_dates=exact_dates,
+        )
+        result = await self.fetch_with_plan(plan)
+        result.api_calls += plan.list_api_calls
+        return plan, result
+
+    async def _download_bytes(self, url: str) -> bytes:
+        metrics_recorder.record_jquants_fetch("/bulk/download")
+        logger.info(
+            "JQuants bulk download",
+            event="jquants_fetch",
+            endpoint="/bulk/download",
+        )
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.content
+
+    def _extract_files(self, body: dict[str, Any]) -> list[BulkFileInfo]:
+        payload: list[Any] = []
+        data_payload = body.get("data")
+        if isinstance(data_payload, list):
+            payload = data_payload
+        else:
+            files_payload = body.get("files")
+            if isinstance(files_payload, list):
+                payload = files_payload
+        files: list[BulkFileInfo] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            key = str(item.get("Key") or item.get("key") or "").strip()
+            if not key:
+                continue
+            last_modified = str(item.get("LastModified") or item.get("last_modified") or "")
+            raw_size = item.get("Size") or item.get("size") or 0
+            try:
+                size = int(raw_size)
+            except (TypeError, ValueError):
+                size = 0
+
+            range_start, range_end = self._infer_file_range(key)
+            files.append(
+                BulkFileInfo(
+                    key=key,
+                    last_modified=last_modified,
+                    size=size,
+                    range_start=range_start,
+                    range_end=range_end,
+                )
+            )
+
+        return files
+
+    def _select_files(
+        self,
+        files: list[BulkFileInfo],
+        *,
+        date_from: str | None,
+        date_to: str | None,
+        exact_dates: list[str] | None,
+    ) -> list[BulkFileInfo]:
+        from_date = _parse_date(date_from)
+        to_date = _parse_date(date_to)
+        target_dates = {
+            parsed
+            for parsed in (_parse_date(value) for value in (exact_dates or []))
+            if parsed is not None
+        }
+
+        selected: list[BulkFileInfo] = []
+        for file_info in files:
+            if target_dates:
+                if file_info.range_start is None or file_info.range_end is None:
+                    selected.append(file_info)
+                    continue
+                if any(file_info.range_start <= value <= file_info.range_end for value in target_dates):
+                    selected.append(file_info)
+                continue
+
+            if from_date is None and to_date is None:
+                selected.append(file_info)
+                continue
+
+            if file_info.range_start is None or file_info.range_end is None:
+                selected.append(file_info)
+                continue
+
+            if from_date is not None and file_info.range_end < from_date:
+                continue
+            if to_date is not None and file_info.range_start > to_date:
+                continue
+            selected.append(file_info)
+
+        return selected
+
+    def _is_cache_fresh(self, file_info: BulkFileInfo) -> bool:
+        data_path = self._data_cache_path(file_info.key)
+        if not data_path.exists():
+            return False
+
+        metadata = self._read_cache_meta(file_info.key)
+        if metadata is None:
+            return False
+
+        return (
+            metadata.get("key") == file_info.key
+            and metadata.get("last_modified") == file_info.last_modified
+            and int(metadata.get("size") or 0) == file_info.size
+        )
+
+    def _read_cache_meta(self, key: str) -> dict[str, Any] | None:
+        meta_path = self._meta_cache_path(key)
+        if not meta_path.exists():
+            return None
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        return payload
+
+    def _write_cache_meta(self, file_info: BulkFileInfo) -> None:
+        payload = {
+            "key": file_info.key,
+            "last_modified": file_info.last_modified,
+            "size": file_info.size,
+            "cached_at": datetime.now(UTC).isoformat(),
+        }
+        self._meta_cache_path(file_info.key).write_text(
+            json.dumps(payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    def _read_csv_gzip_rows(self, path: Path) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        with gzip.open(path, mode="rt", encoding="utf-8-sig", newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                if not isinstance(row, dict):
+                    continue
+                cleaned: dict[str, Any] = {}
+                for raw_key, raw_value in row.items():
+                    if raw_key is None:
+                        continue
+                    key = str(raw_key).strip()
+                    if not key:
+                        continue
+                    if isinstance(raw_value, str):
+                        cleaned[key] = raw_value.strip()
+                    else:
+                        cleaned[key] = raw_value
+                if cleaned:
+                    rows.append(cleaned)
+        return rows
+
+    def _data_cache_path(self, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self._cache_dir / f"{digest}.csv.gz"
+
+    def _meta_cache_path(self, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self._cache_dir / f"{digest}.meta.json"
+
+    def _infer_file_range(self, key: str) -> tuple[date | None, date | None]:
+        file_name = Path(key).name
+
+        daily_match = re.search(r"(\d{8})(?=\.csv(?:\.gz)?$)", file_name)
+        if daily_match:
+            day = _parse_date(daily_match.group(1))
+            return day, day
+
+        monthly_match = re.search(r"(\d{6})(?=\.csv(?:\.gz)?$)", file_name)
+        if monthly_match:
+            ym = monthly_match.group(1)
+            year = int(ym[:4])
+            month = int(ym[4:6])
+            start = date(year, month, 1)
+            if month == 12:
+                end = date(year + 1, 1, 1) - timedelta(days=1)
+            else:
+                end = date(year, month + 1, 1) - timedelta(days=1)
+            return start, end
+
+        return None, None
+
+
+def _parse_date(value: str | None) -> date | None:
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(text, fmt).date()  # noqa: DTZ007
+        except ValueError:
+            continue
+    return None

--- a/apps/bt/src/application/services/sync_strategies.py
+++ b/apps/bt/src/application/services/sync_strategies.py
@@ -9,13 +9,19 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from typing import Any, Callable, Protocol
+from typing import Any, Awaitable, Callable, Literal, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from loguru import logger
 
+from src.application.services.jquants_bulk_service import (
+    BulkFetchPlan,
+    BulkFetchResult,
+    JQuantsBulkService,
+)
 from src.infrastructure.external_api.clients.jquants_client import JQuantsAsyncClient
 from src.infrastructure.db.market.market_db import METADATA_KEYS, MarketDb
 from src.infrastructure.db.market.time_series_store import (
@@ -47,6 +53,7 @@ class SyncContext:
     cancelled: asyncio.Event
     on_progress: Callable[[str, int, int, str], None]
     time_series_store: MarketTimeSeriesStore | None = None
+    bulk_service: JQuantsBulkService | None = None
 
 
 class SyncStrategy(Protocol):
@@ -57,6 +64,305 @@ class SyncStrategy(Protocol):
 _JST = ZoneInfo("Asia/Tokyo")
 _PRIME_MARKET_CODES = {"0111", "prime"}
 _MAX_FINS_SUMMARY_PAGES = 2000
+
+_FetchMethod = Literal["rest", "bulk"]
+
+
+@dataclass(frozen=True)
+class _StageFetchDecision:
+    method: _FetchMethod
+    planner_api_calls: int
+    estimated_rest_calls: int
+    estimated_bulk_calls: int | None
+    plan: BulkFetchPlan | None = None
+
+
+_BULK_STOCK_KEY_ALIASES: dict[str, str] = {
+    "code": "Code",
+    "date": "Date",
+    "o": "O",
+    "open": "O",
+    "h": "H",
+    "high": "H",
+    "l": "L",
+    "low": "L",
+    "c": "C",
+    "close": "C",
+    "vo": "Vo",
+    "volume": "Vo",
+    "adjo": "AdjO",
+    "adjopen": "AdjO",
+    "adjh": "AdjH",
+    "adjhigh": "AdjH",
+    "adjl": "AdjL",
+    "adjlow": "AdjL",
+    "adjc": "AdjC",
+    "adjclose": "AdjC",
+    "adjvo": "AdjVo",
+    "adjvolume": "AdjVo",
+    "adjfactor": "AdjFactor",
+}
+
+_BULK_INDEX_KEY_ALIASES: dict[str, str] = {
+    **_BULK_STOCK_KEY_ALIASES,
+    "sectorname": "SectorName",
+    "sector_name": "SectorName",
+    "indexcode": "Code",
+    "index_code": "Code",
+}
+
+_BULK_FINS_KEY_ALIASES: dict[str, str] = {
+    "code": "Code",
+    "discdate": "DiscDate",
+    "eps": "EPS",
+    "np": "NP",
+    "eq": "Eq",
+    "curpertype": "CurPerType",
+    "doctype": "DocType",
+    "nxfeps": "NxFEPS",
+    "bps": "BPS",
+    "sales": "Sales",
+    "op": "OP",
+    "odp": "OdP",
+    "cfo": "CFO",
+    "divann": "DivAnn",
+    "divfy": "DivFY",
+    "fdivann": "FDivAnn",
+    "fdivfy": "FDivFY",
+    "nxfdivann": "NxFDivAnn",
+    "nxfdivfy": "NxFDivFY",
+    "payoutratioann": "PayoutRatioAnn",
+    "fpayoutratioann": "FPayoutRatioAnn",
+    "nxfpayoutratioann": "NxFPayoutRatioAnn",
+    "feps": "FEPS",
+    "cfi": "CFI",
+    "cff": "CFF",
+    "casheq": "CashEq",
+    "ta": "TA",
+    "shoutfy": "ShOutFY",
+    "trshfy": "TrShFY",
+}
+
+
+def _supports_bulk_sync(client: JQuantsAsyncClient) -> bool:
+    plan = str(getattr(client, "plan", "")).strip().lower()
+    return plan in {"light", "standard", "premium"}
+
+
+def _get_bulk_service(ctx: SyncContext) -> JQuantsBulkService:
+    if ctx.bulk_service is None:
+        ctx.bulk_service = JQuantsBulkService(ctx.client)
+    return ctx.bulk_service
+
+
+async def _get_paginated_rows_with_call_count(
+    client: JQuantsAsyncClient,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    get_with_meta = getattr(client, "get_paginated_with_meta", None)
+    if callable(get_with_meta):
+        get_with_meta_callable = cast(
+            Callable[..., Awaitable[tuple[list[dict[str, Any]], int]]],
+            get_with_meta,
+        )
+        rows, calls = await get_with_meta_callable(path, params=params)
+        return rows, int(calls)
+    rows = await client.get_paginated(path, params=params)
+    return rows, 1
+
+
+def _to_iso_date_text(value: str | None) -> str | None:
+    parsed = _parse_date(value or "")
+    if parsed is None:
+        return None
+    return parsed.isoformat()
+
+
+def _select_bulk_candidates_from_dates(dates: list[str]) -> tuple[str | None, str | None]:
+    parsed = [_parse_date(value) for value in dates]
+    normalized = [d for d in parsed if d is not None]
+    if not normalized:
+        return None, None
+    return min(normalized).isoformat(), max(normalized).isoformat()
+
+
+async def _plan_fetch_method(
+    ctx: SyncContext,
+    *,
+    stage: str,
+    endpoint: str,
+    estimated_rest_calls: int,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    exact_dates: list[str] | None = None,
+    min_rest_calls_to_probe_bulk: int = 3,
+) -> _StageFetchDecision:
+    if not _supports_bulk_sync(ctx.client):
+        logger.info(
+            "sync fetch strategy selected",
+            event="sync_fetch_strategy",
+            stage=stage,
+            endpoint=endpoint,
+            selected="rest",
+            reason="plan_not_supported",
+            estimatedRestCalls=estimated_rest_calls,
+            estimatedBulkCalls=None,
+            plannerApiCalls=0,
+        )
+        return _StageFetchDecision(
+            method="rest",
+            planner_api_calls=0,
+            estimated_rest_calls=estimated_rest_calls,
+            estimated_bulk_calls=None,
+            plan=None,
+        )
+
+    if estimated_rest_calls < min_rest_calls_to_probe_bulk:
+        logger.info(
+            "sync fetch strategy selected",
+            event="sync_fetch_strategy",
+            stage=stage,
+            endpoint=endpoint,
+            selected="rest",
+            reason="rest_estimate_too_small",
+            estimatedRestCalls=estimated_rest_calls,
+            estimatedBulkCalls=None,
+            plannerApiCalls=0,
+        )
+        return _StageFetchDecision(
+            method="rest",
+            planner_api_calls=0,
+            estimated_rest_calls=estimated_rest_calls,
+            estimated_bulk_calls=None,
+            plan=None,
+        )
+
+    bulk_service = _get_bulk_service(ctx)
+    plan = await bulk_service.build_plan(
+        endpoint=endpoint,
+        date_from=date_from,
+        date_to=date_to,
+        exact_dates=exact_dates,
+    )
+    selected: _FetchMethod = "bulk" if plan.estimated_api_calls < estimated_rest_calls else "rest"
+    reason = "bulk_estimate_lower" if selected == "bulk" else "rest_estimate_lower_or_equal"
+
+    logger.info(
+        "sync fetch strategy selected",
+        event="sync_fetch_strategy",
+        stage=stage,
+        endpoint=endpoint,
+        selected=selected,
+        reason=reason,
+        estimatedRestCalls=estimated_rest_calls,
+        estimatedBulkCalls=plan.estimated_api_calls,
+        plannerApiCalls=plan.list_api_calls,
+        estimatedCacheHits=plan.estimated_cache_hits,
+        estimatedCacheMisses=plan.estimated_cache_misses,
+        selectedFiles=len(plan.files),
+    )
+    return _StageFetchDecision(
+        method=selected,
+        planner_api_calls=plan.list_api_calls,
+        estimated_rest_calls=estimated_rest_calls,
+        estimated_bulk_calls=plan.estimated_api_calls,
+        plan=plan,
+    )
+
+
+def _canonicalize_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.strip().lower())
+
+
+def _normalize_bulk_row_keys(
+    rows: list[dict[str, Any]],
+    aliases: dict[str, str],
+) -> list[dict[str, Any]]:
+    normalized_rows: list[dict[str, Any]] = []
+    for row in rows:
+        normalized = dict(row)
+        for raw_key, raw_value in row.items():
+            canonical = _canonicalize_key(str(raw_key))
+            target = aliases.get(canonical)
+            if not target:
+                continue
+            existing = normalized.get(target)
+            if existing is None or (isinstance(existing, str) and not existing.strip()):
+                normalized[target] = raw_value
+        normalized_rows.append(normalized)
+    return normalized_rows
+
+
+def _normalize_bulk_stock_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return _normalize_bulk_row_keys(rows, _BULK_STOCK_KEY_ALIASES)
+
+
+def _normalize_bulk_indices_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return _normalize_bulk_row_keys(rows, _BULK_INDEX_KEY_ALIASES)
+
+
+def _normalize_bulk_fins_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return _normalize_bulk_row_keys(rows, _BULK_FINS_KEY_ALIASES)
+
+
+def _is_incremental_cold_start(
+    ctx: SyncContext,
+    inspection: TimeSeriesInspection | None,
+) -> bool:
+    if inspection is None or ctx.time_series_store is None:
+        return False
+    has_anchor_signal = bool(
+        inspection.topix_max
+        or inspection.stock_max
+        or inspection.indices_max
+        or inspection.latest_indices_dates
+    )
+    if has_anchor_signal:
+        return False
+    return (
+        inspection.topix_count == 0
+        and inspection.stock_count == 0
+        and inspection.indices_count == 0
+    )
+
+
+def _log_sync_fetch_execution(
+    *,
+    stage: str,
+    endpoint: str,
+    decision: _StageFetchDecision,
+    executed: _FetchMethod,
+    actual_api_calls: int,
+    fallback: bool,
+    bulk_result: BulkFetchResult | None = None,
+) -> None:
+    cache_hit_rate: float | None = None
+    cache_hits = 0
+    cache_misses = 0
+    if bulk_result is not None:
+        cache_hits = bulk_result.cache_hits
+        cache_misses = bulk_result.cache_misses
+        total = cache_hits + cache_misses
+        cache_hit_rate = (cache_hits / total) if total > 0 else None
+
+    logger.info(
+        "sync fetch strategy execution",
+        event="sync_fetch_strategy",
+        stage=stage,
+        endpoint=endpoint,
+        selected=decision.method,
+        executed=executed,
+        fallbackUsed=fallback,
+        estimatedRestCalls=decision.estimated_rest_calls,
+        estimatedBulkCalls=decision.estimated_bulk_calls,
+        plannerApiCalls=decision.planner_api_calls,
+        actualApiCalls=actual_api_calls,
+        cacheHits=cache_hits,
+        cacheMisses=cache_misses,
+        cacheHitRate=cache_hit_rate,
+    )
 
 
 class IndicesOnlySyncStrategy:
@@ -77,30 +383,92 @@ class IndicesOnlySyncStrategy:
 
             known_master_codes = await _seed_index_master_from_catalog(ctx)
             target_codes = sorted(get_index_catalog_codes() | known_master_codes)
+            target_code_set = {_normalize_index_code(code) for code in target_codes}
 
             # 2. 各指数のデータ取得
             ctx.on_progress("indices_data", 1, 2, f"Fetching data for {len(target_codes)} indices...")
-            for code in target_codes:
-                if ctx.cancelled.is_set():
-                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+            decision = await _plan_fetch_method(
+                ctx,
+                stage="indices_data",
+                endpoint="/indices/bars/daily",
+                estimated_rest_calls=len(target_codes),
+            )
+            total_calls += decision.planner_api_calls
+
+            used_rest_fallback = False
+            stage_api_calls = 0
+            bulk_result: BulkFetchResult | None = None
+            if decision.method == "bulk" and decision.plan is not None:
                 try:
-                    data = await ctx.client.get_paginated("/indices/bars/daily", params={"code": code})
-                    total_calls += 1
+                    bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision.plan)
+                    total_calls += bulk_result.api_calls
+                    stage_api_calls += bulk_result.api_calls
                     rows = validate_rows_required_fields(
-                        _convert_indices_data_rows(data, code),
+                        _convert_indices_data_rows(_normalize_bulk_indices_rows(bulk_result.rows), None),
                         required_fields=("code", "date"),
                         dedupe_keys=("code", "date"),
                         stage="indices_data",
                     )
+                    rows = [
+                        row
+                        for row in rows
+                        if _normalize_index_code(row.get("code")) in target_code_set
+                    ]
                     if rows:
                         await _upsert_indices_rows_with_master_backfill(
                             ctx,
                             rows,
                             known_master_codes,
                         )
+                    _log_sync_fetch_execution(
+                        stage="indices_data",
+                        endpoint="/indices/bars/daily",
+                        decision=decision,
+                        executed="bulk",
+                        actual_api_calls=stage_api_calls,
+                        fallback=False,
+                        bulk_result=bulk_result,
+                    )
                 except Exception as e:
-                    errors.append(f"Index {code}: {e}")
-                    logger.warning(f"Index {code} sync error: {e}")
+                    used_rest_fallback = True
+                    logger.warning("indices-only bulk fetch failed, falling back to REST: {}", e)
+
+            if decision.method == "rest" or used_rest_fallback:
+                for code in target_codes:
+                    if ctx.cancelled.is_set():
+                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+                    try:
+                        data, page_calls = await _get_paginated_rows_with_call_count(
+                            ctx.client,
+                            "/indices/bars/daily",
+                            params={"code": code},
+                        )
+                        total_calls += page_calls
+                        stage_api_calls += page_calls
+                        rows = validate_rows_required_fields(
+                            _convert_indices_data_rows(data, code),
+                            required_fields=("code", "date"),
+                            dedupe_keys=("code", "date"),
+                            stage="indices_data",
+                        )
+                        if rows:
+                            await _upsert_indices_rows_with_master_backfill(
+                                ctx,
+                                rows,
+                                known_master_codes,
+                            )
+                    except Exception as e:
+                        errors.append(f"Index {code}: {e}")
+                        logger.warning(f"Index {code} sync error: {e}")
+                _log_sync_fetch_execution(
+                    stage="indices_data",
+                    endpoint="/indices/bars/daily",
+                    decision=decision,
+                    executed="rest",
+                    actual_api_calls=stage_api_calls,
+                    fallback=used_rest_fallback,
+                    bulk_result=bulk_result,
+                )
 
             await _index_indices_rows(ctx)
 
@@ -136,9 +504,17 @@ class InitialSyncStrategy:
             if ctx.cancelled.is_set():
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
+            topix_data_raw, topix_calls = await _get_paginated_rows_with_call_count(
+                ctx.client,
+                "/indices/bars/daily/topix",
+            )
+
+            async def _prefetched_topix_rows() -> list[dict[str, Any]]:
+                return topix_data_raw
+
             topix_batch = await run_ingestion_batch(
                 stage="topix",
-                fetch=lambda: ctx.client.get_paginated("/indices/bars/daily/topix"),
+                fetch=_prefetched_topix_rows,
                 normalize=_convert_topix_rows,
                 validate=lambda rows: validate_rows_required_fields(
                     rows,
@@ -149,7 +525,7 @@ class InitialSyncStrategy:
                 publish=lambda rows: _publish_topix_rows(ctx, rows),
                 index=lambda _rows: _index_topix_rows(ctx),
             )
-            total_calls += 1
+            total_calls += topix_calls
             topix_rows = topix_batch.rows
             dates_processed = len(topix_rows)
 
@@ -158,8 +534,11 @@ class InitialSyncStrategy:
             if ctx.cancelled.is_set():
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
-            stocks_data = await ctx.client.get_paginated("/equities/master")
-            total_calls += 1
+            stocks_data, stocks_calls = await _get_paginated_rows_with_call_count(
+                ctx.client,
+                "/equities/master",
+            )
+            total_calls += stocks_calls
             stock_rows = _convert_stock_rows(stocks_data)
             if stock_rows:
                 await asyncio.to_thread(ctx.market_db.upsert_stocks, stock_rows)
@@ -184,34 +563,103 @@ class InitialSyncStrategy:
             # Step 4: 株価データ（日付ベース、TOPIX 日付を使用）
             ctx.on_progress("stock_data", 3, 6, "Fetching daily stock prices...")
             trading_dates = sorted({r["date"] for r in topix_rows})
-            consecutive_failures = 0
-            for i, date in enumerate(trading_dates):
-                if ctx.cancelled.is_set():
-                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
-                if i % 50 == 0:
-                    ctx.on_progress("stock_data", 3, 6, f"Fetching stock data: {i}/{len(trading_dates)} dates...")
+            from_date, to_date = _select_bulk_candidates_from_dates(trading_dates)
+            decision = await _plan_fetch_method(
+                ctx,
+                stage="stock_data_initial",
+                endpoint="/equities/bars/daily",
+                estimated_rest_calls=max(len(trading_dates), 1),
+                date_from=from_date,
+                date_to=to_date,
+                exact_dates=trading_dates,
+            )
+            total_calls += decision.planner_api_calls
+
+            used_rest_fallback = False
+            stage_api_calls = 0
+            bulk_result: BulkFetchResult | None = None
+            if decision.method == "bulk" and decision.plan is not None:
                 try:
-                    batch = await run_ingestion_batch(
+                    bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision.plan)
+                    total_calls += bulk_result.api_calls
+                    stage_api_calls += bulk_result.api_calls
+                    bulk_rows = _normalize_bulk_stock_rows(bulk_result.rows)
+                    if trading_dates:
+                        trading_date_set = {_to_iso_date_text(value) for value in trading_dates}
+                        bulk_rows = [
+                            row
+                            for row in bulk_rows
+                            if _to_iso_date_text(str(row.get("Date") or "")) in trading_date_set
+                        ]
+                    rows = validate_rows_required_fields(
+                        _convert_stock_data_rows(bulk_rows),
+                        required_fields=("code", "date", "open", "high", "low", "close", "volume"),
+                        dedupe_keys=("code", "date"),
                         stage="stock_data",
-                        fetch=lambda date=date: ctx.client.get_paginated("/equities/bars/daily", params={"date": date}),
-                        normalize=_convert_stock_data_rows,
-                        validate=lambda rows: validate_rows_required_fields(
-                            rows,
-                            required_fields=("code", "date", "open", "high", "low", "close", "volume"),
-                            dedupe_keys=("code", "date"),
-                            stage="stock_data",
-                        ),
-                        publish=lambda rows: _publish_stock_data_rows(ctx, rows),
                     )
-                    total_calls += 1
-                    stocks_updated += batch.published_count
-                    consecutive_failures = 0
-                except Exception:
-                    failed_dates.append(date)
-                    consecutive_failures += 1
-                    if consecutive_failures >= 5:
-                        errors.append(f"Too many consecutive failures at {date}")
-                        break
+                    if rows:
+                        stocks_updated += await _publish_stock_data_rows(ctx, rows)
+                    _log_sync_fetch_execution(
+                        stage="stock_data_initial",
+                        endpoint="/equities/bars/daily",
+                        decision=decision,
+                        executed="bulk",
+                        actual_api_calls=stage_api_calls,
+                        fallback=False,
+                        bulk_result=bulk_result,
+                    )
+                except Exception as e:
+                    used_rest_fallback = True
+                    logger.warning("Initial stock_data bulk fetch failed, falling back to REST: {}", e)
+
+            if decision.method == "rest" or used_rest_fallback:
+                consecutive_failures = 0
+                for i, date in enumerate(trading_dates):
+                    if ctx.cancelled.is_set():
+                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+                    if i % 50 == 0:
+                        ctx.on_progress("stock_data", 3, 6, f"Fetching stock data: {i}/{len(trading_dates)} dates...")
+                    try:
+                        payload, page_calls = await _get_paginated_rows_with_call_count(
+                            ctx.client,
+                            "/equities/bars/daily",
+                            params={"date": date},
+                        )
+                        total_calls += page_calls
+                        stage_api_calls += page_calls
+
+                        async def _prefetched_stock_rows() -> list[dict[str, Any]]:
+                            return payload
+
+                        batch = await run_ingestion_batch(
+                            stage="stock_data",
+                            fetch=_prefetched_stock_rows,
+                            normalize=_convert_stock_data_rows,
+                            validate=lambda rows: validate_rows_required_fields(
+                                rows,
+                                required_fields=("code", "date", "open", "high", "low", "close", "volume"),
+                                dedupe_keys=("code", "date"),
+                                stage="stock_data",
+                            ),
+                            publish=lambda rows: _publish_stock_data_rows(ctx, rows),
+                        )
+                        stocks_updated += batch.published_count
+                        consecutive_failures = 0
+                    except Exception:
+                        failed_dates.append(date)
+                        consecutive_failures += 1
+                        if consecutive_failures >= 5:
+                            errors.append(f"Too many consecutive failures at {date}")
+                            break
+                _log_sync_fetch_execution(
+                    stage="stock_data_initial",
+                    endpoint="/equities/bars/daily",
+                    decision=decision,
+                    executed="rest",
+                    actual_api_calls=stage_api_calls,
+                    fallback=used_rest_fallback,
+                    bulk_result=bulk_result,
+                )
 
             await _index_stock_data_rows(ctx)
 
@@ -275,6 +723,7 @@ class IncrementalSyncStrategy:
             # stock_data が一部日付で取りこぼされると topix_data より遅れる場合があるため、
             # 増分同期の基準日は stock_data の最新日を優先する。
             inspection = _inspect_time_series(ctx)
+            cold_start_bootstrap = _is_incremental_cold_start(ctx, inspection)
             last_topix_date = (
                 inspection.topix_max if inspection and inspection.topix_max else ctx.market_db.get_latest_trading_date()
             )
@@ -284,14 +733,32 @@ class IncrementalSyncStrategy:
                 else ctx.market_db.get_latest_stock_data_date()
             )
             last_date = last_stock_date or last_topix_date
+            if cold_start_bootstrap:
+                logger.info(
+                    "Incremental sync detected empty time-series SoT; switching to bootstrap path",
+                    event="sync_fetch_strategy",
+                    stage="incremental_bootstrap",
+                    selected="bootstrap",
+                    reason="empty_timeseries",
+                )
+                last_date = None
             params: dict[str, Any] = {}
             if last_date:
                 # J-Quants は YYYYMMDD 形式が安定しているため、既存データ形式（YYYY-MM-DD / YYYYMMDD）を吸収する
                 params["from"] = _to_jquants_date_param(last_date)
 
+            topix_payload, topix_calls = await _get_paginated_rows_with_call_count(
+                ctx.client,
+                "/indices/bars/daily/topix",
+                params=params,
+            )
+
+            async def _prefetched_incremental_topix_rows() -> list[dict[str, Any]]:
+                return topix_payload
+
             topix_batch = await run_ingestion_batch(
                 stage="topix",
-                fetch=lambda: ctx.client.get_paginated("/indices/bars/daily/topix", params=params),
+                fetch=_prefetched_incremental_topix_rows,
                 normalize=_convert_topix_rows,
                 validate=lambda rows: validate_rows_required_fields(
                     rows,
@@ -302,7 +769,7 @@ class IncrementalSyncStrategy:
                 publish=lambda rows: _publish_topix_rows(ctx, rows),
                 index=lambda _rows: _index_topix_rows(ctx),
             )
-            total_calls += 1
+            total_calls += topix_calls
             topix_rows = topix_batch.rows
 
             # Step 2: 銘柄マスタ更新
@@ -310,8 +777,11 @@ class IncrementalSyncStrategy:
             if ctx.cancelled.is_set():
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
-            stocks_data = await ctx.client.get_paginated("/equities/master")
-            total_calls += 1
+            stocks_data, stocks_calls = await _get_paginated_rows_with_call_count(
+                ctx.client,
+                "/equities/master",
+            )
+            total_calls += stocks_calls
             stock_rows = _convert_stock_rows(stocks_data)
             if stock_rows:
                 await asyncio.to_thread(ctx.market_db.upsert_stocks, stock_rows)
@@ -329,26 +799,95 @@ class IncrementalSyncStrategy:
                 )
             else:
                 new_dates = sorted({r["date"] for r in topix_rows if r.get("date")}, key=_date_sort_key)
-            for date in new_dates:
-                if ctx.cancelled.is_set():
-                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+            from_date_new, to_date_new = _select_bulk_candidates_from_dates(new_dates)
+            decision_stock_data = await _plan_fetch_method(
+                ctx,
+                stage="stock_data_incremental",
+                endpoint="/equities/bars/daily",
+                estimated_rest_calls=max(len(new_dates), 1),
+                date_from=from_date_new,
+                date_to=to_date_new,
+                exact_dates=new_dates,
+            )
+            total_calls += decision_stock_data.planner_api_calls
+
+            used_stock_rest_fallback = False
+            stock_stage_api_calls = 0
+            stock_bulk_result: BulkFetchResult | None = None
+            if decision_stock_data.method == "bulk" and decision_stock_data.plan is not None:
                 try:
-                    batch = await run_ingestion_batch(
+                    stock_bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision_stock_data.plan)
+                    total_calls += stock_bulk_result.api_calls
+                    stock_stage_api_calls += stock_bulk_result.api_calls
+                    bulk_rows = _normalize_bulk_stock_rows(stock_bulk_result.rows)
+                    if new_dates:
+                        new_date_set = {_to_iso_date_text(value) for value in new_dates}
+                        bulk_rows = [
+                            row
+                            for row in bulk_rows
+                            if _to_iso_date_text(str(row.get("Date") or "")) in new_date_set
+                        ]
+                    rows = validate_rows_required_fields(
+                        _convert_stock_data_rows(bulk_rows),
+                        required_fields=("code", "date", "open", "high", "low", "close", "volume"),
+                        dedupe_keys=("code", "date"),
                         stage="stock_data",
-                        fetch=lambda date=date: ctx.client.get_paginated("/equities/bars/daily", params={"date": date}),
-                        normalize=_convert_stock_data_rows,
-                        validate=lambda rows: validate_rows_required_fields(
-                            rows,
-                            required_fields=("code", "date", "open", "high", "low", "close", "volume"),
-                            dedupe_keys=("code", "date"),
-                            stage="stock_data",
-                        ),
-                        publish=lambda rows: _publish_stock_data_rows(ctx, rows),
                     )
-                    total_calls += 1
-                    stocks_updated += batch.published_count
+                    if rows:
+                        stocks_updated += await _publish_stock_data_rows(ctx, rows)
+                    _log_sync_fetch_execution(
+                        stage="stock_data_incremental",
+                        endpoint="/equities/bars/daily",
+                        decision=decision_stock_data,
+                        executed="bulk",
+                        actual_api_calls=stock_stage_api_calls,
+                        fallback=False,
+                        bulk_result=stock_bulk_result,
+                    )
                 except Exception as e:
-                    errors.append(f"Date {date}: {e}")
+                    used_stock_rest_fallback = True
+                    logger.warning("Incremental stock_data bulk fetch failed, falling back to REST: {}", e)
+
+            if decision_stock_data.method == "rest" or used_stock_rest_fallback:
+                for date in new_dates:
+                    if ctx.cancelled.is_set():
+                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+                    try:
+                        payload, page_calls = await _get_paginated_rows_with_call_count(
+                            ctx.client,
+                            "/equities/bars/daily",
+                            params={"date": date},
+                        )
+                        total_calls += page_calls
+                        stock_stage_api_calls += page_calls
+
+                        async def _prefetched_new_date_rows() -> list[dict[str, Any]]:
+                            return payload
+
+                        batch = await run_ingestion_batch(
+                            stage="stock_data",
+                            fetch=_prefetched_new_date_rows,
+                            normalize=_convert_stock_data_rows,
+                            validate=lambda rows: validate_rows_required_fields(
+                                rows,
+                                required_fields=("code", "date", "open", "high", "low", "close", "volume"),
+                                dedupe_keys=("code", "date"),
+                                stage="stock_data",
+                            ),
+                            publish=lambda rows: _publish_stock_data_rows(ctx, rows),
+                        )
+                        stocks_updated += batch.published_count
+                    except Exception as e:
+                        errors.append(f"Date {date}: {e}")
+                _log_sync_fetch_execution(
+                    stage="stock_data_incremental",
+                    endpoint="/equities/bars/daily",
+                    decision=decision_stock_data,
+                    executed="rest",
+                    actual_api_calls=stock_stage_api_calls,
+                    fallback=used_stock_rest_fallback,
+                    bulk_result=stock_bulk_result,
+                )
 
             await _index_stock_data_rows(ctx)
 
@@ -358,49 +897,22 @@ class IncrementalSyncStrategy:
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
             known_master_codes = await _seed_index_master_from_catalog(ctx)
-            latest_index_dates = (
+            raw_latest_index_dates = (
                 dict(inspection.latest_indices_dates)
                 if inspection and inspection.latest_indices_dates
                 else ctx.market_db.get_latest_indices_data_dates()
             )
+            latest_index_dates = {
+                _normalize_index_code(code): value
+                for code, value in raw_latest_index_dates.items()
+                if _normalize_index_code(code)
+            }
             target_codes = sorted(
                 get_index_catalog_codes()
                 | set(latest_index_dates.keys())
                 | known_master_codes
             )
-
-            for code in target_codes:
-                if ctx.cancelled.is_set():
-                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
-
-                params: dict[str, Any] = {"code": code}
-                last_index_date = latest_index_dates.get(code)
-                if last_index_date:
-                    params["from"] = _to_jquants_date_param(last_index_date)
-
-                try:
-                    data = await ctx.client.get_paginated("/indices/bars/daily", params=params)
-                    total_calls += 1
-
-                    rows = validate_rows_required_fields(
-                        _convert_indices_data_rows(data, code),
-                        required_fields=("code", "date"),
-                        dedupe_keys=("code", "date"),
-                        stage="indices_data",
-                    )
-                    if last_index_date:
-                        rows = [r for r in rows if _is_date_after(r["date"], last_index_date)]
-
-                    if rows:
-                        await _upsert_indices_rows_with_master_backfill(
-                            ctx,
-                            rows,
-                            known_master_codes,
-                            discovery_log="Inserted {} discovered index master rows while syncing by code.",
-                        )
-                except Exception as e:
-                    errors.append(f"Index {code}: {e}")
-                    logger.warning(f"Index {code} incremental sync error: {e}")
+            target_code_set = {_normalize_index_code(code) for code in target_codes}
 
             # code 指定同期の補完として、日付指定で新規コードを探索する。
             latest_index_date = _latest_date(list(latest_index_dates.values()))
@@ -416,11 +928,12 @@ class IncrementalSyncStrategy:
                 and last_date
                 and _is_date_after(last_date, latest_index_date)
             ):
-                topix_for_indices = await ctx.client.get_paginated(
+                topix_for_indices, topix_for_indices_calls = await _get_paginated_rows_with_call_count(
+                    ctx.client,
                     "/indices/bars/daily/topix",
                     params={"from": _to_jquants_date_param(latest_index_date)},
                 )
-                total_calls += 1
+                total_calls += topix_for_indices_calls
                 topix_dates = [
                     {"date": d.get("Date", "")}
                     for d in topix_for_indices
@@ -433,32 +946,153 @@ class IncrementalSyncStrategy:
                     key=_date_sort_key,
                 )
 
-            for index_date in fallback_dates:
-                if ctx.cancelled.is_set():
-                    return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+            all_code_has_anchor = all(latest_index_dates.get(_normalize_index_code(code)) for code in target_codes)
+            decision_indices = await _plan_fetch_method(
+                ctx,
+                stage="indices_incremental",
+                endpoint="/indices/bars/daily",
+                estimated_rest_calls=max(len(target_codes) + len(fallback_dates), 1),
+                date_from=latest_index_date if all_code_has_anchor else None,
+            )
+            total_calls += decision_indices.planner_api_calls
 
+            used_indices_rest_fallback = False
+            indices_stage_api_calls = 0
+            indices_bulk_result: BulkFetchResult | None = None
+            if decision_indices.method == "bulk" and decision_indices.plan is not None:
                 try:
-                    data = await ctx.client.get_paginated(
-                        "/indices/bars/daily",
-                        params={"date": _to_jquants_date_param(index_date)},
-                    )
-                    total_calls += 1
+                    indices_bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision_indices.plan)
+                    total_calls += indices_bulk_result.api_calls
+                    indices_stage_api_calls += indices_bulk_result.api_calls
                     rows = validate_rows_required_fields(
-                        _convert_indices_data_rows(data, None),
+                        _convert_indices_data_rows(_normalize_bulk_indices_rows(indices_bulk_result.rows), None),
                         required_fields=("code", "date"),
                         dedupe_keys=("code", "date"),
                         stage="indices_data",
                     )
-                    if rows:
+                    fallback_date_set = {
+                        normalized
+                        for normalized in (_to_iso_date_text(value) for value in fallback_dates)
+                        if normalized is not None
+                    }
+                    filtered_rows: list[dict[str, Any]] = []
+                    for row in rows:
+                        code = _normalize_index_code(row.get("code"))
+                        row_date = _to_iso_date_text(str(row.get("date") or ""))
+                        if not code or row_date is None:
+                            continue
+
+                        include = False
+                        code_anchor = latest_index_dates.get(code)
+                        if code in target_code_set:
+                            if code_anchor is None:
+                                include = True
+                            else:
+                                include = _is_date_after(row_date, code_anchor)
+
+                        if not include and row_date in fallback_date_set:
+                            include = True
+
+                        if include:
+                            filtered_rows.append(row)
+
+                    if filtered_rows:
                         await _upsert_indices_rows_with_master_backfill(
                             ctx,
-                            rows,
+                            filtered_rows,
                             known_master_codes,
-                            discovery_log="Inserted {} discovered index master rows while syncing by date.",
+                            discovery_log="Inserted {} discovered index master rows while syncing by bulk.",
                         )
+                    _log_sync_fetch_execution(
+                        stage="indices_incremental",
+                        endpoint="/indices/bars/daily",
+                        decision=decision_indices,
+                        executed="bulk",
+                        actual_api_calls=indices_stage_api_calls,
+                        fallback=False,
+                        bulk_result=indices_bulk_result,
+                    )
                 except Exception as e:
-                    errors.append(f"Index date {index_date}: {e}")
-                    logger.warning("Index date {} incremental sync error: {}", index_date, e)
+                    used_indices_rest_fallback = True
+                    logger.warning("Incremental indices bulk fetch failed, falling back to REST: {}", e)
+
+            if decision_indices.method == "rest" or used_indices_rest_fallback:
+                for code in target_codes:
+                    if ctx.cancelled.is_set():
+                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+
+                    params: dict[str, Any] = {"code": code}
+                    normalized_code = _normalize_index_code(code)
+                    last_index_date = latest_index_dates.get(normalized_code)
+                    if last_index_date:
+                        params["from"] = _to_jquants_date_param(last_index_date)
+
+                    try:
+                        data, page_calls = await _get_paginated_rows_with_call_count(
+                            ctx.client,
+                            "/indices/bars/daily",
+                            params=params,
+                        )
+                        total_calls += page_calls
+                        indices_stage_api_calls += page_calls
+
+                        rows = validate_rows_required_fields(
+                            _convert_indices_data_rows(data, code),
+                            required_fields=("code", "date"),
+                            dedupe_keys=("code", "date"),
+                            stage="indices_data",
+                        )
+                        if last_index_date:
+                            rows = [r for r in rows if _is_date_after(r["date"], last_index_date)]
+
+                        if rows:
+                            await _upsert_indices_rows_with_master_backfill(
+                                ctx,
+                                rows,
+                                known_master_codes,
+                                discovery_log="Inserted {} discovered index master rows while syncing by code.",
+                            )
+                    except Exception as e:
+                        errors.append(f"Index {code}: {e}")
+                        logger.warning(f"Index {code} incremental sync error: {e}")
+
+                for index_date in fallback_dates:
+                    if ctx.cancelled.is_set():
+                        return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
+
+                    try:
+                        data, page_calls = await _get_paginated_rows_with_call_count(
+                            ctx.client,
+                            "/indices/bars/daily",
+                            params={"date": _to_jquants_date_param(index_date)},
+                        )
+                        total_calls += page_calls
+                        indices_stage_api_calls += page_calls
+                        rows = validate_rows_required_fields(
+                            _convert_indices_data_rows(data, None),
+                            required_fields=("code", "date"),
+                            dedupe_keys=("code", "date"),
+                            stage="indices_data",
+                        )
+                        if rows:
+                            await _upsert_indices_rows_with_master_backfill(
+                                ctx,
+                                rows,
+                                known_master_codes,
+                                discovery_log="Inserted {} discovered index master rows while syncing by date.",
+                            )
+                    except Exception as e:
+                        errors.append(f"Index date {index_date}: {e}")
+                        logger.warning("Index date {} incremental sync error: {}", index_date, e)
+                _log_sync_fetch_execution(
+                    stage="indices_incremental",
+                    endpoint="/indices/bars/daily",
+                    decision=decision_indices,
+                    executed="rest",
+                    actual_api_calls=indices_stage_api_calls,
+                    fallback=used_indices_rest_fallback,
+                    bulk_result=indices_bulk_result,
+                )
 
             await _index_indices_rows(ctx)
 
@@ -506,34 +1140,85 @@ async def _sync_fundamentals_initial(
     updated = 0
     failed_codes: list[str] = []
     errors: list[str] = []
+    prime_code_set = set(prime_codes)
+    bulk_succeeded = False
+    stage_api_calls = 0
+    bulk_result: BulkFetchResult | None = None
 
-    for idx, code in enumerate(prime_codes):
-        if ctx.cancelled.is_set():
-            return {
-                "api_calls": api_calls,
-                "updated": updated,
-                "dates_processed": 0,
-                "errors": errors,
-                "cancelled": True,
-            }
+    decision = await _plan_fetch_method(
+        ctx,
+        stage="fundamentals_initial",
+        endpoint="/fins/summary",
+        estimated_rest_calls=max(len(prime_codes), 1),
+    )
+    api_calls += decision.planner_api_calls
 
-        if idx > 0 and idx % 100 == 0:
-            ctx.on_progress("fundamentals", 2, 6, f"Fetching fundamentals: {idx}/{len(prime_codes)} codes...")
-
+    if decision.method == "bulk" and decision.plan is not None:
         try:
-            data, page_calls = await _fetch_fins_summary_by_code(ctx.client, code)
-            api_calls += page_calls
+            bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision.plan)
+            api_calls += bulk_result.api_calls
+            stage_api_calls += bulk_result.api_calls
+            bulk_rows = convert_fins_summary_rows(_normalize_bulk_fins_rows(bulk_result.rows))
+            rows = [row for row in bulk_rows if row.get("code") in prime_code_set]
             rows = validate_rows_required_fields(
-                convert_fins_summary_rows(data, default_code=code),
+                rows,
                 required_fields=("code", "disclosed_date"),
                 dedupe_keys=("code", "disclosed_date"),
                 stage="fundamentals",
             )
             if rows:
                 updated += await _publish_statement_rows(ctx, rows)
+            bulk_succeeded = True
+            _log_sync_fetch_execution(
+                stage="fundamentals_initial",
+                endpoint="/fins/summary",
+                decision=decision,
+                executed="bulk",
+                actual_api_calls=stage_api_calls,
+                fallback=False,
+                bulk_result=bulk_result,
+            )
         except Exception as e:
-            failed_codes.append(code)
-            errors.append(f"Fundamentals code {code}: {e}")
+            logger.warning("Initial fundamentals bulk fetch failed, falling back to REST: {}", e)
+
+    if not bulk_succeeded:
+        for idx, code in enumerate(prime_codes):
+            if ctx.cancelled.is_set():
+                return {
+                    "api_calls": api_calls,
+                    "updated": updated,
+                    "dates_processed": 0,
+                    "errors": errors,
+                    "cancelled": True,
+                }
+
+            if idx > 0 and idx % 100 == 0:
+                ctx.on_progress("fundamentals", 2, 6, f"Fetching fundamentals: {idx}/{len(prime_codes)} codes...")
+
+            try:
+                data, page_calls = await _fetch_fins_summary_by_code(ctx.client, code)
+                api_calls += page_calls
+                stage_api_calls += page_calls
+                rows = validate_rows_required_fields(
+                    convert_fins_summary_rows(data, default_code=code),
+                    required_fields=("code", "disclosed_date"),
+                    dedupe_keys=("code", "disclosed_date"),
+                    stage="fundamentals",
+                )
+                if rows:
+                    updated += await _publish_statement_rows(ctx, rows)
+            except Exception as e:
+                failed_codes.append(code)
+                errors.append(f"Fundamentals code {code}: {e}")
+        _log_sync_fetch_execution(
+            stage="fundamentals_initial",
+            endpoint="/fins/summary",
+            decision=decision,
+            executed="rest",
+            actual_api_calls=stage_api_calls,
+            fallback=decision.method == "bulk",
+            bulk_result=bulk_result,
+        )
 
     await _index_statement_rows(ctx)
 
@@ -595,39 +1280,104 @@ async def _sync_fundamentals_incremental(
         or _get_latest_statement_disclosed_date(ctx)
     )
     date_targets = _build_incremental_date_targets(anchor, previous_failed_dates)
+    normalized_targets = {
+        normalized
+        for normalized in (_to_iso_date_text(value) for value in date_targets)
+        if normalized is not None
+    }
+    dates_phase_completed = 0
+    bulk_dates_succeeded = False
+    date_phase_api_calls = 0
+    date_phase_bulk_result: BulkFetchResult | None = None
+    if date_targets:
+        decision = await _plan_fetch_method(
+            ctx,
+            stage="fundamentals_incremental_dates",
+            endpoint="/fins/summary",
+            estimated_rest_calls=max(len(date_targets), 1),
+            exact_dates=date_targets,
+        )
+        api_calls += decision.planner_api_calls
 
-    for idx, disclosed_date in enumerate(date_targets):
-        if ctx.cancelled.is_set():
-            return {
-                "api_calls": api_calls,
-                "updated": updated,
-                "dates_processed": idx,
-                "errors": errors,
-                "cancelled": True,
-            }
+        if decision.method == "bulk" and decision.plan is not None:
+            try:
+                date_phase_bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision.plan)
+                api_calls += date_phase_bulk_result.api_calls
+                date_phase_api_calls += date_phase_bulk_result.api_calls
+                bulk_rows = convert_fins_summary_rows(_normalize_bulk_fins_rows(date_phase_bulk_result.rows))
+                rows = [row for row in bulk_rows if row.get("code") in prime_code_set]
+                if normalized_targets:
+                    rows = [
+                        row
+                        for row in rows
+                        if _to_iso_date_text(str(row.get("disclosed_date") or "")) in normalized_targets
+                    ]
+                rows = validate_rows_required_fields(
+                    rows,
+                    required_fields=("code", "disclosed_date"),
+                    dedupe_keys=("code", "disclosed_date"),
+                    stage="fundamentals",
+                )
+                if rows:
+                    updated += await _publish_statement_rows(ctx, rows)
+                bulk_dates_succeeded = True
+                dates_phase_completed = len(date_targets)
+                _log_sync_fetch_execution(
+                    stage="fundamentals_incremental_dates",
+                    endpoint="/fins/summary",
+                    decision=decision,
+                    executed="bulk",
+                    actual_api_calls=date_phase_api_calls,
+                    fallback=False,
+                    bulk_result=date_phase_bulk_result,
+                )
+            except Exception as e:
+                logger.warning("Incremental fundamentals bulk date fetch failed, falling back to REST: {}", e)
 
-        if idx > 0 and idx % 30 == 0:
-            ctx.on_progress("fundamentals", 4, 5, f"Fetching fundamentals dates: {idx}/{len(date_targets)}...")
+        if not bulk_dates_succeeded:
+            for idx, disclosed_date in enumerate(date_targets):
+                if ctx.cancelled.is_set():
+                    return {
+                        "api_calls": api_calls,
+                        "updated": updated,
+                        "dates_processed": idx,
+                        "errors": errors,
+                        "cancelled": True,
+                    }
 
-        try:
-            data, page_calls = await _fetch_fins_summary_paginated(
-                ctx.client,
-                {"date": _to_jquants_date_param(disclosed_date)},
+                if idx > 0 and idx % 30 == 0:
+                    ctx.on_progress("fundamentals", 4, 5, f"Fetching fundamentals dates: {idx}/{len(date_targets)}...")
+
+                try:
+                    data, page_calls = await _fetch_fins_summary_paginated(
+                        ctx.client,
+                        {"date": _to_jquants_date_param(disclosed_date)},
+                    )
+                    api_calls += page_calls
+                    date_phase_api_calls += page_calls
+                    rows = convert_fins_summary_rows(data)
+                    rows = [row for row in rows if row.get("code") in prime_code_set]
+                    rows = validate_rows_required_fields(
+                        rows,
+                        required_fields=("code", "disclosed_date"),
+                        dedupe_keys=("code", "disclosed_date"),
+                        stage="fundamentals",
+                    )
+                    if rows:
+                        updated += await _publish_statement_rows(ctx, rows)
+                except Exception as e:
+                    failed_dates.append(disclosed_date)
+                    errors.append(f"Fundamentals date {disclosed_date}: {e}")
+            dates_phase_completed = len(date_targets)
+            _log_sync_fetch_execution(
+                stage="fundamentals_incremental_dates",
+                endpoint="/fins/summary",
+                decision=decision,
+                executed="rest",
+                actual_api_calls=date_phase_api_calls,
+                fallback=decision.method == "bulk",
+                bulk_result=date_phase_bulk_result,
             )
-            api_calls += page_calls
-            rows = convert_fins_summary_rows(data)
-            rows = [row for row in rows if row.get("code") in prime_code_set]
-            rows = validate_rows_required_fields(
-                rows,
-                required_fields=("code", "disclosed_date"),
-                dedupe_keys=("code", "disclosed_date"),
-                stage="fundamentals",
-            )
-            if rows:
-                updated += await _publish_statement_rows(ctx, rows)
-        except Exception as e:
-            failed_dates.append(disclosed_date)
-            errors.append(f"Fundamentals date {disclosed_date}: {e}")
 
     statement_codes = _get_statement_codes(ctx)
     missing_prime_codes = sorted(set(prime_codes) - set(statement_codes))
@@ -638,7 +1388,7 @@ async def _sync_fundamentals_incremental(
             return {
                 "api_calls": api_calls,
                 "updated": updated,
-                "dates_processed": len(date_targets),
+                "dates_processed": dates_phase_completed,
                 "errors": errors,
                 "cancelled": True,
             }
@@ -693,7 +1443,7 @@ async def _sync_fundamentals_incremental(
     return {
         "api_calls": api_calls,
         "updated": updated,
-        "dates_processed": len(date_targets),
+        "dates_processed": dates_phase_completed,
         "errors": errors,
         "cancelled": False,
     }

--- a/apps/bt/src/infrastructure/external_api/clients/jquants_client.py
+++ b/apps/bt/src/infrastructure/external_api/clients/jquants_client.py
@@ -59,12 +59,13 @@ class JQuantsAsyncClient:
         timeout: float = 30.0,
     ) -> None:
         self._api_key = api_key
+        self._plan = plan.strip().lower()
         self._client = httpx.AsyncClient(
             base_url=self.BASE_URL,
             headers={"x-api-key": api_key},
             timeout=timeout,
         )
-        self._rate_limiter = RateLimiter(plan=plan)
+        self._rate_limiter = RateLimiter(plan=self._plan)
 
     @property
     def has_api_key(self) -> bool:
@@ -78,6 +79,10 @@ class JQuantsAsyncClient:
         if len(key) > 8:
             return f"{key[:4]}...{key[-4:]}"
         return "****"
+
+    @property
+    def plan(self) -> str:
+        return self._plan
 
     async def _get_with_retry(
         self, path: str, params: dict[str, Any] | None = None
@@ -173,6 +178,12 @@ class JQuantsAsyncClient:
     async def get_paginated(
         self, path: str, params: dict[str, Any] | None = None, max_pages: int = 10
     ) -> list[dict[str, Any]]:
+        data, _calls = await self.get_paginated_with_meta(path, params=params, max_pages=max_pages)
+        return data
+
+    async def get_paginated_with_meta(
+        self, path: str, params: dict[str, Any] | None = None, max_pages: int = 10
+    ) -> tuple[list[dict[str, Any]], int]:
         """ページネーション付き GET リクエスト
 
         JQuants v2 の pagination_key ベースのページネーションを処理する。
@@ -214,7 +225,7 @@ class JQuantsAsyncClient:
             current_params = {**current_params, "pagination_key": pagination_key}
 
         logger.debug(f"JQuants paginated {path}: {len(all_data)} records in {page_count} pages")
-        return all_data
+        return all_data, page_count
 
     async def close(self) -> None:
         """HTTP クライアントをクローズ"""

--- a/apps/bt/tests/unit/server/clients/test_jquants_client.py
+++ b/apps/bt/tests/unit/server/clients/test_jquants_client.py
@@ -21,6 +21,10 @@ class TestJQuantsAsyncClient:
     def test_has_api_key(self, client):
         assert client.has_api_key is True
 
+    def test_plan_is_normalized(self):
+        c = JQuantsAsyncClient(api_key="dummy", plan=" Premium ")
+        assert c.plan == "premium"
+
     def test_no_api_key(self):
         c = JQuantsAsyncClient(api_key="", plan="free")
         assert c.has_api_key is False
@@ -151,6 +155,31 @@ class TestGetPaginated:
         ]
         result = await client.get_paginated("/equities/master", max_pages=2)
         assert len(result) == 2
+        await client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_paginated_with_meta_returns_external_call_count(self, client):
+        route = respx.get("https://api.jquants.com/v2/equities/master")
+        route.side_effect = [
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"Code": "7203"}],
+                    "pagination_key": "page2",
+                },
+            ),
+            httpx.Response(
+                200,
+                json={"data": [{"Code": "6758"}]},
+            ),
+        ]
+
+        rows, call_count = await client.get_paginated_with_meta("/equities/master")
+
+        assert len(rows) == 2
+        assert call_count == 2
+        assert route.call_count == 2
         await client.close()
 
 

--- a/apps/bt/tests/unit/server/services/test_jquants_bulk_service.py
+++ b/apps/bt/tests/unit/server/services/test_jquants_bulk_service.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.application.services import jquants_bulk_service as bulk_module
+from src.application.services.jquants_bulk_service import JQuantsBulkService, _parse_date
+
+
+def _gzip_csv_bytes(rows: list[dict[str, Any]]) -> bytes:
+    if not rows:
+        return b""
+    buffer = io.BytesIO()
+    with gzip.open(buffer, mode="wt", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    return buffer.getvalue()
+
+
+async def _noop_downloader(_url: str) -> bytes:
+    return b""
+
+
+class _BulkClient:
+    def __init__(
+        self,
+        *,
+        list_payload: list[dict[str, Any]],
+        signed_urls: dict[str, str],
+        list_response: dict[str, Any] | None = None,
+        bulk_get_payloads: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        self._list_payload = list_payload
+        self._signed_urls = signed_urls
+        self._list_response = list_response
+        self._bulk_get_payloads = bulk_get_payloads or {}
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append((path, params))
+        if path == "/bulk/list":
+            if self._list_response is not None:
+                return dict(self._list_response)
+            return {"data": self._list_payload}
+        if path == "/bulk/get":
+            key = str((params or {}).get("key") or "")
+            if key in self._bulk_get_payloads:
+                return dict(self._bulk_get_payloads[key])
+            return {"url": self._signed_urls[key]}
+        raise RuntimeError(f"unexpected path: {path}")
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_build_plan_and_cache_reuse(tmp_path: Path) -> None:
+    rows = [{"Code": "72030", "Date": "2026-02-10", "O": "1", "H": "2", "L": "1", "C": "2", "Vo": "1000"}]
+    payload = _gzip_csv_bytes(rows)
+    key = "equities_bars_daily_20260210.csv.gz"
+    client = _BulkClient(
+        list_payload=[{"Key": key, "LastModified": "2026-02-11T00:00:00Z", "Size": len(payload)}],
+        signed_urls={key: "https://signed.local/equities-20260210.csv.gz"},
+    )
+
+    download_calls: list[str] = []
+
+    async def _downloader(url: str) -> bytes:
+        download_calls.append(url)
+        return payload
+
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_downloader,
+    )
+
+    plan = await service.build_plan(
+        endpoint="/equities/bars/daily",
+        exact_dates=["2026-02-10"],
+    )
+    assert len(plan.files) == 1
+    assert plan.estimated_api_calls == 3
+    assert plan.estimated_cache_hits == 0
+    assert plan.estimated_cache_misses == 1
+
+    result_first = await service.fetch_with_plan(plan)
+    assert result_first.api_calls == 2
+    assert result_first.cache_hits == 0
+    assert result_first.cache_misses == 1
+    assert result_first.rows[0]["Code"] == "72030"
+    assert result_first.rows[0]["Date"] == "2026-02-10"
+    assert download_calls == ["https://signed.local/equities-20260210.csv.gz"]
+
+    plan_second = await service.build_plan(
+        endpoint="/equities/bars/daily",
+        exact_dates=["2026-02-10"],
+    )
+    assert plan_second.estimated_cache_hits == 1
+    assert plan_second.estimated_cache_misses == 0
+    assert plan_second.estimated_api_calls == 1
+
+    result_second = await service.fetch_with_plan(plan_second)
+    assert result_second.api_calls == 0
+    assert result_second.cache_hits == 1
+    assert result_second.cache_misses == 0
+    assert download_calls == ["https://signed.local/equities-20260210.csv.gz"]
+    assert len([call for call in client.calls if call[0] == "/bulk/get"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_selects_monthly_file_by_exact_date(tmp_path: Path) -> None:
+    monthly_key = "fins_summary_historical_202602.csv.gz"
+    daily_key = "fins_summary_live_20260301.csv.gz"
+    client = _BulkClient(
+        list_payload=[
+            {"Key": monthly_key, "LastModified": "2026-03-01T00:00:00Z", "Size": 100},
+            {"Key": daily_key, "LastModified": "2026-03-01T00:00:00Z", "Size": 100},
+        ],
+        signed_urls={monthly_key: "https://signed.local/monthly.csv.gz", daily_key: "https://signed.local/daily.csv.gz"},
+    )
+    async def _never_downloader(_url: str) -> bytes:
+        raise AssertionError("download should not run in plan-only test")
+
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_never_downloader,
+    )
+
+    plan = await service.build_plan(
+        endpoint="/fins/summary",
+        exact_dates=["2026-02-15"],
+    )
+    assert [f.key for f in plan.files] == [monthly_key]
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_wraps_signed_url_download_error(tmp_path: Path) -> None:
+    key = "indices_bars_daily_20260210.csv.gz"
+    payload_rows = [{"Date": "2026-02-10", "Code": "0000", "O": "1", "H": "2", "L": "1", "C": "2"}]
+    payload = _gzip_csv_bytes(payload_rows)
+    client = _BulkClient(
+        list_payload=[{"Key": key, "LastModified": "2026-02-11T00:00:00Z", "Size": len(payload)}],
+        signed_urls={key: "https://signed.local/indices-20260210.csv.gz"},
+    )
+
+    async def _failing_downloader(_url: str) -> bytes:
+        raise RuntimeError("network down")
+
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_failing_downloader,
+    )
+
+    plan = await service.build_plan(endpoint="/indices/bars/daily")
+    with pytest.raises(RuntimeError, match="bulk signed-url download failed"):
+        await service.fetch_with_plan(plan)
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_raises_when_bulk_get_url_is_missing(tmp_path: Path) -> None:
+    key = "indices_bars_daily_20260210.csv.gz"
+    client = _BulkClient(
+        list_payload=[{"Key": key, "LastModified": "2026-02-11T00:00:00Z", "Size": 10}],
+        signed_urls={key: "https://signed.local/unused.csv.gz"},
+        bulk_get_payloads={key: {}},
+    )
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_noop_downloader,
+    )
+
+    plan = await service.build_plan(endpoint="/indices/bars/daily")
+    with pytest.raises(RuntimeError, match="did not return a valid url"):
+        await service.fetch_with_plan(plan)
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_plan_and_fetch_adds_list_call(tmp_path: Path) -> None:
+    key = "equities_bars_daily_20260210.csv.gz"
+    payload = _gzip_csv_bytes([{"Code": "72030", "Date": "2026-02-10", "O": "1", "H": "2", "L": "1", "C": "2", "Vo": "1000"}])
+    client = _BulkClient(
+        list_payload=[{"Key": key, "LastModified": "2026-02-11T00:00:00Z", "Size": len(payload)}],
+        signed_urls={key: "https://signed.local/equities-20260210.csv.gz"},
+    )
+
+    async def _downloader(_url: str) -> bytes:
+        return payload
+
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_downloader,
+    )
+
+    _plan, result = await service.plan_and_fetch(endpoint="/equities/bars/daily")
+    assert result.api_calls == 3  # /bulk/list + /bulk/get + signed-url
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_build_plan_accepts_files_key_payload(tmp_path: Path) -> None:
+    monthly_key = "fins_summary_historical_202602.csv.gz"
+    client = _BulkClient(
+        list_payload=[],
+        signed_urls={},
+        list_response={"files": [{"Key": monthly_key, "LastModified": "2026-03-01T00:00:00Z", "Size": "abc"}]},
+    )
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_noop_downloader,
+    )
+
+    plan = await service.build_plan(endpoint="/fins/summary", date_from="2026-02-01", date_to="2026-02-28")
+    assert [f.key for f in plan.files] == [monthly_key]
+    assert plan.files[0].size == 0
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_select_files_includes_unknown_range_for_safety(tmp_path: Path) -> None:
+    unknown_key = "fins_summary_live_latest.csv.gz"
+    out_of_range_key = "fins_summary_historical_202601.csv.gz"
+    client = _BulkClient(
+        list_payload=[
+            {"Key": unknown_key, "LastModified": "2026-03-01T00:00:00Z", "Size": 1},
+            {"Key": out_of_range_key, "LastModified": "2026-03-01T00:00:00Z", "Size": 1},
+        ],
+        signed_urls={},
+    )
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=lambda _url: b"",  # type: ignore[arg-type]
+    )
+
+    plan = await service.build_plan(endpoint="/fins/summary", date_from="2026-02-01", date_to="2026-02-28")
+    assert [f.key for f in plan.files] == [unknown_key]
+
+
+def test_bulk_service_cache_meta_invalid_json_and_non_dict(tmp_path: Path) -> None:
+    client = _BulkClient(list_payload=[], signed_urls={})
+    service = JQuantsBulkService(client, cache_dir=tmp_path / "bulk-cache", downloader=_noop_downloader)  # type: ignore[arg-type]
+    key = "equities_bars_daily_20260210.csv.gz"
+    meta_path = service._meta_cache_path(key)
+
+    meta_path.write_text("{not-json", encoding="utf-8")
+    assert service._read_cache_meta(key) is None
+
+    meta_path.write_text("[]", encoding="utf-8")
+    assert service._read_cache_meta(key) is None
+
+
+def test_parse_date_helper_supports_both_formats() -> None:
+    assert _parse_date("2026-02-10")
+    assert _parse_date("20260210")
+    assert _parse_date("") is None
+    assert _parse_date("not-a-date") is None
+
+
+@pytest.mark.asyncio
+async def test_bulk_service_download_bytes_records_metrics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Response:
+        content = b"ok"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class _AsyncClient:
+        async def __aenter__(self) -> "_AsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+        async def get(self, url: str) -> _Response:
+            assert url == "https://signed.local/file.csv.gz"
+            return _Response()
+
+    client = _BulkClient(list_payload=[], signed_urls={})
+    service = JQuantsBulkService(client, cache_dir=tmp_path / "bulk-cache", downloader=_noop_downloader)  # type: ignore[arg-type]
+
+    recorder = MagicMock()
+    monkeypatch.setattr(bulk_module, "metrics_recorder", recorder)
+    monkeypatch.setattr(bulk_module.httpx, "AsyncClient", lambda timeout=60.0: _AsyncClient())
+
+    data = await service._download_bytes("https://signed.local/file.csv.gz")
+    assert data == b"ok"
+    recorder.record_jquants_fetch.assert_called_once_with("/bulk/download")

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from src.application.services.jquants_bulk_service import BulkFetchPlan, BulkFetchResult
 from src.infrastructure.db.market.market_db import METADATA_KEYS
 from src.infrastructure.db.market.time_series_store import TimeSeriesInspection
 from src.application.services.sync_strategies import (
@@ -15,6 +16,7 @@ from src.application.services.sync_strategies import (
     IndicesOnlySyncStrategy,
     InitialSyncStrategy,
     SyncContext,
+    _StageFetchDecision,
     _build_fallback_index_master_rows,
     _build_incremental_date_targets,
     _collect_unique_codes,
@@ -503,6 +505,37 @@ class IndicesOnlyClient:
         ]
 
 
+class _FakeBulkService:
+    def __init__(
+        self,
+        *,
+        results_by_endpoint: dict[str, BulkFetchResult] | None = None,
+        fail_endpoints: set[str] | None = None,
+    ) -> None:
+        self.results_by_endpoint = results_by_endpoint or {}
+        self.fail_endpoints = fail_endpoints or set()
+        self.fetch_calls: list[str] = []
+
+    async def fetch_with_plan(self, plan: BulkFetchPlan) -> BulkFetchResult:
+        self.fetch_calls.append(plan.endpoint)
+        if plan.endpoint in self.fail_endpoints:
+            raise RuntimeError("bulk failed")
+        result = self.results_by_endpoint.get(plan.endpoint)
+        if result is None:
+            return BulkFetchResult(rows=[], api_calls=0, cache_hits=0, cache_misses=0, selected_files=0)
+        return result
+
+
+def _rest_decision(estimated_rest_calls: int) -> _StageFetchDecision:
+    return _StageFetchDecision(
+        method="rest",
+        planner_api_calls=0,
+        estimated_rest_calls=estimated_rest_calls,
+        estimated_bulk_calls=None,
+        plan=None,
+    )
+
+
 @pytest.fixture(autouse=True)
 def patch_small_index_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
     def _seed_rows(*, existing_codes: set[str] | None = None) -> list[dict[str, str | None]]:
@@ -640,6 +673,42 @@ async def test_incremental_sync_uses_timeseries_inspection_anchor_when_sqlite_is
 
 
 @pytest.mark.asyncio
+async def test_incremental_sync_bootstraps_when_timeseries_store_is_empty() -> None:
+    market_db = DummyMarketDb(
+        latest_trading_date="20260206",
+        latest_stock_data_date="20260206",
+        latest_indices_data_dates={"0000": "20260206"},
+    )
+    client = DummyClient()
+    store = DummyTimeSeriesStore(
+        market_db=market_db,
+        inspection=TimeSeriesInspection(
+            source="duckdb-parquet",
+            topix_count=0,
+            stock_count=0,
+            indices_count=0,
+            latest_indices_dates={},
+        ),
+    )
+
+    ctx = SyncContext(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        time_series_store=store,  # type: ignore[arg-type]
+    )
+
+    result = await IncrementalSyncStrategy().execute(ctx)
+
+    assert result.success
+    topix_calls = [c for c in client.calls if c[0] == "/indices/bars/daily/topix"]
+    assert topix_calls
+    assert topix_calls[0][1] == {}
+    assert any(path == "/equities/bars/daily" and params == {"date": "2026-02-06"} for path, params in client.calls)
+
+
+@pytest.mark.asyncio
 async def test_incremental_sync_skips_rows_with_missing_ohlcv() -> None:
     market_db = DummyMarketDb(latest_trading_date="20260206")
     client = DummyClient(
@@ -713,6 +782,82 @@ async def test_incremental_sync_supplements_indices_with_date_based_discovery() 
     assert any(path == "/indices/bars/daily" and params == {"date": "20260210"} for path, params in client.calls)
     assert any(row["code"] == "0040" for row in market_db.indices_rows)
     assert any(row["date"] == "2026-02-10" for row in market_db.indices_rows)
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_indices_bulk_result_matches_rest_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    indices_quotes = [
+        {"Date": "2026-02-10", "Code": "40", "O": 102, "H": 103, "L": 101, "C": 102, "SectorName": "TOPIX"},
+    ]
+
+    rest_market_db = DummyMarketDb(latest_trading_date="20260206")
+    rest_client = DummyClient(indices_quotes=indices_quotes)
+    rest_ctx = SyncContext(
+        client=rest_client,  # type: ignore[arg-type]
+        market_db=rest_market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+    )
+    rest_result = await IncrementalSyncStrategy().execute(rest_ctx)
+    assert rest_result.success
+    rest_keys = {(str(row["code"]), str(row["date"])) for row in rest_market_db.indices_rows}
+
+    bulk_market_db = DummyMarketDb(latest_trading_date="20260206")
+    bulk_client = DummyClient(indices_quotes=indices_quotes)
+    bulk_plan = BulkFetchPlan(
+        endpoint="/indices/bars/daily",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=3,
+        estimated_cache_hits=0,
+        estimated_cache_misses=1,
+    )
+    bulk_service = _FakeBulkService(
+        results_by_endpoint={
+            "/indices/bars/daily": BulkFetchResult(
+                rows=indices_quotes,
+                api_calls=2,
+                cache_hits=0,
+                cache_misses=1,
+                selected_files=1,
+            )
+        }
+    )
+
+    async def _plan_stub(
+        _ctx: SyncContext,
+        *,
+        stage: str,
+        endpoint: str,
+        estimated_rest_calls: int,
+        **_kwargs: Any,
+    ) -> _StageFetchDecision:
+        if stage == "indices_incremental":
+            return _StageFetchDecision(
+                method="bulk",
+                planner_api_calls=0,
+                estimated_rest_calls=estimated_rest_calls,
+                estimated_bulk_calls=3,
+                plan=bulk_plan,
+            )
+        return _rest_decision(estimated_rest_calls)
+
+    monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
+
+    bulk_ctx = SyncContext(
+        client=bulk_client,  # type: ignore[arg-type]
+        market_db=bulk_market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        bulk_service=bulk_service,  # type: ignore[arg-type]
+    )
+    bulk_result = await IncrementalSyncStrategy().execute(bulk_ctx)
+    assert bulk_result.success
+    bulk_keys = {(str(row["code"]), str(row["date"])) for row in bulk_market_db.indices_rows}
+
+    assert bulk_keys == rest_keys
 
 
 @pytest.mark.asyncio
@@ -1024,6 +1169,132 @@ async def test_initial_sync_success_path_without_failed_dates() -> None:
 
 
 @pytest.mark.asyncio
+async def test_initial_sync_stock_data_uses_bulk_when_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    topix_dates = [f"2026-02-{day:02d}" for day in range(10, 14)]
+    market_db = DummyMarketDb()
+    client = InitialSyncClient(topix_dates=topix_dates)
+    bulk_service = _FakeBulkService(
+        results_by_endpoint={
+            "/equities/bars/daily": BulkFetchResult(
+                rows=[
+                    {"Code": "72030", "Date": value, "O": 1, "H": 2, "L": 1, "C": 2, "Vo": 1000}
+                    for value in topix_dates
+                ],
+                api_calls=2,
+                cache_hits=0,
+                cache_misses=1,
+                selected_files=1,
+            )
+        }
+    )
+    bulk_plan = BulkFetchPlan(
+        endpoint="/equities/bars/daily",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=3,
+        estimated_cache_hits=0,
+        estimated_cache_misses=1,
+    )
+
+    async def _plan_stub(
+        _ctx: SyncContext,
+        *,
+        stage: str,
+        endpoint: str,
+        estimated_rest_calls: int,
+        **_kwargs: Any,
+    ) -> _StageFetchDecision:
+        if stage == "stock_data_initial":
+            return _StageFetchDecision(
+                method="bulk",
+                planner_api_calls=0,
+                estimated_rest_calls=estimated_rest_calls,
+                estimated_bulk_calls=3,
+                plan=bulk_plan,
+            )
+        return _rest_decision(estimated_rest_calls)
+
+    monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
+    monkeypatch.setattr(
+        "src.application.services.sync_strategies._get_bulk_service",
+        lambda _ctx: bulk_service,
+    )
+
+    ctx = SyncContext(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+    )
+
+    result = await InitialSyncStrategy().execute(ctx)
+
+    assert result.success
+    assert "/equities/bars/daily" in bulk_service.fetch_calls
+    daily_calls = [call for call in client.calls if call[0] == "/equities/bars/daily"]
+    assert daily_calls == []
+    assert result.stocksUpdated == len(topix_dates)
+
+
+@pytest.mark.asyncio
+async def test_initial_sync_stock_data_bulk_failure_falls_back_to_rest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    topix_dates = [f"2026-02-{day:02d}" for day in range(10, 13)]
+    market_db = DummyMarketDb()
+    client = InitialSyncClient(topix_dates=topix_dates)
+    bulk_service = _FakeBulkService(fail_endpoints={"/equities/bars/daily"})
+    bulk_plan = BulkFetchPlan(
+        endpoint="/equities/bars/daily",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=3,
+        estimated_cache_hits=0,
+        estimated_cache_misses=1,
+    )
+
+    async def _plan_stub(
+        _ctx: SyncContext,
+        *,
+        stage: str,
+        endpoint: str,
+        estimated_rest_calls: int,
+        **_kwargs: Any,
+    ) -> _StageFetchDecision:
+        if stage == "stock_data_initial":
+            return _StageFetchDecision(
+                method="bulk",
+                planner_api_calls=0,
+                estimated_rest_calls=estimated_rest_calls,
+                estimated_bulk_calls=3,
+                plan=bulk_plan,
+            )
+        return _rest_decision(estimated_rest_calls)
+
+    monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
+    monkeypatch.setattr(
+        "src.application.services.sync_strategies._get_bulk_service",
+        lambda _ctx: bulk_service,
+    )
+
+    ctx = SyncContext(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+    )
+
+    result = await InitialSyncStrategy().execute(ctx)
+
+    assert result.success
+    daily_calls = [call for call in client.calls if call[0] == "/equities/bars/daily"]
+    assert len(daily_calls) == len(topix_dates)
+    assert "/equities/bars/daily" in bulk_service.fetch_calls
+
+
+@pytest.mark.asyncio
 async def test_initial_sync_with_empty_topix_and_empty_master() -> None:
     market_db = DummyMarketDb()
     client = InitialSyncClient(topix_dates=[], master_rows=[])
@@ -1296,6 +1567,110 @@ async def test_incremental_sync_fundamentals_date_and_missing_prime_backfill(
     assert "9999" not in {row["code"] for row in market_db.statements_rows}
     fins_calls = [call for call in client.calls if call[0] == "/fins/summary"]
     assert any((params or {}).get("date") == "20260210" for _, params in fins_calls)
+    assert any((params or {}).get("code") == "67580" for _, params in fins_calls)
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_fundamentals_bulk_date_phase_keeps_code_backfill_equivalent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    market_db = DummyMarketDb(latest_trading_date="20260206")
+    market_db.metadata[METADATA_KEYS["FUNDAMENTALS_LAST_DISCLOSED_DATE"]] = "2026-02-09"
+    market_db.statements_rows = [{"code": "7203", "disclosed_date": "2026-02-09"}]
+
+    client = DummyClient(
+        master_quotes=[
+            {
+                "Code": "72030",
+                "CoName": "トヨタ自動車",
+                "Mkt": "0111",
+                "MktNm": "プライム",
+                "S17": "6",
+                "S17Nm": "輸送用機器",
+                "S33": "3700",
+                "S33Nm": "輸送用機器",
+                "Date": "1949-05-16",
+            },
+            {
+                "Code": "67580",
+                "CoName": "ソニーグループ",
+                "Mkt": "0111",
+                "MktNm": "プライム",
+                "S17": "6",
+                "S17Nm": "輸送用機器",
+                "S33": "3700",
+                "S33Nm": "輸送用機器",
+                "Date": "1958-12-01",
+            },
+        ],
+        fins_by_code={
+            "67580": [{"Code": "67580", "DiscDate": "2026-02-10", "EPS": 80.0}],
+        },
+    )
+    bulk_service = _FakeBulkService(
+        results_by_endpoint={
+            "/fins/summary": BulkFetchResult(
+                rows=[
+                    {"Code": "72030", "DiscDate": "2026-02-10", "EPS": 110.0},
+                    {"Code": "99990", "DiscDate": "2026-02-10", "EPS": 90.0},
+                ],
+                api_calls=2,
+                cache_hits=0,
+                cache_misses=1,
+                selected_files=1,
+            )
+        }
+    )
+    bulk_plan = BulkFetchPlan(
+        endpoint="/fins/summary",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=3,
+        estimated_cache_hits=0,
+        estimated_cache_misses=1,
+    )
+
+    monkeypatch.setattr(
+        "src.application.services.sync_strategies._build_incremental_date_targets",
+        lambda _anchor, _retry: ["2026-02-10"],
+    )
+
+    async def _plan_stub(
+        _ctx: SyncContext,
+        *,
+        stage: str,
+        endpoint: str,
+        estimated_rest_calls: int,
+        **_kwargs: Any,
+    ) -> _StageFetchDecision:
+        if stage == "fundamentals_incremental_dates":
+            return _StageFetchDecision(
+                method="bulk",
+                planner_api_calls=0,
+                estimated_rest_calls=estimated_rest_calls,
+                estimated_bulk_calls=3,
+                plan=bulk_plan,
+            )
+        return _rest_decision(estimated_rest_calls)
+
+    monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
+
+    ctx = SyncContext(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        bulk_service=bulk_service,  # type: ignore[arg-type]
+    )
+
+    result = await IncrementalSyncStrategy().execute(ctx)
+
+    assert result.success
+    assert result.fundamentalsDatesProcessed == 1
+    assert {"7203", "6758"} <= {row["code"] for row in market_db.statements_rows}
+    assert "9999" not in {row["code"] for row in market_db.statements_rows}
+    fins_calls = [call for call in client.calls if call[0] == "/fins/summary"]
+    assert not any((params or {}).get("date") == "20260210" for _, params in fins_calls)
     assert any((params or {}).get("code") == "67580" for _, params in fins_calls)
 
 


### PR DESCRIPTION
## Summary
- add bulk list/get + signed-url CSV(gzip) fetch service with local cache reuse
- extend JQuants async client with normalized plan and paginated call-count API
- implement stage-level Bulk+REST planner in initial/incremental/indices-only sync flows
- add incremental cold-start bootstrap and stage fallback behavior
- add sync_fetch_strategy structured execution logs for estimated vs actual request counts
- add and expand tests for sync strategies, bulk service, and jquants client
- update AGENTS.md and bt-market-sync-strategies skill docs

## Validation
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_sync_strategies.py
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_jquants_bulk_service.py
- uv run --project apps/bt pytest apps/bt/tests/unit/server/clients/test_jquants_client.py
- uv run --project apps/bt pytest apps/bt/tests/unit/server/test_routes_db_sync.py
- uv run --project apps/bt ruff check apps/bt/src/application/services apps/bt/src/infrastructure/external_api/clients
- uv run --project apps/bt pyright apps/bt/src/application/services apps/bt/src/infrastructure/external_api/clients