### PR TITLE
fix(sync): restore db sync tracking across page reloads

### DIFF
--- a/.codex/skills/ts-api-endpoints/references/openapi-paths.md
+++ b/.codex/skills/ts-api-endpoints/references/openapi-paths.md
@@ -2,7 +2,7 @@
 
 Generated from `apps/ts/packages/contracts/openapi/bt-openapi.json`. Do not edit manually.
 
-Total paths: **119**
+Total paths: **120**
 
 ## /api/analytics
 
@@ -94,6 +94,7 @@ Total paths: **119**
 | `/api/db/stats` | `GET` |
 | `/api/db/stocks/refresh` | `POST` |
 | `/api/db/sync` | `POST` |
+| `/api/db/sync/jobs/active` | `GET` |
 | `/api/db/sync/jobs/{jobId}` | `GET, DELETE` |
 | `/api/db/validate` | `GET` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `GET /api/db/stats` / `GET /api/db/validate` の時系列スナップショット SoT は DuckDB inspection（`timeSeriesSource` を返却）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
 - `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
+- `/api/db/sync/jobs/active` は実行中ジョブの再取得 SoT とし、web は再読み込み/再訪時に localStorage と組み合わせて active job 追跡を復元する。`/api/db/sync/jobs/{jobId}` が 404 の場合は stale な jobId を破棄する
 - `/api/db/sync` と `POST /api/db/stocks/refresh` の時系列アンカー判定・publish/index は DuckDB inspection + time-series store を必須 SoT とし、SQLite `market.db` 時系列テーブルへの fallback を禁止する（inspection 失敗時はエラーで停止）
 - DuckDB time-series store は `publish/index/inspect/close` をプロセス内ロックで直列化し、sync 実行と `/api/db/stats` `/api/db/validate` 参照の同時実行による 500 を防止する
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
@@ -166,7 +167,7 @@ bun run --filter @trading25/web e2e:smoke  # web E2E smoke（Playwright）
 - Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Fundamental Metrics / FY History Metrics / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集し、Fundamentals パネル内部の指標は `fundamentalsMetricOrder` / `fundamentalsMetricVisibility`、FY History パネル内部の指標は `fundamentalsHistoryMetricOrder` / `fundamentalsHistoryMetricVisibility` で順序・表示ON/OFFを保持する。Fundamentals パネル高さは表示中指標数に応じて動的に変化する
 - Portfolio / Watchlist の銘柄追加入力はチャート検索と同等の銘柄サーチ（コード/銘柄名）を使う。追加送信 payload は `companyName` 必須（候補選択時は候補名、未選択時はコードをフォールバック）。Watchlist 追加の送信は 4 桁コードのみ許可する
 - Fundamentals summary の予想EPS表示は `revisedForecastEps > adjustedForecastEps > forecastEps` の優先順位を SoT とする
-- web `Settings > Database Sync` は DuckDB SoT 同期 + DuckDB Snapshot 表示を提供し、sync中は stageごとの fetch strategy（bulk/rest と endpoint）を進捗表示する
+- web `Settings > Database Sync` は DuckDB SoT 同期 + DuckDB Snapshot 表示を提供し、sync中は stageごとの fetch strategy（bulk/rest と endpoint）を進捗表示する。active sync job は `localStorage + /api/db/sync/jobs/active` で再読み込み/再訪時も復元する
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ bun run workspace:dev
 ### 2.1) Market Sync Data Plane 実行オプション
 
 - Web: `Settings > Database Sync` で DuckDB SoT 同期を実行し、`DuckDB Snapshot`（`/api/db/stats`, `/api/db/validate`）を確認可能
+- Sync中にページ再読み込み/再訪しても、`/api/db/sync/jobs/active` + localStorage により実行中ジョブ追跡を自動復元
 
 ### 3) Signal Attribution（LOO + Shapley top-N）
 - Web: Backtest ページの `Attribution` サブタブで `Run` から実行し、`History` で保存済み JSON を閲覧

--- a/apps/bt/src/entrypoints/http/routes/db.py
+++ b/apps/bt/src/entrypoints/http/routes/db.py
@@ -4,6 +4,7 @@ Database Routes
 GET    /api/db/stats                 — DB 統計
 GET    /api/db/validate              — DB 検証
 POST   /api/db/sync                  — Sync 開始
+GET    /api/db/sync/jobs/active      — 実行中 Sync ジョブ状態
 GET    /api/db/sync/jobs/{jobId}     — Sync ジョブ状態
 DELETE /api/db/sync/jobs/{jobId}     — Sync ジョブキャンセル
 POST   /api/db/stocks/refresh        — 銘柄データ再取得
@@ -29,12 +30,15 @@ from src.entrypoints.http.schemas.db import (
     MarketValidationResponse,
     RefreshRequest,
     RefreshResponse,
+    SyncProgress,
     SyncRequest,
     SyncJobResponse,
+    SyncResult,
 )
 from src.entrypoints.http.schemas.job import CancelJobResponse, JobStatus
 from src.application.services import db_stats_service, db_validation_service, stock_refresh_service
-from src.application.services.sync_service import SyncMode, sync_job_manager, start_sync
+from src.application.services.generic_job_manager import JobInfo
+from src.application.services.sync_service import SyncJobData, SyncMode, sync_job_manager, start_sync
 
 router = APIRouter(tags=["Database"])
 
@@ -172,16 +176,7 @@ async def start_sync_job(request: Request, body: SyncRequest) -> JSONResponse:
     )
 
 
-@router.get(
-    "/api/db/sync/jobs/{jobId}",
-    response_model=SyncJobResponse,
-    summary="Get sync job status",
-)
-def get_sync_job(jobId: str) -> SyncJobResponse:
-    job = sync_job_manager.get_job(jobId)
-    if job is None:
-        raise HTTPException(status_code=404, detail=f"Job {jobId} not found")
-
+def _to_sync_job_response(job: JobInfo[SyncJobData, SyncProgress, SyncResult]) -> SyncJobResponse:
     return SyncJobResponse(
         jobId=job.job_id,
         status=job.status.value,
@@ -192,6 +187,30 @@ def get_sync_job(jobId: str) -> SyncJobResponse:
         completedAt=job.completed_at.isoformat() if job.completed_at else None,
         error=job.error,
     )
+
+
+@router.get(
+    "/api/db/sync/jobs/active",
+    response_model=SyncJobResponse | None,
+    summary="Get active sync job status",
+)
+def get_active_sync_job() -> SyncJobResponse | None:
+    job = sync_job_manager.get_active_job()
+    if job is None:
+        return None
+    return _to_sync_job_response(job)
+
+
+@router.get(
+    "/api/db/sync/jobs/{jobId}",
+    response_model=SyncJobResponse,
+    summary="Get sync job status",
+)
+def get_sync_job(jobId: str) -> SyncJobResponse:
+    job = sync_job_manager.get_job(jobId)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {jobId} not found")
+    return _to_sync_job_response(job)
 
 
 @router.delete(

--- a/apps/bt/tests/unit/server/test_routes_db_sync.py
+++ b/apps/bt/tests/unit/server/test_routes_db_sync.py
@@ -204,6 +204,36 @@ class TestSyncRoutes:
         resp = client.get("/api/db/sync/jobs/nonexistent-id")
         assert resp.status_code == 404
 
+    def test_get_active_sync_job_returns_null_when_idle(self, client: TestClient) -> None:
+        with patch("src.entrypoints.http.routes.db.sync_job_manager.get_active_job") as mock_get_active:
+            mock_get_active.return_value = None
+
+            resp = client.get("/api/db/sync/jobs/active")
+            assert resp.status_code == 200
+            assert resp.json() is None
+
+    def test_get_active_sync_job_success(self, client: TestClient) -> None:
+        with patch("src.entrypoints.http.routes.db.sync_job_manager.get_active_job") as mock_get_active:
+            job = MagicMock()
+            job.job_id = "job-active"
+            job.status = JobStatus.RUNNING
+            job.data.resolved_mode = "incremental"
+            job.data.mode.value = "incremental"
+            job.progress = None
+            job.result = None
+            job.created_at = datetime.now(UTC)
+            job.started_at = None
+            job.completed_at = None
+            job.error = None
+            mock_get_active.return_value = job
+
+            resp = client.get("/api/db/sync/jobs/active")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["jobId"] == "job-active"
+            assert body["status"] == "running"
+            assert body["mode"] == "incremental"
+
     def test_get_sync_job_success(self, client: TestClient) -> None:
         with patch("src.entrypoints.http.routes.db.sync_job_manager.get_job") as mock_get_job:
             job = MagicMock()

--- a/apps/ts/packages/contracts/openapi/bt-openapi.json
+++ b/apps/ts/packages/contracts/openapi/bt-openapi.json
@@ -17725,6 +17725,65 @@
         ]
       }
     },
+    "/api/db/sync/jobs/active": {
+      "get": {
+        "operationId": "get_active_sync_job_api_db_sync_jobs_active_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/SyncJobResponse"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Active Sync Job Api Db Sync Jobs Active Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get active sync job status",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
     "/api/db/validate": {
       "get": {
         "operationId": "get_db_validate_api_db_validate_get",

--- a/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
@@ -1209,6 +1209,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/db/sync/jobs/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get active sync job status */
+        get: operations["get_active_sync_job_api_db_sync_jobs_active_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/db/validate": {
         parameters: {
             query?: never;
@@ -12049,6 +12066,53 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_active_sync_job_api_db_sync_jobs_active_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncJobResponse"] | null;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Internal Server Error */

--- a/apps/ts/packages/web/src/hooks/useDbSync.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useDbSync.test.tsx
@@ -2,7 +2,15 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { apiDelete, apiGet, apiPost } from '@/lib/api-client';
 import { createTestWrapper } from '@/test-utils';
-import { useCancelSync, useDbStats, useDbValidation, useRefreshStocks, useStartSync, useSyncJobStatus } from './useDbSync';
+import {
+  useActiveSyncJob,
+  useCancelSync,
+  useDbStats,
+  useDbValidation,
+  useRefreshStocks,
+  useStartSync,
+  useSyncJobStatus,
+} from './useDbSync';
 
 vi.mock('@/lib/api-client', () => ({
   apiGet: vi.fn(),
@@ -48,6 +56,44 @@ describe('useDbSync hooks', () => {
     const { wrapper } = createTestWrapper();
     const { result } = renderHook(() => useSyncJobStatus(null), { wrapper });
     expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useSyncJobStatus keeps polling when no status data is available', () => {
+    vi.mocked(apiGet).mockRejectedValueOnce(new Error('temporary error'));
+    const { queryClient, wrapper } = createTestWrapper();
+    renderHook(() => useSyncJobStatus('abc'), { wrapper });
+
+    const query = queryClient.getQueryCache().find({ queryKey: ['sync-job', 'abc'] });
+    const options = query?.options as { refetchInterval?: unknown } | undefined;
+    const refetchInterval = options?.refetchInterval as
+      | ((query: { state: { data?: { status?: string } } }) => number | false)
+      | undefined;
+
+    expect(refetchInterval).toBeTypeOf('function');
+    expect(refetchInterval?.({ state: { data: undefined } })).toBe(1000);
+  });
+
+  it('useSyncJobStatus stops polling for terminal status', () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ jobId: 'abc', status: 'completed' });
+    const { queryClient, wrapper } = createTestWrapper();
+    renderHook(() => useSyncJobStatus('abc'), { wrapper });
+
+    const query = queryClient.getQueryCache().find({ queryKey: ['sync-job', 'abc'] });
+    const options = query?.options as { refetchInterval?: unknown } | undefined;
+    const refetchInterval = options?.refetchInterval as
+      | ((query: { state: { data?: { status?: string } } }) => number | false)
+      | undefined;
+
+    expect(refetchInterval).toBeTypeOf('function');
+    expect(refetchInterval?.({ state: { data: { status: 'completed' } } })).toBe(false);
+  });
+
+  it('useActiveSyncJob fetches active job status', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({ jobId: 'active-1', status: 'running' });
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useActiveSyncJob(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiGet).toHaveBeenCalledWith('/api/db/sync/jobs/active');
   });
 
   it('useCancelSync cancels a job and invalidates', async () => {

--- a/apps/ts/packages/web/src/hooks/useDbSync.ts
+++ b/apps/ts/packages/web/src/hooks/useDbSync.ts
@@ -21,6 +21,10 @@ function fetchJobStatus(jobId: string): Promise<SyncJobResponse> {
   return apiGet<SyncJobResponse>(`/api/db/sync/jobs/${jobId}`);
 }
 
+function fetchActiveJobStatus(): Promise<SyncJobResponse | null> {
+  return apiGet<SyncJobResponse | null>('/api/db/sync/jobs/active');
+}
+
 function cancelJob(jobId: string): Promise<CancelJobResponse> {
   return apiDelete<CancelJobResponse>(`/api/db/sync/jobs/${jobId}`);
 }
@@ -88,12 +92,22 @@ export function useSyncJobStatus(jobId: string | null) {
     },
     enabled: !!jobId,
     refetchInterval: (query) => {
-      // Poll every 1s while running, stop when completed/failed/cancelled
       const status = query.state.data?.status;
-      if (status === 'running' || status === 'pending') return 1000;
-      return false;
+      // Keep polling until terminal status is observed.
+      if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+        return false;
+      }
+      return 1000;
     },
     staleTime: 0, // Always fetch fresh data
+  });
+}
+
+export function useActiveSyncJob() {
+  return useQuery({
+    queryKey: ['sync-job-active'],
+    queryFn: fetchActiveJobStatus,
+    staleTime: 0,
   });
 }
 

--- a/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '@/lib/api-client';
 import { SettingsPage } from './SettingsPage';
 
 type SyncJobStatus = {
@@ -29,6 +30,7 @@ const mockCancelSyncState = {
 };
 
 const mockUseSyncJobStatus = vi.fn();
+const mockUseActiveSyncJob = vi.fn();
 const mockUseDbStats = vi.fn();
 const mockUseDbValidation = vi.fn();
 const mockUseRefreshStocks = vi.fn();
@@ -36,6 +38,7 @@ const mockUseRefreshStocks = vi.fn();
 vi.mock('@/hooks/useDbSync', () => ({
   useStartSync: () => mockStartSyncState,
   useCancelSync: () => mockCancelSyncState,
+  useActiveSyncJob: () => mockUseActiveSyncJob(),
   useSyncJobStatus: (jobId: string | null) => mockUseSyncJobStatus(jobId),
   useDbStats: (options?: unknown) => mockUseDbStats(options),
   useDbValidation: (options?: unknown) => mockUseDbValidation(options),
@@ -44,9 +47,15 @@ vi.mock('@/hooks/useDbSync', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   mockStartSyncState.isPending = false;
   mockStartSyncState.error = null;
   mockCancelSyncState.isPending = false;
+  mockUseActiveSyncJob.mockReturnValue({
+    data: null,
+    isLoading: false,
+    error: null,
+  });
   mockUseRefreshStocks.mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
@@ -99,6 +108,46 @@ beforeEach(() => {
 });
 
 describe('SettingsPage', () => {
+  it('loads active job id from localStorage on mount', () => {
+    localStorage.setItem('trading25.settings.sync.activeJobId', 'stored-job-1');
+
+    render(<SettingsPage />);
+
+    expect(mockUseSyncJobStatus).toHaveBeenCalledWith('stored-job-1');
+  });
+
+  it('restores active job id from backend active job endpoint', () => {
+    mockUseActiveSyncJob.mockReturnValue({
+      data: {
+        jobId: 'active-job-1',
+        status: 'running',
+        mode: 'incremental',
+        startedAt: '2026-03-04T00:00:00Z',
+      } as SyncJobStatus,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SettingsPage />);
+
+    expect(mockUseSyncJobStatus).toHaveBeenCalledWith('active-job-1');
+  });
+
+  it('clears persisted active job id when status endpoint returns 404', async () => {
+    localStorage.setItem('trading25.settings.sync.activeJobId', 'missing-job');
+    mockUseSyncJobStatus.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new ApiError('Job not found', 404),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(localStorage.getItem('trading25.settings.sync.activeJobId')).toBeNull();
+    });
+  });
+
   it('starts sync and renders running status', async () => {
     const user = userEvent.setup();
 

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -1,11 +1,12 @@
 import { Database, Loader2, RotateCcw } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SyncModeSelect } from '@/components/Settings/SyncModeSelect';
 import { SyncStatusCard } from '@/components/Settings/SyncStatusCard';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
+  useActiveSyncJob,
   useCancelSync,
   useDbStats,
   useDbValidation,
@@ -13,6 +14,7 @@ import {
   useStartSync,
   useSyncJobStatus,
 } from '@/hooks/useDbSync';
+import { ApiError } from '@/lib/api-client';
 import type {
   MarketRefreshResponse,
   MarketStatsResponse,
@@ -26,6 +28,39 @@ function formatTimestamp(value?: string | null): string {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleString();
+}
+
+const ACTIVE_SYNC_JOB_STORAGE_KEY = 'trading25.settings.sync.activeJobId';
+
+function readPersistedActiveSyncJobId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const value = window.localStorage.getItem(ACTIVE_SYNC_JOB_STORAGE_KEY);
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistActiveSyncJobId(jobId: string | null): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (jobId) {
+      window.localStorage.setItem(ACTIVE_SYNC_JOB_STORAGE_KEY, jobId);
+      return;
+    }
+    window.localStorage.removeItem(ACTIVE_SYNC_JOB_STORAGE_KEY);
+  } catch {
+    // localStorage can fail in restricted environments.
+  }
 }
 
 interface SyncActionButtonProps {
@@ -209,15 +244,34 @@ function RefreshResultTable({ result }: { result: MarketRefreshResponse }) {
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: settings page coordinates sync and refresh sections
 export function SettingsPage() {
   const [syncMode, setSyncMode] = useState<SyncMode>('auto');
-  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [activeJobId, setActiveJobId] = useState<string | null>(readPersistedActiveSyncJobId);
   const [refreshCodesInput, setRefreshCodesInput] = useState('');
   const [refreshInputError, setRefreshInputError] = useState<string | null>(null);
   const [refreshResult, setRefreshResult] = useState<MarketRefreshResponse | null>(null);
 
   const startSync = useStartSync();
-  const { data: jobStatus, isLoading: isPolling } = useSyncJobStatus(activeJobId);
+  const { data: activeSyncJob } = useActiveSyncJob();
+  const { data: jobStatus, isLoading: isPolling, error: syncJobError } = useSyncJobStatus(activeJobId);
   const cancelSync = useCancelSync();
   const refreshStocks = useRefreshStocks();
+
+  useEffect(() => {
+    if (!activeSyncJob?.jobId) {
+      return;
+    }
+    setActiveJobId(activeSyncJob.jobId);
+  }, [activeSyncJob?.jobId]);
+
+  useEffect(() => {
+    persistActiveSyncJobId(activeJobId);
+  }, [activeJobId]);
+
+  useEffect(() => {
+    if (!(syncJobError instanceof ApiError) || syncJobError.status !== 404) {
+      return;
+    }
+    setActiveJobId(null);
+  }, [syncJobError]);
 
   const isRunning = jobStatus?.status === 'pending' || jobStatus?.status === 'running';
   const { data: dbStats, isLoading: isStatsLoading, error: statsError } = useDbStats({ isSyncRunning: isRunning });


### PR DESCRIPTION
## Summary
- add /api/db/sync/jobs/active to expose the current active DB sync job
- restore Settings page DB sync tracking across reload/revisit using backend active-job lookup plus localStorage
- clear stale stored job IDs when /api/db/sync/jobs/{jobId} returns 404 and keep polling until terminal status
- sync OpenAPI/contracts and update README/AGENTS with the new behavior

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/test_routes_db_sync.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/test_routes_db_sync.py --cov=src.entrypoints.http.routes.db --cov-branch --cov-report=term
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pyright apps/bt/src/entrypoints/http/routes/db.py
- bun run test src/hooks/useDbSync.test.tsx src/pages/SettingsPage.test.tsx (in apps/ts/packages/web)
- bunx vitest run src/hooks/useDbSync.test.tsx src/pages/SettingsPage.test.tsx --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/hooks/useDbSync.ts --coverage.include=src/pages/SettingsPage.tsx (in apps/ts/packages/web)
- bun run typecheck (in apps/ts/packages/web)
- bun run --filter @trading25/contracts bt:sync (in apps/ts)