### PR TITLE
fix(db-sync): prevent settings snapshot 500 during sync

### DIFF
--- a/apps/bt/src/infrastructure/db/market/base.py
+++ b/apps/bt/src/infrastructure/db/market/base.py
@@ -2,14 +2,14 @@
 Base Database Access
 
 SQLAlchemy Core Engine 管理の基底クラス。
-StaticPool + check_same_thread=False で FastAPI の非同期環境に対応。
+NullPool + check_same_thread=False で FastAPI の並行アクセスに対応。
 PRAGMA は event.listens_for で接続ごとに確実に設定される。
 """
 
 from __future__ import annotations
 
 from sqlalchemy import Engine, create_engine, event
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import NullPool
 
 
 class BaseDbAccess:
@@ -30,19 +30,23 @@ class BaseDbAccess:
             self._engine = create_engine(
                 "sqlite://",
                 creator=_creator,
-                poolclass=StaticPool,
+                poolclass=NullPool,
             )
         else:
             self._engine = create_engine(
                 f"sqlite:///{db_path}",
-                connect_args={"check_same_thread": False},
-                poolclass=StaticPool,
+                connect_args={
+                    "check_same_thread": False,
+                    "timeout": 30.0,
+                },
+                poolclass=NullPool,
             )
 
         # 全接続で PRAGMA を確実に設定（プール再利用時も）
         @event.listens_for(self._engine, "connect")
         def _set_pragmas(dbapi_conn: object, _connection_record: object) -> None:  # pyright: ignore[reportUnusedFunction]
             cursor = dbapi_conn.cursor()  # type: ignore[union-attr]
+            cursor.execute("PRAGMA busy_timeout=30000")
             if not read_only:
                 cursor.execute("PRAGMA journal_mode=WAL")
                 cursor.execute("PRAGMA foreign_keys=ON")

--- a/apps/bt/tests/unit/server/db/test_base.py
+++ b/apps/bt/tests/unit/server/db/test_base.py
@@ -5,8 +5,10 @@ Tests for BaseDbAccess
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Thread
 
 from sqlalchemy import text
+from sqlalchemy.pool import NullPool
 
 from src.infrastructure.db.market.base import BaseDbAccess
 
@@ -78,4 +80,57 @@ class TestBaseDbAccess:
         from sqlalchemy import Engine
 
         assert isinstance(db.engine, Engine)
+        db.close()
+
+    def test_uses_null_pool(self, tmp_path: Path) -> None:
+        db = BaseDbAccess(str(tmp_path / "test.db"))
+        assert isinstance(db.engine.pool, NullPool)
+        db.close()
+
+    def test_busy_timeout_set_on_connection(self, tmp_path: Path) -> None:
+        db = BaseDbAccess(str(tmp_path / "test.db"))
+        with db.engine.connect() as conn:
+            timeout = conn.execute(text("PRAGMA busy_timeout")).scalar()
+            assert timeout == 30000
+        db.close()
+
+    def test_concurrent_read_write_does_not_raise_transaction_errors(self, tmp_path: Path) -> None:
+        db = BaseDbAccess(str(tmp_path / "test.db"))
+        with db.engine.begin() as conn:
+            conn.execute(text("CREATE TABLE sync_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)"))
+
+        errors: list[Exception] = []
+
+        def _writer() -> None:
+            try:
+                for idx in range(300):
+                    with db.engine.begin() as conn:
+                        conn.execute(
+                            text(
+                                "INSERT OR REPLACE INTO sync_metadata (key, value) "
+                                "VALUES ('k', :value)"
+                            ),
+                            {"value": str(idx)},
+                        )
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        def _reader() -> None:
+            try:
+                for _ in range(300):
+                    with db.engine.connect() as conn:
+                        conn.execute(text("SELECT COUNT(*) FROM sync_metadata")).scalar()
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        writer = Thread(target=_writer)
+        reader = Thread(target=_reader)
+        writer.start()
+        reader.start()
+        writer.join(timeout=10)
+        reader.join(timeout=10)
+
+        assert not writer.is_alive()
+        assert not reader.is_alive()
+        assert not errors
         db.close()

--- a/apps/ts/packages/web/src/hooks/useDbSync.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useDbSync.test.tsx
@@ -78,6 +78,28 @@ describe('useDbSync hooks', () => {
     expect(apiGet).toHaveBeenCalledWith('/api/db/validate');
   });
 
+  it('useDbStats uses fast polling while sync is running', () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ initialized: true });
+    const { queryClient, wrapper } = createTestWrapper();
+    renderHook(() => useDbStats({ isSyncRunning: true }), { wrapper });
+
+    const query = queryClient.getQueryCache().find({ queryKey: ['db-stats'] });
+    const options = query?.options as { refetchInterval?: unknown; staleTime?: unknown } | undefined;
+    expect(options?.refetchInterval).toBe(2000);
+    expect(options?.staleTime).toBe(0);
+  });
+
+  it('useDbValidation uses slower polling while sync is idle', () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ status: 'healthy' });
+    const { queryClient, wrapper } = createTestWrapper();
+    renderHook(() => useDbValidation({ isSyncRunning: false }), { wrapper });
+
+    const query = queryClient.getQueryCache().find({ queryKey: ['db-validation'] });
+    const options = query?.options as { refetchInterval?: unknown; staleTime?: unknown } | undefined;
+    expect(options?.refetchInterval).toBe(30000);
+    expect(options?.staleTime).toBe(5000);
+  });
+
   it('useRefreshStocks posts request and invalidates db queries', async () => {
     vi.mocked(apiPost).mockResolvedValueOnce({
       totalStocks: 1,

--- a/apps/ts/packages/web/src/hooks/useDbSync.ts
+++ b/apps/ts/packages/web/src/hooks/useDbSync.ts
@@ -37,6 +37,34 @@ function refreshStocks(request: RefreshStocksRequest): Promise<MarketRefreshResp
   return apiPost<MarketRefreshResponse>('/api/db/stocks/refresh', request);
 }
 
+interface SnapshotPollingOptions {
+  isSyncRunning?: boolean;
+}
+
+const SNAPSHOT_POLL_INTERVAL_RUNNING_MS = 2_000;
+const SNAPSHOT_POLL_INTERVAL_IDLE_MS = 30_000;
+const SNAPSHOT_STALE_TIME_RUNNING_MS = 0;
+const SNAPSHOT_STALE_TIME_IDLE_MS = 5_000;
+
+interface SnapshotQueryTiming {
+  refetchInterval: number;
+  staleTime: number;
+}
+
+function resolveSnapshotQueryTiming(isSyncRunning: boolean): SnapshotQueryTiming {
+  if (isSyncRunning) {
+    return {
+      refetchInterval: SNAPSHOT_POLL_INTERVAL_RUNNING_MS,
+      staleTime: SNAPSHOT_STALE_TIME_RUNNING_MS,
+    };
+  }
+
+  return {
+    refetchInterval: SNAPSHOT_POLL_INTERVAL_IDLE_MS,
+    staleTime: SNAPSHOT_STALE_TIME_IDLE_MS,
+  };
+}
+
 // Hooks
 export function useStartSync() {
   return useMutation({
@@ -83,21 +111,25 @@ export function useCancelSync() {
   });
 }
 
-export function useDbStats() {
+export function useDbStats(options?: SnapshotPollingOptions) {
+  const isSyncRunning = options?.isSyncRunning ?? false;
+  const timing = resolveSnapshotQueryTiming(isSyncRunning);
   return useQuery({
     queryKey: ['db-stats'],
     queryFn: fetchDbStats,
-    refetchInterval: 30_000,
-    staleTime: 5_000,
+    refetchInterval: timing.refetchInterval,
+    staleTime: timing.staleTime,
   });
 }
 
-export function useDbValidation() {
+export function useDbValidation(options?: SnapshotPollingOptions) {
+  const isSyncRunning = options?.isSyncRunning ?? false;
+  const timing = resolveSnapshotQueryTiming(isSyncRunning);
   return useQuery({
     queryKey: ['db-validation'],
     queryFn: fetchDbValidation,
-    refetchInterval: 30_000,
-    staleTime: 5_000,
+    refetchInterval: timing.refetchInterval,
+    staleTime: timing.staleTime,
   });
 }
 

--- a/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
@@ -30,8 +30,8 @@ vi.mock('@/hooks/useDbSync', () => ({
   useStartSync: () => mockStartSyncState,
   useCancelSync: () => mockCancelSyncState,
   useSyncJobStatus: (jobId: string | null) => mockUseSyncJobStatus(jobId),
-  useDbStats: () => mockUseDbStats(),
-  useDbValidation: () => mockUseDbValidation(),
+  useDbStats: (options?: unknown) => mockUseDbStats(options),
+  useDbValidation: (options?: unknown) => mockUseDbValidation(options),
   useRefreshStocks: () => mockUseRefreshStocks(),
 }));
 
@@ -109,6 +109,19 @@ describe('SettingsPage', () => {
 
     await user.click(screen.getByRole('button', { name: /Cancel/i }));
     expect(mockCancelSyncState.mutate).toHaveBeenCalledWith('job-1');
+  });
+
+  it('passes sync running flag to snapshot hooks', async () => {
+    const user = userEvent.setup();
+
+    render(<SettingsPage />);
+    expect(mockUseDbStats).toHaveBeenCalledWith({ isSyncRunning: false });
+    expect(mockUseDbValidation).toHaveBeenCalledWith({ isSyncRunning: false });
+
+    await user.click(screen.getByRole('button', { name: /Start Sync/i }));
+
+    expect(mockUseDbStats).toHaveBeenCalledWith({ isSyncRunning: true });
+    expect(mockUseDbValidation).toHaveBeenCalledWith({ isSyncRunning: true });
   });
 
   it('starts sync request without legacy sqlite data-plane override', async () => {

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -218,10 +218,12 @@ export function SettingsPage() {
   const { data: jobStatus, isLoading: isPolling } = useSyncJobStatus(activeJobId);
   const cancelSync = useCancelSync();
   const refreshStocks = useRefreshStocks();
-  const { data: dbStats, isLoading: isStatsLoading, error: statsError } = useDbStats();
-  const { data: dbValidation, isLoading: isValidationLoading, error: validationError } = useDbValidation();
 
   const isRunning = jobStatus?.status === 'pending' || jobStatus?.status === 'running';
+  const { data: dbStats, isLoading: isStatsLoading, error: statsError } = useDbStats({ isSyncRunning: isRunning });
+  const { data: dbValidation, isLoading: isValidationLoading, error: validationError } = useDbValidation({
+    isSyncRunning: isRunning,
+  });
 
   const handleStartSync = () => {
     const request: StartSyncRequest = { mode: syncMode };


### PR DESCRIPTION
## Summary
- replace bt SQLite StaticPool with NullPool to avoid shared-connection transaction corruption under concurrent read/write
- set SQLite busy timeout (connect timeout + PRAGMA busy_timeout) to reduce lock-related failures during sync
- make Settings DuckDB snapshot polling adaptive (2s while sync is running, 30s when idle)
- add/update unit tests for DB concurrency behavior and snapshot polling options

## Verification
- uv run --project apps/bt pytest apps/bt/tests/unit/server/db/test_base.py apps/bt/tests/unit/server/test_routes_db.py
- uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/server/db/test_base.py apps/bt/tests/unit/server/test_routes_db.py
- uv run --project apps/bt coverage report -m --include=apps/bt/src/infrastructure/db/market/base.py
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test src/hooks/useDbSync.test.tsx src/pages/SettingsPage.test.tsx
- bun run --filter @trading25/web test:coverage src/hooks/useDbSync.test.tsx src/pages/SettingsPage.test.tsx