### PR TITLE
fix(bt): enforce DuckDB-only SoT for market sync/refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `GET /api/db/stats` / `GET /api/db/validate` の時系列スナップショット SoT は DuckDB inspection（`timeSeriesSource` を返却）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
 - `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
+- `/api/db/sync` と `POST /api/db/stocks/refresh` の時系列アンカー判定・publish/index は DuckDB inspection + time-series store を必須 SoT とし、SQLite `market.db` 時系列テーブルへの fallback を禁止する（inspection 失敗時はエラーで停止）
 - DuckDB time-series store は `publish/index/inspect/close` をプロセス内ロックで直列化し、sync 実行と `/api/db/stats` `/api/db/validate` 参照の同時実行による 500 を防止する
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない

--- a/apps/bt/src/application/services/stock_refresh_service.py
+++ b/apps/bt/src/application/services/stock_refresh_service.py
@@ -7,6 +7,7 @@ POST /api/db/stocks/refresh のビジネスロジック。
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 
@@ -14,6 +15,7 @@ from loguru import logger
 
 from src.infrastructure.external_api.clients.jquants_client import JQuantsAsyncClient
 from src.infrastructure.db.market.market_db import METADATA_KEYS, MarketDb
+from src.infrastructure.db.market.time_series_store import MarketTimeSeriesStore
 from src.infrastructure.db.market.query_helpers import expand_stock_code, normalize_stock_code
 from src.entrypoints.http.schemas.db import RefreshResponse, RefreshStockResult
 from src.application.services.stock_data_row_builder import build_stock_data_row
@@ -22,6 +24,7 @@ from src.application.services.stock_data_row_builder import build_stock_data_row
 async def refresh_stocks(
     codes: list[str],
     market_db: MarketDb,
+    time_series_store: MarketTimeSeriesStore,
     jquants_client: JQuantsAsyncClient,
 ) -> RefreshResponse:
     """銘柄データを再取得"""
@@ -31,9 +34,9 @@ async def refresh_stocks(
     errors: list[str] = []
 
     # TOPIX 日付範囲を取得（フィルタ用）
-    topix_range = market_db.get_topix_date_range()
-    min_date = topix_range["min"] if topix_range else None
-    max_date = topix_range["max"] if topix_range else None
+    inspection = await asyncio.to_thread(time_series_store.inspect)
+    min_date = inspection.topix_min
+    max_date = inspection.topix_max
 
     for code in codes:
         normalized = normalize_stock_code(code)
@@ -73,7 +76,10 @@ async def refresh_stocks(
                     normalized,
                 )
 
-            stored = market_db.upsert_stock_data(rows) if rows else 0
+            stored = 0
+            if rows:
+                stored = await asyncio.to_thread(time_series_store.publish_stock_data, rows)
+                await asyncio.to_thread(time_series_store.index_stock_data)
             total_stored += stored
             results.append(RefreshStockResult(
                 code=normalized,

--- a/apps/bt/src/application/services/sync_service.py
+++ b/apps/bt/src/application/services/sync_service.py
@@ -58,6 +58,8 @@ async def start_sync(
     close_time_series_store: bool = False,
 ) -> JobInfo[SyncJobData, SyncProgress, SyncResult] | None:
     """Sync ジョブを作成して開始。アクティブジョブがある場合は None。"""
+    if time_series_store is None:
+        raise RuntimeError("DuckDB time-series store is required for sync")
     market_db.ensure_schema()
     resolved_mode = _resolve_mode(mode, market_db)
     data = SyncJobData(mode=mode, resolved_mode=resolved_mode)

--- a/apps/bt/src/application/services/sync_strategies.py
+++ b/apps/bt/src/application/services/sync_strategies.py
@@ -54,6 +54,7 @@ class SyncContext:
     on_progress: Callable[[str, int, int, str], None]
     time_series_store: MarketTimeSeriesStore | None = None
     bulk_service: JQuantsBulkService | None = None
+    bulk_probe_disabled: bool = False
 
 
 class SyncStrategy(Protocol):
@@ -144,9 +145,8 @@ _BULK_FINS_KEY_ALIASES: dict[str, str] = {
 }
 
 
-def _supports_bulk_sync(client: JQuantsAsyncClient) -> bool:
-    plan = str(getattr(client, "plan", "")).strip().lower()
-    return plan in {"light", "standard", "premium"}
+def _get_plan_hint(client: JQuantsAsyncClient) -> str:
+    return str(getattr(client, "plan", "")).strip().lower()
 
 
 def _get_bulk_service(ctx: SyncContext) -> JQuantsBulkService:
@@ -199,17 +199,19 @@ async def _plan_fetch_method(
     exact_dates: list[str] | None = None,
     min_rest_calls_to_probe_bulk: int = 3,
 ) -> _StageFetchDecision:
-    if not _supports_bulk_sync(ctx.client):
+    if ctx.bulk_probe_disabled:
+        plan_hint = _get_plan_hint(ctx.client)
         logger.info(
             "sync fetch strategy selected",
             event="sync_fetch_strategy",
             stage=stage,
             endpoint=endpoint,
             selected="rest",
-            reason="plan_not_supported",
+            reason="bulk_probe_disabled",
             estimatedRestCalls=estimated_rest_calls,
             estimatedBulkCalls=None,
             plannerApiCalls=0,
+            planHint=plan_hint or None,
         )
         return _StageFetchDecision(
             method="rest",
@@ -220,6 +222,7 @@ async def _plan_fetch_method(
         )
 
     if estimated_rest_calls < min_rest_calls_to_probe_bulk:
+        plan_hint = _get_plan_hint(ctx.client)
         logger.info(
             "sync fetch strategy selected",
             event="sync_fetch_strategy",
@@ -230,6 +233,7 @@ async def _plan_fetch_method(
             estimatedRestCalls=estimated_rest_calls,
             estimatedBulkCalls=None,
             plannerApiCalls=0,
+            planHint=plan_hint or None,
         )
         return _StageFetchDecision(
             method="rest",
@@ -240,12 +244,42 @@ async def _plan_fetch_method(
         )
 
     bulk_service = _get_bulk_service(ctx)
-    plan = await bulk_service.build_plan(
-        endpoint=endpoint,
-        date_from=date_from,
-        date_to=date_to,
-        exact_dates=exact_dates,
-    )
+    plan_hint = _get_plan_hint(ctx.client)
+    try:
+        plan = await bulk_service.build_plan(
+            endpoint=endpoint,
+            date_from=date_from,
+            date_to=date_to,
+            exact_dates=exact_dates,
+        )
+    except Exception as e:
+        # free/unknown plan や一時障害で /bulk/list が失敗した場合は
+        # 同期ジョブ全体を止めず、以降は REST に固定して継続する。
+        ctx.bulk_probe_disabled = True
+        logger.warning(
+            "sync bulk plan probe failed, falling back to REST for this job: {}",
+            e,
+        )
+        logger.info(
+            "sync fetch strategy selected",
+            event="sync_fetch_strategy",
+            stage=stage,
+            endpoint=endpoint,
+            selected="rest",
+            reason="bulk_probe_failed",
+            estimatedRestCalls=estimated_rest_calls,
+            estimatedBulkCalls=None,
+            plannerApiCalls=1,
+            planHint=plan_hint or None,
+        )
+        return _StageFetchDecision(
+            method="rest",
+            planner_api_calls=1,
+            estimated_rest_calls=estimated_rest_calls,
+            estimated_bulk_calls=None,
+            plan=None,
+        )
+
     selected: _FetchMethod = "bulk" if plan.estimated_api_calls < estimated_rest_calls else "rest"
     reason = "bulk_estimate_lower" if selected == "bulk" else "rest_estimate_lower_or_equal"
 
@@ -262,6 +296,7 @@ async def _plan_fetch_method(
         estimatedCacheHits=plan.estimated_cache_hits,
         estimatedCacheMisses=plan.estimated_cache_misses,
         selectedFiles=len(plan.files),
+        planHint=plan_hint or None,
     )
     return _StageFetchDecision(
         method=selected,
@@ -308,11 +343,8 @@ def _normalize_bulk_fins_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]
 
 
 def _is_incremental_cold_start(
-    ctx: SyncContext,
-    inspection: TimeSeriesInspection | None,
+    inspection: TimeSeriesInspection,
 ) -> bool:
-    if inspection is None or ctx.time_series_store is None:
-        return False
     has_anchor_signal = bool(
         inspection.topix_max
         or inspection.stock_max
@@ -723,15 +755,9 @@ class IncrementalSyncStrategy:
             # stock_data が一部日付で取りこぼされると topix_data より遅れる場合があるため、
             # 増分同期の基準日は stock_data の最新日を優先する。
             inspection = _inspect_time_series(ctx)
-            cold_start_bootstrap = _is_incremental_cold_start(ctx, inspection)
-            last_topix_date = (
-                inspection.topix_max if inspection and inspection.topix_max else ctx.market_db.get_latest_trading_date()
-            )
-            last_stock_date = (
-                inspection.stock_max
-                if inspection and inspection.stock_max
-                else ctx.market_db.get_latest_stock_data_date()
-            )
+            cold_start_bootstrap = _is_incremental_cold_start(inspection)
+            last_topix_date = inspection.topix_max
+            last_stock_date = inspection.stock_max
             last_date = last_stock_date or last_topix_date
             if cold_start_bootstrap:
                 logger.info(
@@ -897,11 +923,7 @@ class IncrementalSyncStrategy:
                 return SyncResult(success=False, totalApiCalls=total_calls, errors=["Cancelled"])
 
             known_master_codes = await _seed_index_master_from_catalog(ctx)
-            raw_latest_index_dates = (
-                dict(inspection.latest_indices_dates)
-                if inspection and inspection.latest_indices_dates
-                else ctx.market_db.get_latest_indices_data_dates()
-            )
+            raw_latest_index_dates = dict(inspection.latest_indices_dates)
             latest_index_dates = {
                 _normalize_index_code(code): value
                 for code, value in raw_latest_index_dates.items()
@@ -1626,28 +1648,33 @@ def _build_incremental_date_targets(anchor: str | None, retry_dates: list[str]) 
     return targets
 
 
-def _inspect_time_series(ctx: SyncContext) -> TimeSeriesInspection | None:
+def _require_time_series_store(ctx: SyncContext) -> MarketTimeSeriesStore:
     if ctx.time_series_store is None:
-        return None
+        raise RuntimeError("DuckDB time-series store is required for sync strategy execution")
+    return ctx.time_series_store
+
+
+def _inspect_time_series(ctx: SyncContext) -> TimeSeriesInspection:
+    store = _require_time_series_store(ctx)
     try:
-        return ctx.time_series_store.inspect()
-    except Exception as e:  # noqa: BLE001 - inspection failure should not block sync
-        logger.warning("Failed to inspect time-series store during sync: {}", e)
-        return None
+        inspection = store.inspect()
+    except Exception as e:  # noqa: BLE001 - include backend error in sync failure
+        raise RuntimeError(f"DuckDB inspection failed during sync: {e}") from e
+    if inspection.source != "duckdb-parquet":
+        raise RuntimeError(
+            f"Unexpected time-series source during sync: {inspection.source}"
+        )
+    return inspection
 
 
 def _get_latest_statement_disclosed_date(ctx: SyncContext) -> str | None:
     inspection = _inspect_time_series(ctx)
-    if inspection and inspection.latest_statement_disclosed_date:
-        return inspection.latest_statement_disclosed_date
-    return ctx.market_db.get_latest_statement_disclosed_date()
+    return inspection.latest_statement_disclosed_date
 
 
 def _get_statement_codes(ctx: SyncContext) -> set[str]:
     inspection = _inspect_time_series(ctx)
-    if inspection and inspection.statement_codes:
-        return set(inspection.statement_codes)
-    return ctx.market_db.get_statement_codes()
+    return set(inspection.statement_codes)
 
 
 def get_strategy(resolved_mode: str) -> SyncStrategy:
@@ -1692,57 +1719,49 @@ async def _upsert_indices_rows_with_master_backfill(
 async def _publish_topix_rows(ctx: SyncContext, rows: list[dict[str, Any]]) -> int:
     if not rows:
         return 0
-    if ctx.time_series_store is None:
-        return await asyncio.to_thread(ctx.market_db.upsert_topix_data, rows)
-    return await asyncio.to_thread(ctx.time_series_store.publish_topix_data, rows)
+    store = _require_time_series_store(ctx)
+    return await asyncio.to_thread(store.publish_topix_data, rows)
 
 
 async def _publish_stock_data_rows(ctx: SyncContext, rows: list[dict[str, Any]]) -> int:
     if not rows:
         return 0
-    if ctx.time_series_store is None:
-        return await asyncio.to_thread(ctx.market_db.upsert_stock_data, rows)
-    return await asyncio.to_thread(ctx.time_series_store.publish_stock_data, rows)
+    store = _require_time_series_store(ctx)
+    return await asyncio.to_thread(store.publish_stock_data, rows)
 
 
 async def _publish_indices_rows(ctx: SyncContext, rows: list[dict[str, Any]]) -> int:
     if not rows:
         return 0
-    if ctx.time_series_store is None:
-        return await asyncio.to_thread(ctx.market_db.upsert_indices_data, rows)
-    return await asyncio.to_thread(ctx.time_series_store.publish_indices_data, rows)
+    store = _require_time_series_store(ctx)
+    return await asyncio.to_thread(store.publish_indices_data, rows)
 
 
 async def _publish_statement_rows(ctx: SyncContext, rows: list[dict[str, Any]]) -> int:
     if not rows:
         return 0
-    if ctx.time_series_store is None:
-        return await asyncio.to_thread(ctx.market_db.upsert_statements, rows)
-    return await asyncio.to_thread(ctx.time_series_store.publish_statements, rows)
+    store = _require_time_series_store(ctx)
+    return await asyncio.to_thread(store.publish_statements, rows)
 
 
 async def _index_topix_rows(ctx: SyncContext) -> None:
-    if ctx.time_series_store is None:
-        return
-    await asyncio.to_thread(ctx.time_series_store.index_topix_data)
+    store = _require_time_series_store(ctx)
+    await asyncio.to_thread(store.index_topix_data)
 
 
 async def _index_stock_data_rows(ctx: SyncContext) -> None:
-    if ctx.time_series_store is None:
-        return
-    await asyncio.to_thread(ctx.time_series_store.index_stock_data)
+    store = _require_time_series_store(ctx)
+    await asyncio.to_thread(store.index_stock_data)
 
 
 async def _index_indices_rows(ctx: SyncContext) -> None:
-    if ctx.time_series_store is None:
-        return
-    await asyncio.to_thread(ctx.time_series_store.index_indices_data)
+    store = _require_time_series_store(ctx)
+    await asyncio.to_thread(store.index_indices_data)
 
 
 async def _index_statement_rows(ctx: SyncContext) -> None:
-    if ctx.time_series_store is None:
-        return
-    await asyncio.to_thread(ctx.time_series_store.index_statements)
+    store = _require_time_series_store(ctx)
+    await asyncio.to_thread(store.index_statements)
 
 
 def _convert_topix_rows(data: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/apps/bt/src/entrypoints/http/routes/db.py
+++ b/apps/bt/src/entrypoints/http/routes/db.py
@@ -219,9 +219,15 @@ async def cancel_sync_job(jobId: str) -> CancelJobResponse:
 )
 async def refresh_stocks(request: Request, body: RefreshRequest) -> RefreshResponse:
     market_db = _get_market_db(request)
+    time_series_store = _get_market_time_series_store(request)
     jquants_client = _get_jquants_client(request)
 
     if not market_db.is_initialized():
         raise HTTPException(status_code=422, detail="Database not initialized. Please run sync first.")
 
-    return await stock_refresh_service.refresh_stocks(body.codes, market_db, jquants_client)
+    return await stock_refresh_service.refresh_stocks(
+        body.codes,
+        market_db,
+        time_series_store,
+        jquants_client,
+    )

--- a/apps/bt/tests/unit/server/services/test_stock_refresh_service.py
+++ b/apps/bt/tests/unit/server/services/test_stock_refresh_service.py
@@ -9,18 +9,26 @@ from src.application.services.stock_refresh_service import refresh_stocks
 
 class DummyMarketDb:
     def __init__(self) -> None:
-        self.rows: list[dict[str, Any]] = []
         self.metadata: dict[str, str] = {}
-
-    def get_topix_date_range(self) -> dict[str, str]:
-        return {"min": "2026-02-01", "max": "2026-02-28"}
-
-    def upsert_stock_data(self, rows: list[dict[str, Any]]) -> int:
-        self.rows.extend(rows)
-        return len(rows)
 
     def set_sync_metadata(self, key: str, value: str) -> None:
         self.metadata[key] = value
+
+
+class DummyTimeSeriesStore:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def inspect(self, *, missing_stock_dates_limit: int = 0, statement_non_null_columns: list[str] | None = None) -> Any:
+        del missing_stock_dates_limit, statement_non_null_columns
+        return type("Inspection", (), {"topix_min": "2026-02-01", "topix_max": "2026-02-28"})()
+
+    def publish_stock_data(self, rows: list[dict[str, Any]]) -> int:
+        self.rows.extend(rows)
+        return len(rows)
+
+    def index_stock_data(self) -> None:
+        return None
 
 
 class DummyJQuantsClient:
@@ -41,6 +49,7 @@ class DummyFailingJQuantsClient:
 @pytest.mark.asyncio
 async def test_refresh_stocks_skips_incomplete_ohlcv_rows() -> None:
     market_db = DummyMarketDb()
+    store = DummyTimeSeriesStore()
     client = DummyJQuantsClient(
         rows=[
             {
@@ -66,19 +75,20 @@ async def test_refresh_stocks_skips_incomplete_ohlcv_rows() -> None:
         ]
     )
 
-    result = await refresh_stocks(["131A"], market_db, client)  # type: ignore[arg-type]
+    result = await refresh_stocks(["131A"], market_db, store, client)  # type: ignore[arg-type]
 
     assert result.successCount == 1
     assert result.failedCount == 0
     assert result.totalRecordsStored == 1
-    assert len(market_db.rows) == 1
-    assert market_db.rows[0]["code"] == "131A"
-    assert market_db.rows[0]["date"] == "2026-02-10"
+    assert len(store.rows) == 1
+    assert store.rows[0]["code"] == "131A"
+    assert store.rows[0]["date"] == "2026-02-10"
 
 
 @pytest.mark.asyncio
 async def test_refresh_stocks_applies_topix_date_range_filter() -> None:
     market_db = DummyMarketDb()
+    store = DummyTimeSeriesStore()
     client = DummyJQuantsClient(
         rows=[
             {"Code": "72030", "Date": "2026-01-31", "O": 1, "H": 2, "L": 1, "C": 2, "Vo": 100},
@@ -87,20 +97,26 @@ async def test_refresh_stocks_applies_topix_date_range_filter() -> None:
         ]
     )
 
-    result = await refresh_stocks(["7203"], market_db, client)  # type: ignore[arg-type]
+    result = await refresh_stocks(["7203"], market_db, store, client)  # type: ignore[arg-type]
 
     assert result.successCount == 1
     assert result.failedCount == 0
     assert result.totalRecordsStored == 1
-    assert len(market_db.rows) == 1
-    assert market_db.rows[0]["date"] == "2026-02-10"
+    assert len(store.rows) == 1
+    assert store.rows[0]["date"] == "2026-02-10"
 
 
 @pytest.mark.asyncio
 async def test_refresh_stocks_handles_jquants_error() -> None:
     market_db = DummyMarketDb()
+    store = DummyTimeSeriesStore()
 
-    result = await refresh_stocks(["7203"], market_db, DummyFailingJQuantsClient())  # type: ignore[arg-type]
+    result = await refresh_stocks(
+        ["7203"],
+        market_db,
+        store,
+        DummyFailingJQuantsClient(),
+    )  # type: ignore[arg-type]
 
     assert result.successCount == 0
     assert result.failedCount == 1

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -32,6 +32,7 @@ from src.application.services.sync_strategies import (
     _latest_date,
     _load_metadata_json_list,
     _normalize_date_list,
+    _plan_fetch_method,
     _parse_date,
     _to_jquants_date_param,
     get_strategy,
@@ -202,11 +203,96 @@ class DummyMarketDb:
         return None
 
 
+def _normalize_index_code(value: Any) -> str:
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        return ""
+    if text.isdigit() and len(text) < 4:
+        return text.zfill(4)
+    return text.upper()
+
+
+def _inspection_from_market_db(market_db: DummyMarketDb) -> TimeSeriesInspection:
+    topix_dates = sorted(
+        {
+            str(row.get("date"))
+            for row in market_db.topix_rows
+            if row.get("date")
+        },
+        key=_date_sort_key,
+    )
+    stock_dates = sorted(
+        {
+            str(row.get("date"))
+            for row in market_db.stock_rows
+            if row.get("date")
+        },
+        key=_date_sort_key,
+    )
+    indices_dates = sorted(
+        {
+            str(row.get("date"))
+            for row in market_db.indices_rows
+            if row.get("date")
+        },
+        key=_date_sort_key,
+    )
+
+    latest_indices_dates: dict[str, str] = {}
+    for row in market_db.indices_rows:
+        code = _normalize_index_code(row.get("code"))
+        row_date = str(row.get("date", "")).strip()
+        if not code or not row_date:
+            continue
+        current = latest_indices_dates.get(code)
+        if current is None or _is_date_after(row_date, current):
+            latest_indices_dates[code] = row_date
+    if not latest_indices_dates:
+        latest_indices_dates = {
+            _normalize_index_code(code): value
+            for code, value in market_db.get_latest_indices_data_dates().items()
+            if _normalize_index_code(code) and value
+        }
+
+    statement_dates = [
+        str(row.get("disclosed_date"))
+        for row in market_db.statements_rows
+        if row.get("disclosed_date")
+    ]
+    latest_statement_disclosed_date = (
+        max(statement_dates, key=_date_sort_key) if statement_dates else None
+    )
+    statement_codes = {
+        str(row.get("code"))
+        for row in market_db.statements_rows
+        if row.get("code")
+    }
+
+    return TimeSeriesInspection(
+        source="duckdb-parquet",
+        topix_count=len(market_db.topix_rows),
+        topix_min=topix_dates[0] if topix_dates else market_db.latest_trading_date,
+        topix_max=topix_dates[-1] if topix_dates else market_db.latest_trading_date,
+        stock_count=len(market_db.stock_rows),
+        stock_min=stock_dates[0] if stock_dates else market_db.latest_stock_data_date,
+        stock_max=stock_dates[-1] if stock_dates else market_db.latest_stock_data_date,
+        stock_date_count=len(stock_dates),
+        indices_count=len(market_db.indices_rows),
+        indices_min=indices_dates[0] if indices_dates else _latest_date(list(latest_indices_dates.values())),
+        indices_max=indices_dates[-1] if indices_dates else _latest_date(list(latest_indices_dates.values())),
+        indices_date_count=len(indices_dates),
+        latest_indices_dates=latest_indices_dates,
+        statements_count=len(market_db.statements_rows),
+        latest_statement_disclosed_date=latest_statement_disclosed_date,
+        statement_codes=statement_codes,
+    )
+
+
 class DummyTimeSeriesStore:
     def __init__(
         self,
         market_db: DummyMarketDb,
-        inspection: TimeSeriesInspection,
+        inspection: TimeSeriesInspection | None = None,
     ) -> None:
         self._market_db = market_db
         self._inspection = inspection
@@ -242,10 +328,47 @@ class DummyTimeSeriesStore:
         statement_non_null_columns: list[str] | None = None,
     ) -> TimeSeriesInspection:
         del missing_stock_dates_limit, statement_non_null_columns
-        return self._inspection
+        if self._inspection is not None:
+            return self._inspection
+        return _inspection_from_market_db(self._market_db)
 
     def close(self) -> None:
         return None
+
+
+class FailingInspectionStore(DummyTimeSeriesStore):
+    def inspect(
+        self,
+        *,
+        missing_stock_dates_limit: int = 0,
+        statement_non_null_columns: list[str] | None = None,
+    ) -> TimeSeriesInspection:
+        del missing_stock_dates_limit, statement_non_null_columns
+        raise RuntimeError("inspect failed")
+
+
+def _build_ctx(
+    *,
+    client: Any,
+    market_db: DummyMarketDb,
+    cancelled: asyncio.Event | None = None,
+    on_progress: Any = None,
+    time_series_store: DummyTimeSeriesStore | None = None,
+    bulk_service: Any = None,
+    bulk_probe_disabled: bool = True,
+) -> SyncContext:
+    resolved_cancelled = cancelled or asyncio.Event()
+    resolved_on_progress = on_progress or (lambda *_: None)
+    resolved_store = time_series_store or DummyTimeSeriesStore(market_db)
+    return SyncContext(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=resolved_cancelled,
+        on_progress=resolved_on_progress,
+        time_series_store=resolved_store,  # type: ignore[arg-type]
+        bulk_service=bulk_service,  # type: ignore[arg-type]
+        bulk_probe_disabled=bulk_probe_disabled,
+    )
 
 
 class DummyClient:
@@ -526,6 +649,31 @@ class _FakeBulkService:
         return result
 
 
+class _PlanOnlyClient:
+    def __init__(self, plan: str) -> None:
+        self.plan = plan
+
+
+class _PlanOnlyBulkService:
+    def __init__(self, plan: BulkFetchPlan | Exception) -> None:
+        self._plan = plan
+        self.build_calls = 0
+
+    async def build_plan(
+        self,
+        *,
+        endpoint: str,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        exact_dates: list[str] | None = None,
+    ) -> BulkFetchPlan:
+        del endpoint, date_from, date_to, exact_dates
+        self.build_calls += 1
+        if isinstance(self._plan, Exception):
+            raise self._plan
+        return self._plan
+
+
 def _rest_decision(estimated_rest_calls: int) -> _StageFetchDecision:
     return _StageFetchDecision(
         method="rest",
@@ -572,6 +720,72 @@ def patch_small_index_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_plan_fetch_method_probes_bulk_even_if_plan_hint_is_free() -> None:
+    bulk_plan = BulkFetchPlan(
+        endpoint="/equities/bars/daily",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=1,
+        estimated_cache_hits=0,
+        estimated_cache_misses=0,
+    )
+    bulk_service = _PlanOnlyBulkService(bulk_plan)
+    ctx = _build_ctx(
+        client=_PlanOnlyClient("free"),  # type: ignore[arg-type]
+        market_db=DummyMarketDb(),  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        bulk_service=bulk_service,  # type: ignore[arg-type]
+        bulk_probe_disabled=False,
+    )
+
+    decision = await _plan_fetch_method(
+        ctx,
+        stage="stock_data_incremental",
+        endpoint="/equities/bars/daily",
+        estimated_rest_calls=1200,
+    )
+
+    assert decision.method == "bulk"
+    assert decision.planner_api_calls == 1
+    assert bulk_service.build_calls == 1
+    assert ctx.bulk_probe_disabled is False
+
+
+@pytest.mark.asyncio
+async def test_plan_fetch_method_disables_future_probe_after_bulk_probe_failure() -> None:
+    bulk_service = _PlanOnlyBulkService(RuntimeError("bulk list forbidden"))
+    ctx = _build_ctx(
+        client=_PlanOnlyClient("free"),  # type: ignore[arg-type]
+        market_db=DummyMarketDb(),  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        bulk_service=bulk_service,  # type: ignore[arg-type]
+        bulk_probe_disabled=False,
+    )
+
+    first = await _plan_fetch_method(
+        ctx,
+        stage="stock_data_incremental",
+        endpoint="/equities/bars/daily",
+        estimated_rest_calls=1200,
+    )
+    second = await _plan_fetch_method(
+        ctx,
+        stage="indices_incremental",
+        endpoint="/indices/bars/daily",
+        estimated_rest_calls=1200,
+    )
+
+    assert first.method == "rest"
+    assert first.planner_api_calls == 1
+    assert second.method == "rest"
+    assert second.planner_api_calls == 0
+    assert bulk_service.build_calls == 1
+    assert ctx.bulk_probe_disabled is True
+
+
+@pytest.mark.asyncio
 async def test_incremental_sync_handles_mixed_date_formats() -> None:
     market_db = DummyMarketDb(latest_trading_date="20260206")
     client = DummyClient()
@@ -581,7 +795,7 @@ async def test_incremental_sync_handles_mixed_date_formats() -> None:
     def on_progress(stage: str, current: int, total: int, message: str) -> None:
         progresses.append((stage, current, total, message))
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -598,13 +812,85 @@ async def test_incremental_sync_handles_mixed_date_formats() -> None:
     topix_calls = [c for c in client.calls if c[0] == "/indices/bars/daily/topix"]
     assert topix_calls
     assert topix_calls[0][1] == {"from": "20260206"}
-    indices_calls = [c for c in client.calls if c[0] == "/indices/bars/daily"]
-    assert indices_calls
-    assert any(params == {"code": "0000", "from": "20260206"} for _, params in indices_calls)
-    assert any(row["code"] == "0000" and row["date"] == "2026-02-10" for row in market_db.indices_rows)
 
     assert market_db.metadata.get(METADATA_KEYS["LAST_SYNC_DATE"])
     assert progresses[-1][0] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_does_not_fallback_to_sqlite_anchor_when_duckdb_has_no_anchor() -> None:
+    market_db = DummyMarketDb(latest_trading_date="20260206", latest_stock_data_date="20260206")
+    client = DummyClient()
+    inspection = TimeSeriesInspection(
+        source="duckdb-parquet",
+        topix_count=1,
+        topix_min="2026-02-06",
+        topix_max=None,
+        stock_count=1,
+        stock_min="2026-02-06",
+        stock_max=None,
+        indices_count=1,
+        indices_min="2026-02-06",
+        indices_max=None,
+        latest_indices_dates={},
+        statements_count=0,
+    )
+    store = DummyTimeSeriesStore(market_db, inspection)
+
+    ctx = _build_ctx(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        time_series_store=store,  # type: ignore[arg-type]
+    )
+
+    result = await IncrementalSyncStrategy().execute(ctx)
+
+    assert result.success
+    topix_calls = [c for c in client.calls if c[0] == "/indices/bars/daily/topix"]
+    assert topix_calls
+    assert topix_calls[0][1] == {}
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_fails_when_duckdb_inspection_raises() -> None:
+    market_db = DummyMarketDb(latest_trading_date="20260206")
+    client = DummyClient()
+    store = FailingInspectionStore(
+        market_db,
+        TimeSeriesInspection(source="duckdb-parquet"),
+    )
+    ctx = _build_ctx(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        time_series_store=store,  # type: ignore[arg-type]
+    )
+
+    result = await IncrementalSyncStrategy().execute(ctx)
+
+    assert not result.success
+    assert any("DuckDB inspection failed during sync" in err for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_fails_when_time_series_store_is_missing() -> None:
+    market_db = DummyMarketDb(latest_trading_date="20260206")
+    client = DummyClient()
+    ctx = SyncContext(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        time_series_store=None,
+    )
+
+    result = await IncrementalSyncStrategy().execute(ctx)
+
+    assert not result.success
+    assert any("DuckDB time-series store is required for sync strategy execution" in err for err in result.errors)
 
 
 @pytest.mark.asyncio
@@ -612,7 +898,7 @@ async def test_incremental_sync_uses_stock_data_anchor_when_topix_is_ahead() -> 
     market_db = DummyMarketDb(latest_trading_date="20260210", latest_stock_data_date="20260206")
     client = DummyClient()
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -651,7 +937,7 @@ async def test_incremental_sync_uses_timeseries_inspection_anchor_when_sqlite_is
         ),
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -666,10 +952,6 @@ async def test_incremental_sync_uses_timeseries_inspection_anchor_when_sqlite_is
     assert topix_calls
     assert topix_calls[0][1] == {"from": "20260206"}
     assert any(path == "/equities/bars/daily" and params == {"date": "2026-02-10"} for path, params in client.calls)
-    assert any(
-        path == "/indices/bars/daily" and params == {"code": "0000", "from": "20260206"}
-        for path, params in client.calls
-    )
 
 
 @pytest.mark.asyncio
@@ -691,7 +973,7 @@ async def test_incremental_sync_bootstraps_when_timeseries_store_is_empty() -> N
         ),
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -718,7 +1000,7 @@ async def test_incremental_sync_skips_rows_with_missing_ohlcv() -> None:
         ]
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -744,7 +1026,7 @@ async def test_incremental_sync_skips_index_rows_with_missing_date() -> None:
         ]
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -768,7 +1050,7 @@ async def test_incremental_sync_supplements_indices_with_date_based_discovery() 
         ]
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -794,7 +1076,7 @@ async def test_incremental_sync_indices_bulk_result_matches_rest_discovery(
 
     rest_market_db = DummyMarketDb(latest_trading_date="20260206")
     rest_client = DummyClient(indices_quotes=indices_quotes)
-    rest_ctx = SyncContext(
+    rest_ctx = _build_ctx(
         client=rest_client,  # type: ignore[arg-type]
         market_db=rest_market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -846,7 +1128,7 @@ async def test_incremental_sync_indices_bulk_result_matches_rest_discovery(
 
     monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
 
-    bulk_ctx = SyncContext(
+    bulk_ctx = _build_ctx(
         client=bulk_client,  # type: ignore[arg-type]
         market_db=bulk_market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -883,7 +1165,7 @@ async def test_incremental_sync_fallback_inserts_missing_master_for_fk_compatibi
         ]
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -914,7 +1196,7 @@ async def test_incremental_sync_rechecks_anchor_date_for_index_discovery() -> No
         ]
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -941,7 +1223,7 @@ async def test_incremental_sync_requires_last_sync_metadata() -> None:
     market_db.get_sync_metadata = _no_last_sync  # type: ignore[method-assign]
     client = DummyClient()
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -961,7 +1243,7 @@ async def test_incremental_sync_cancelled_before_start() -> None:
     cancelled = asyncio.Event()
     cancelled.set()
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=cancelled,
@@ -983,7 +1265,7 @@ async def test_incremental_sync_handles_unexpected_topix_exception() -> None:
         raise RuntimeError("topix fail")
 
     client.get_paginated = _raise  # type: ignore[method-assign]
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1029,7 +1311,7 @@ async def test_indices_only_sync_collects_errors_and_continues_other_codes(
     client = IndicesOnlyClient()
     progresses: list[tuple[str, int, int, str]] = []
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1053,7 +1335,7 @@ async def test_indices_only_sync_cancelled_immediately() -> None:
     client = IndicesOnlyClient()
     cancelled = asyncio.Event()
     cancelled.set()
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=cancelled,
@@ -1081,7 +1363,7 @@ async def test_indices_only_sync_cancelled_during_loop() -> None:
                 cancelled.set()
             return [{"Date": "2026-02-10", "O": 10, "H": 12, "L": 9, "C": 11}]
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=_Client(),  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=cancelled,
@@ -1109,7 +1391,7 @@ async def test_indices_only_sync_handles_seed_exception(
         async def get_paginated(self, _path: str, _params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
             return []
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=_Client(),  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1128,7 +1410,7 @@ async def test_initial_sync_breaks_after_consecutive_failures_and_sets_metadata(
     market_db = DummyMarketDb()
     client = InitialSyncClient(topix_dates=topix_dates, fail_stock_dates=set(topix_dates))
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1153,7 +1435,7 @@ async def test_initial_sync_success_path_without_failed_dates() -> None:
     market_db = DummyMarketDb()
     client = InitialSyncClient(topix_dates=topix_dates)
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1222,7 +1504,7 @@ async def test_initial_sync_stock_data_uses_bulk_when_selected(
         lambda _ctx: bulk_service,
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1279,7 +1561,7 @@ async def test_initial_sync_stock_data_bulk_failure_falls_back_to_rest(
         lambda _ctx: bulk_service,
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1299,7 +1581,7 @@ async def test_initial_sync_with_empty_topix_and_empty_master() -> None:
     market_db = DummyMarketDb()
     client = InitialSyncClient(topix_dates=[], master_rows=[])
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1324,7 +1606,7 @@ async def test_initial_sync_returns_cancelled_when_flag_set_during_stock_loop() 
         if stage == "stock_data":
             cancelled.set()
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=cancelled,
@@ -1344,7 +1626,7 @@ async def test_initial_sync_cancelled_before_start() -> None:
     cancelled = asyncio.Event()
     cancelled.set()
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=InitialSyncClient(topix_dates=["2026-02-10"]),  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=cancelled,
@@ -1376,7 +1658,7 @@ async def test_incremental_sync_without_anchor_date_and_with_stock_master_update
         ]
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1395,7 +1677,7 @@ async def test_incremental_sync_collects_stock_daily_fetch_errors() -> None:
     market_db = DummyMarketDb(latest_trading_date=None, latest_stock_data_date=None, latest_indices_data_dates={})
     client = DummyClient(daily_error_dates={"2026-02-06", "2026-02-10"})
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1445,7 +1727,7 @@ async def test_initial_sync_fundamentals_fetches_prime_only_and_handles_paginati
         },
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1485,7 +1767,7 @@ async def test_initial_sync_fundamentals_retries_with_4digit_code_when_5digit_fa
         fins_error_codes={"72030"},
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1551,7 +1833,7 @@ async def test_incremental_sync_fundamentals_date_and_missing_prime_backfill(
         lambda _anchor, _retry: ["2026-02-10"],
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1655,7 +1937,7 @@ async def test_incremental_sync_fundamentals_bulk_date_phase_keeps_code_backfill
 
     monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1707,7 +1989,7 @@ async def test_incremental_sync_fundamentals_backfill_uses_5digit_code_first(
         lambda _anchor, _retry: [],
     )
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1755,7 +2037,7 @@ async def test_incremental_sync_fundamentals_uses_latest_disclosed_when_metadata
 
     monkeypatch.setattr("src.application.services.sync_strategies._build_incremental_date_targets", _capture)
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,  # type: ignore[arg-type]
         market_db=market_db,  # type: ignore[arg-type]
         cancelled=asyncio.Event(),
@@ -1945,7 +2227,7 @@ async def test_incremental_sync_repeated_run_keeps_idempotent_rows() -> None:
     client = DummyClient()
     strategy = IncrementalSyncStrategy()
 
-    ctx = SyncContext(
+    ctx = _build_ctx(
         client=client,
         market_db=market_db,
         cancelled=asyncio.Event(),

--- a/apps/bt/tests/unit/server/test_routes_db_sync.py
+++ b/apps/bt/tests/unit/server/test_routes_db_sync.py
@@ -253,8 +253,12 @@ class TestSyncRoutes:
 
 class TestRefreshRoute:
     def test_refresh_success(self, client: TestClient) -> None:
-        with patch("src.application.services.stock_refresh_service.refresh_stocks") as mock_refresh:
+        with (
+            patch("src.entrypoints.http.routes.db._get_market_time_series_store") as mock_store,
+            patch("src.application.services.stock_refresh_service.refresh_stocks") as mock_refresh,
+        ):
             from src.entrypoints.http.schemas.db import RefreshResponse, RefreshStockResult
+            mock_store.return_value = MagicMock()
             mock_refresh.return_value = RefreshResponse(
                 totalStocks=1,
                 successCount=1,


### PR DESCRIPTION
## Summary
- enforce DuckDB time-series store as mandatory for sync strategy execution (no SQLite fallback paths)
- switch incremental anchor resolution to DuckDB inspection only and fail fast on inspection errors
- route `/api/db/stocks/refresh` through DuckDB inspection + publish/index instead of SQLite upsert
- update AGENTS.md to document sync/refresh DuckDB-only SoT rule
- expand unit tests for DuckDB inspection/fallback behavior and refresh route/service wiring

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check src/application/services/sync_strategies.py src/application/services/stock_refresh_service.py src/entrypoints/http/routes/db.py tests/unit/server/services/test_sync_strategies.py tests/unit/server/services/test_stock_refresh_service.py tests/unit/server/test_routes_db_sync.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest tests/unit/server/services/test_sync_strategies.py tests/unit/server/services/test_stock_refresh_service.py tests/unit/server/test_routes_db_sync.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt coverage run --branch -m pytest tests/unit/server/services/test_sync_strategies.py tests/unit/server/services/test_stock_refresh_service.py tests/unit/server/test_routes_db_sync.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt coverage report -m src/application/services/sync_strategies.py src/application/services/stock_refresh_service.py src/entrypoints/http/routes/db.py`
