### PR TITLE
fix(bt): prevent intermittent 500 during market sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `GET /api/db/stats` / `GET /api/db/validate` の時系列スナップショット SoT は DuckDB inspection（`timeSeriesSource` を返却）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
 - `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
+- DuckDB time-series store は `publish/index/inspect/close` をプロセス内ロックで直列化し、sync 実行と `/api/db/stats` `/api/db/validate` 参照の同時実行による 500 を防止する
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする

--- a/apps/bt/src/infrastructure/db/market/time_series_store.py
+++ b/apps/bt/src/infrastructure/db/market/time_series_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from threading import RLock
 from typing import Any, Protocol, cast
 
 from loguru import logger
@@ -120,86 +121,89 @@ class DuckDbParquetTimeSeriesStore:
             ) from exc
 
         self._conn = duckdb.connect(str(self._duckdb_path))
+        # app state で共有されるため、sync 書き込みと stats/validate 読み取りを直列化する。
+        self._lock = RLock()
         self._dirty_tables: set[str] = set()
         self._ensure_schema()
 
     def _ensure_schema(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS topix_data (
-                date TEXT PRIMARY KEY,
-                open DOUBLE,
-                high DOUBLE,
-                low DOUBLE,
-                close DOUBLE,
-                created_at TEXT
+        with self._lock:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS topix_data (
+                    date TEXT PRIMARY KEY,
+                    open DOUBLE,
+                    high DOUBLE,
+                    low DOUBLE,
+                    close DOUBLE,
+                    created_at TEXT
+                )
+                """
             )
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS stock_data (
-                code TEXT,
-                date TEXT,
-                open DOUBLE,
-                high DOUBLE,
-                low DOUBLE,
-                close DOUBLE,
-                volume BIGINT,
-                adjustment_factor DOUBLE,
-                created_at TEXT,
-                PRIMARY KEY (code, date)
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS stock_data (
+                    code TEXT,
+                    date TEXT,
+                    open DOUBLE,
+                    high DOUBLE,
+                    low DOUBLE,
+                    close DOUBLE,
+                    volume BIGINT,
+                    adjustment_factor DOUBLE,
+                    created_at TEXT,
+                    PRIMARY KEY (code, date)
+                )
+                """
             )
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS indices_data (
-                code TEXT,
-                date TEXT,
-                open DOUBLE,
-                high DOUBLE,
-                low DOUBLE,
-                close DOUBLE,
-                sector_name TEXT,
-                created_at TEXT,
-                PRIMARY KEY (code, date)
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS indices_data (
+                    code TEXT,
+                    date TEXT,
+                    open DOUBLE,
+                    high DOUBLE,
+                    low DOUBLE,
+                    close DOUBLE,
+                    sector_name TEXT,
+                    created_at TEXT,
+                    PRIMARY KEY (code, date)
+                )
+                """
             )
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS statements (
-                code TEXT,
-                disclosed_date TEXT,
-                earnings_per_share DOUBLE,
-                profit DOUBLE,
-                equity DOUBLE,
-                type_of_current_period TEXT,
-                type_of_document TEXT,
-                next_year_forecast_earnings_per_share DOUBLE,
-                bps DOUBLE,
-                sales DOUBLE,
-                operating_profit DOUBLE,
-                ordinary_profit DOUBLE,
-                operating_cash_flow DOUBLE,
-                dividend_fy DOUBLE,
-                forecast_dividend_fy DOUBLE,
-                next_year_forecast_dividend_fy DOUBLE,
-                payout_ratio DOUBLE,
-                forecast_payout_ratio DOUBLE,
-                next_year_forecast_payout_ratio DOUBLE,
-                forecast_eps DOUBLE,
-                investing_cash_flow DOUBLE,
-                financing_cash_flow DOUBLE,
-                cash_and_equivalents DOUBLE,
-                total_assets DOUBLE,
-                shares_outstanding DOUBLE,
-                treasury_shares DOUBLE,
-                PRIMARY KEY (code, disclosed_date)
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS statements (
+                    code TEXT,
+                    disclosed_date TEXT,
+                    earnings_per_share DOUBLE,
+                    profit DOUBLE,
+                    equity DOUBLE,
+                    type_of_current_period TEXT,
+                    type_of_document TEXT,
+                    next_year_forecast_earnings_per_share DOUBLE,
+                    bps DOUBLE,
+                    sales DOUBLE,
+                    operating_profit DOUBLE,
+                    ordinary_profit DOUBLE,
+                    operating_cash_flow DOUBLE,
+                    dividend_fy DOUBLE,
+                    forecast_dividend_fy DOUBLE,
+                    next_year_forecast_dividend_fy DOUBLE,
+                    payout_ratio DOUBLE,
+                    forecast_payout_ratio DOUBLE,
+                    next_year_forecast_payout_ratio DOUBLE,
+                    forecast_eps DOUBLE,
+                    investing_cash_flow DOUBLE,
+                    financing_cash_flow DOUBLE,
+                    cash_and_equivalents DOUBLE,
+                    total_assets DOUBLE,
+                    shares_outstanding DOUBLE,
+                    treasury_shares DOUBLE,
+                    PRIMARY KEY (code, disclosed_date)
+                )
+                """
             )
-            """
-        )
 
     def publish_topix_data(self, rows: list[dict[str, Any]]) -> int:
         if not rows:
@@ -215,20 +219,21 @@ class DuckDbParquetTimeSeriesStore:
             )
             for row in rows
         ]
-        self._conn.executemany(
-            """
-            INSERT INTO topix_data (date, open, high, low, close, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT (date) DO UPDATE
-            SET open = excluded.open,
-                high = excluded.high,
-                low = excluded.low,
-                close = excluded.close,
-                created_at = excluded.created_at
-            """,
-            values,
-        )
-        self._dirty_tables.add("topix_data")
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO topix_data (date, open, high, low, close, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (date) DO UPDATE
+                SET open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    created_at = excluded.created_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("topix_data")
         return len(rows)
 
     def publish_stock_data(self, rows: list[dict[str, Any]]) -> int:
@@ -248,23 +253,24 @@ class DuckDbParquetTimeSeriesStore:
             )
             for row in rows
         ]
-        self._conn.executemany(
-            """
-            INSERT INTO stock_data
-                (code, date, open, high, low, close, volume, adjustment_factor, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (code, date) DO UPDATE
-            SET open = excluded.open,
-                high = excluded.high,
-                low = excluded.low,
-                close = excluded.close,
-                volume = excluded.volume,
-                adjustment_factor = excluded.adjustment_factor,
-                created_at = excluded.created_at
-            """,
-            values,
-        )
-        self._dirty_tables.add("stock_data")
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO stock_data
+                    (code, date, open, high, low, close, volume, adjustment_factor, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (code, date) DO UPDATE
+                SET open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    volume = excluded.volume,
+                    adjustment_factor = excluded.adjustment_factor,
+                    created_at = excluded.created_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("stock_data")
         return len(rows)
 
     def publish_indices_data(self, rows: list[dict[str, Any]]) -> int:
@@ -283,22 +289,23 @@ class DuckDbParquetTimeSeriesStore:
             )
             for row in rows
         ]
-        self._conn.executemany(
-            """
-            INSERT INTO indices_data
-                (code, date, open, high, low, close, sector_name, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (code, date) DO UPDATE
-            SET open = excluded.open,
-                high = excluded.high,
-                low = excluded.low,
-                close = excluded.close,
-                sector_name = excluded.sector_name,
-                created_at = excluded.created_at
-            """,
-            values,
-        )
-        self._dirty_tables.add("indices_data")
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO indices_data
+                    (code, date, open, high, low, close, sector_name, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (code, date) DO UPDATE
+                SET open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    sector_name = excluded.sector_name,
+                    created_at = excluded.created_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("indices_data")
         return len(rows)
 
     def publish_statements(self, rows: list[dict[str, Any]]) -> int:
@@ -327,8 +334,9 @@ class DuckDbParquetTimeSeriesStore:
             tuple(row.get(column) for column in insert_columns)
             for row in rows
         ]
-        self._conn.executemany(sql, values)
-        self._dirty_tables.add("statements")
+        with self._lock:
+            self._conn.executemany(sql, values)
+            self._dirty_tables.add("statements")
         return len(rows)
 
     def index_topix_data(self) -> None:
@@ -349,112 +357,113 @@ class DuckDbParquetTimeSeriesStore:
         missing_stock_dates_limit: int = 0,
         statement_non_null_columns: list[str] | None = None,
     ) -> TimeSeriesInspection:
-        topix_row_raw = self._conn.execute(
-            "SELECT COUNT(*) AS count, MIN(date) AS min_date, MAX(date) AS max_date FROM topix_data"
-        ).fetchone()
-        stock_row_raw = self._conn.execute(
-            """
-            SELECT
-                COUNT(*) AS count,
-                MIN(date) AS min_date,
-                MAX(date) AS max_date,
-                COUNT(DISTINCT date) AS date_count
-            FROM stock_data
-            """
-        ).fetchone()
-        indices_row_raw = self._conn.execute(
-            """
-            SELECT
-                COUNT(*) AS count,
-                MIN(date) AS min_date,
-                MAX(date) AS max_date,
-                COUNT(DISTINCT date) AS date_count
-            FROM indices_data
-            """
-        ).fetchone()
-        indices_rows = self._conn.execute(
-            """
-            SELECT code, MAX(date) AS max_date
-            FROM indices_data
-            GROUP BY code
-            """
-        ).fetchall()
-        statements_row_raw = self._conn.execute(
-            """
-            SELECT
-                COUNT(*) AS count,
-                MAX(disclosed_date) AS max_disclosed
-            FROM statements
-            """
-        ).fetchone()
-        missing_count_row = self._conn.execute(
-            """
-            SELECT COUNT(*)
-            FROM topix_data t
-            LEFT JOIN (SELECT DISTINCT date FROM stock_data) s ON t.date = s.date
-            WHERE s.date IS NULL
-            """
-        ).fetchone()
-        statement_codes_rows = self._conn.execute(
-            "SELECT DISTINCT code FROM statements WHERE code IS NOT NULL"
-        ).fetchall()
-        topix_row = topix_row_raw if topix_row_raw is not None else (0, None, None)
-        stock_row = stock_row_raw if stock_row_raw is not None else (0, None, None, 0)
-        indices_row = indices_row_raw if indices_row_raw is not None else (0, None, None, 0)
-        statements_row = statements_row_raw if statements_row_raw is not None else (0, None)
-        missing_stock_dates_count = int(missing_count_row[0] or 0) if missing_count_row else 0
-
-        missing_stock_dates: list[str] = []
-        if missing_stock_dates_limit > 0:
-            missing_rows = self._conn.execute(
+        with self._lock:
+            topix_row_raw = self._conn.execute(
+                "SELECT COUNT(*) AS count, MIN(date) AS min_date, MAX(date) AS max_date FROM topix_data"
+            ).fetchone()
+            stock_row_raw = self._conn.execute(
                 """
-                SELECT t.date
+                SELECT
+                    COUNT(*) AS count,
+                    MIN(date) AS min_date,
+                    MAX(date) AS max_date,
+                    COUNT(DISTINCT date) AS date_count
+                FROM stock_data
+                """
+            ).fetchone()
+            indices_row_raw = self._conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS count,
+                    MIN(date) AS min_date,
+                    MAX(date) AS max_date,
+                    COUNT(DISTINCT date) AS date_count
+                FROM indices_data
+                """
+            ).fetchone()
+            indices_rows = self._conn.execute(
+                """
+                SELECT code, MAX(date) AS max_date
+                FROM indices_data
+                GROUP BY code
+                """
+            ).fetchall()
+            statements_row_raw = self._conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS count,
+                    MAX(disclosed_date) AS max_disclosed
+                FROM statements
+                """
+            ).fetchone()
+            missing_count_row = self._conn.execute(
+                """
+                SELECT COUNT(*)
                 FROM topix_data t
                 LEFT JOIN (SELECT DISTINCT date FROM stock_data) s ON t.date = s.date
                 WHERE s.date IS NULL
-                ORDER BY t.date DESC
-                LIMIT ?
-                """,
-                [missing_stock_dates_limit],
+                """
+            ).fetchone()
+            statement_codes_rows = self._conn.execute(
+                "SELECT DISTINCT code FROM statements WHERE code IS NOT NULL"
             ).fetchall()
-            missing_stock_dates = [str(row[0]) for row in missing_rows if row and row[0]]
+            topix_row = topix_row_raw if topix_row_raw is not None else (0, None, None)
+            stock_row = stock_row_raw if stock_row_raw is not None else (0, None, None, 0)
+            indices_row = indices_row_raw if indices_row_raw is not None else (0, None, None, 0)
+            statements_row = statements_row_raw if statements_row_raw is not None else (0, None)
+            missing_stock_dates_count = int(missing_count_row[0] or 0) if missing_count_row else 0
 
-        statement_non_null_counts = self._duckdb_statement_non_null_counts(
-            statement_non_null_columns or []
-        )
+            missing_stock_dates: list[str] = []
+            if missing_stock_dates_limit > 0:
+                missing_rows = self._conn.execute(
+                    """
+                    SELECT t.date
+                    FROM topix_data t
+                    LEFT JOIN (SELECT DISTINCT date FROM stock_data) s ON t.date = s.date
+                    WHERE s.date IS NULL
+                    ORDER BY t.date DESC
+                    LIMIT ?
+                    """,
+                    [missing_stock_dates_limit],
+                ).fetchall()
+                missing_stock_dates = [str(row[0]) for row in missing_rows if row and row[0]]
 
-        latest_indices_dates = {
-            str(row[0]): str(row[1])
-            for row in indices_rows
-            if row and row[0] and row[1]
-        }
-        statement_codes = {
-            str(row[0])
-            for row in statement_codes_rows
-            if row and row[0]
-        }
+            statement_non_null_counts = self._duckdb_statement_non_null_counts(
+                statement_non_null_columns or []
+            )
 
-        return TimeSeriesInspection(
-            source="duckdb-parquet",
-            topix_count=int(topix_row[0] or 0),
-            topix_min=cast(str | None, topix_row[1]),
-            topix_max=cast(str | None, topix_row[2]),
-            stock_count=int(stock_row[0] or 0),
-            stock_min=cast(str | None, stock_row[1]),
-            stock_max=cast(str | None, stock_row[2]),
-            stock_date_count=int(stock_row[3] or 0),
-            missing_stock_dates=missing_stock_dates,
-            missing_stock_dates_count=missing_stock_dates_count,
-            indices_count=int(indices_row[0] or 0),
-            indices_min=cast(str | None, indices_row[1]),
-            indices_max=cast(str | None, indices_row[2]),
-            indices_date_count=int(indices_row[3] or 0),
-            latest_indices_dates=latest_indices_dates,
-            statements_count=int(statements_row[0] or 0),
-            latest_statement_disclosed_date=cast(str | None, statements_row[1]),
-            statement_codes=statement_codes,
-            statement_non_null_counts=statement_non_null_counts,
-        )
+            latest_indices_dates = {
+                str(row[0]): str(row[1])
+                for row in indices_rows
+                if row and row[0] and row[1]
+            }
+            statement_codes = {
+                str(row[0])
+                for row in statement_codes_rows
+                if row and row[0]
+            }
+
+            return TimeSeriesInspection(
+                source="duckdb-parquet",
+                topix_count=int(topix_row[0] or 0),
+                topix_min=cast(str | None, topix_row[1]),
+                topix_max=cast(str | None, topix_row[2]),
+                stock_count=int(stock_row[0] or 0),
+                stock_min=cast(str | None, stock_row[1]),
+                stock_max=cast(str | None, stock_row[2]),
+                stock_date_count=int(stock_row[3] or 0),
+                missing_stock_dates=missing_stock_dates,
+                missing_stock_dates_count=missing_stock_dates_count,
+                indices_count=int(indices_row[0] or 0),
+                indices_min=cast(str | None, indices_row[1]),
+                indices_max=cast(str | None, indices_row[2]),
+                indices_date_count=int(indices_row[3] or 0),
+                latest_indices_dates=latest_indices_dates,
+                statements_count=int(statements_row[0] or 0),
+                latest_statement_disclosed_date=cast(str | None, statements_row[1]),
+                statement_codes=statement_codes,
+                statement_non_null_counts=statement_non_null_counts,
+            )
 
     def _duckdb_statement_non_null_counts(self, columns: list[str]) -> dict[str, int]:
         if not columns:
@@ -485,24 +494,26 @@ class DuckDbParquetTimeSeriesStore:
         return '"' + identifier.replace('"', '""') + '"'
 
     def _export_if_dirty(self, table_name: str) -> None:
-        if table_name not in self._dirty_tables:
-            return
-        spec = self._TABLE_SPECS[table_name]
-        output_path = self._parquet_dir / spec.parquet_name
-        if output_path.exists():
-            output_path.unlink()
+        with self._lock:
+            if table_name not in self._dirty_tables:
+                return
+            spec = self._TABLE_SPECS[table_name]
+            output_path = self._parquet_dir / spec.parquet_name
+            if output_path.exists():
+                output_path.unlink()
 
-        escaped = str(output_path).replace("'", "''")
-        self._conn.execute(
-            f"COPY (SELECT * FROM {spec.table_name} ORDER BY {spec.order_by}) "
-            f"TO '{escaped}' (FORMAT PARQUET)"
-        )
-        self._dirty_tables.discard(table_name)
+            escaped = str(output_path).replace("'", "''")
+            self._conn.execute(
+                f"COPY (SELECT * FROM {spec.table_name} ORDER BY {spec.order_by}) "
+                f"TO '{escaped}' (FORMAT PARQUET)"
+            )
+            self._dirty_tables.discard(table_name)
 
     def close(self) -> None:
-        for table_name in list(self._dirty_tables):
-            self._export_if_dirty(table_name)
-        self._conn.close()
+        with self._lock:
+            for table_name in list(self._dirty_tables):
+                self._export_if_dirty(table_name)
+            self._conn.close()
 
 
 def create_time_series_store(

--- a/apps/bt/tests/unit/server/db/test_time_series_store.py
+++ b/apps/bt/tests/unit/server/db/test_time_series_store.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
+from threading import Barrier, Lock, RLock, Thread
+from time import sleep
 
 import pytest
 
-from src.infrastructure.db.market.time_series_store import create_time_series_store
+from src.infrastructure.db.market.time_series_store import (
+    DuckDbParquetTimeSeriesStore,
+    create_time_series_store,
+)
 
 
 def _stock_row() -> dict[str, object]:
@@ -125,3 +131,185 @@ def test_duckdb_store_inspect_reports_core_stats(tmp_path: Path) -> None:
     assert inspection.statement_non_null_counts["unknown_column"] == 0
 
     store.close()
+
+
+class _ResultCursor:
+    def __init__(
+        self,
+        *,
+        one: tuple[object, ...] | None = None,
+        many: list[tuple[object, ...]] | None = None,
+    ) -> None:
+        self._one = one
+        self._many = many or []
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        return self._one
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return list(self._many)
+
+
+class _ConcurrentAccessDetectingConnection:
+    """同時アクセスを検知して例外化するテスト用接続。"""
+
+    def __init__(self) -> None:
+        self._guard = Lock()
+        self.closed = False
+
+    def execute(self, sql: str, params: list[int] | None = None) -> _ResultCursor:
+        del params
+        self._enter_critical()
+        try:
+            return self._cursor_for(sql)
+        finally:
+            self._exit_critical()
+
+    def executemany(self, sql: str, _values: list[tuple[object, ...]]) -> None:
+        del sql
+        self._enter_critical()
+        try:
+            return
+        finally:
+            self._exit_critical()
+
+    def close(self) -> None:
+        self.closed = True
+
+    def _enter_critical(self) -> None:
+        if not self._guard.acquire(blocking=False):
+            raise RuntimeError("concurrent access detected")
+        sleep(0.001)
+
+    def _exit_critical(self) -> None:
+        self._guard.release()
+
+    @staticmethod
+    def _cursor_for(sql: str) -> _ResultCursor:
+        if "FROM topix_data" in sql and "MAX(date)" in sql:
+            return _ResultCursor(one=(0, None, None))
+        if "FROM stock_data" in sql and "COUNT(DISTINCT date)" in sql:
+            return _ResultCursor(one=(0, None, None, 0))
+        if "FROM indices_data" in sql and "COUNT(DISTINCT date)" in sql:
+            return _ResultCursor(one=(0, None, None, 0))
+        if "FROM indices_data" in sql and "GROUP BY code" in sql:
+            return _ResultCursor(many=[])
+        if "FROM statements" in sql and "MAX(disclosed_date)" in sql:
+            return _ResultCursor(one=(0, None))
+        if "LEFT JOIN (SELECT DISTINCT date FROM stock_data)" in sql:
+            return _ResultCursor(one=(0,))
+        if "SELECT DISTINCT code FROM statements" in sql:
+            return _ResultCursor(many=[])
+        if "PRAGMA table_info('statements')" in sql:
+            return _ResultCursor(many=[])
+        if "COPY (SELECT * FROM" in sql:
+            return _ResultCursor()
+        return _ResultCursor()
+
+
+def _build_lock_test_store(tmp_path: Path) -> DuckDbParquetTimeSeriesStore:
+    store = DuckDbParquetTimeSeriesStore.__new__(DuckDbParquetTimeSeriesStore)
+    store._duckdb_path = tmp_path / "market.duckdb"
+    store._parquet_dir = tmp_path / "parquet"
+    store._parquet_dir.mkdir(parents=True, exist_ok=True)
+    store._conn = _ConcurrentAccessDetectingConnection()
+    store._dirty_tables = set()
+    store._lock = RLock()
+    return store
+
+
+def test_duckdb_store_serializes_publish_and_inspect(tmp_path: Path) -> None:
+    store = _build_lock_test_store(tmp_path)
+    barrier = Barrier(3)
+    errors: list[Exception] = []
+
+    row = _stock_row()
+
+    def _publish_worker() -> None:
+        try:
+            barrier.wait(timeout=2)
+            for _ in range(200):
+                store.publish_stock_data([row])
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    def _inspect_worker() -> None:
+        try:
+            barrier.wait(timeout=2)
+            for _ in range(200):
+                store.inspect()
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    publisher = Thread(target=_publish_worker)
+    inspector = Thread(target=_inspect_worker)
+    publisher.start()
+    inspector.start()
+    barrier.wait(timeout=2)
+    publisher.join(timeout=5)
+    inspector.join(timeout=5)
+
+    assert not publisher.is_alive()
+    assert not inspector.is_alive()
+    assert not errors
+
+
+def test_duckdb_store_init_raises_when_duckdb_import_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def _patched_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "duckdb":
+            raise ModuleNotFoundError("No module named 'duckdb'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _patched_import)
+
+    with pytest.raises(RuntimeError, match="duckdb"):
+        DuckDbParquetTimeSeriesStore(
+            duckdb_path=str(tmp_path / "market-timeseries" / "market.duckdb"),
+            parquet_dir=str(tmp_path / "market-timeseries" / "parquet"),
+        )
+
+
+def test_publish_methods_return_zero_for_empty_rows(tmp_path: Path) -> None:
+    store = _build_lock_test_store(tmp_path)
+    assert store.publish_topix_data([]) == 0
+    assert store.publish_stock_data([]) == 0
+    assert store.publish_indices_data([]) == 0
+    assert store.publish_statements([]) == 0
+
+
+def test_export_if_dirty_handles_absent_and_existing_parquet(tmp_path: Path) -> None:
+    store = _build_lock_test_store(tmp_path)
+
+    # dirty でない場合は no-op
+    store._export_if_dirty("topix_data")
+
+    output = store._parquet_dir / "topix_data.parquet"
+    output.write_text("stale")
+    store._dirty_tables.add("topix_data")
+
+    store._export_if_dirty("topix_data")
+
+    assert not output.exists()
+    assert "topix_data" not in store._dirty_tables
+
+
+def test_close_flushes_dirty_tables_and_closes_connection(tmp_path: Path) -> None:
+    store = _build_lock_test_store(tmp_path)
+    (store._parquet_dir / "topix_data.parquet").write_text("stale")
+    store._dirty_tables.add("topix_data")
+
+    store.close()
+
+    assert store._dirty_tables == set()
+    assert store._conn.closed is True


### PR DESCRIPTION
## Summary
- serialize DuckDB time-series access in DuckDbParquetTimeSeriesStore with an in-process lock
- apply locking to publish/index/inspect/close paths to prevent concurrent sync write + stats/validate read races
- add regression tests for concurrent access and edge branches (missing duckdb import, empty publish payload, export/close behavior)
- update AGENTS.md with the DuckDB serialization rule

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt --no-sync ruff check apps/bt/src/infrastructure/db/market/time_series_store.py apps/bt/tests/unit/server/db/test_time_series_store.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt --no-sync pytest apps/bt/tests/unit/server/db/test_time_series_store.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt --no-sync coverage run --branch -m pytest apps/bt/tests/unit/server/db/test_time_series_store.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt --no-sync coverage report -m apps/bt/src/infrastructure/db/market/time_series_store.py (line/branch 100%)
