### PR TITLE
fix(bt): stabilize bulk stock_data sync fallback diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `GET /api/db/stats` / `GET /api/db/validate` の時系列スナップショット SoT は DuckDB inspection（`timeSeriesSource` を返却）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
 - `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
+- `stock_data` の bulk ingest は bulk file 単位で publish し、大量期間同期時のメモリピークによる bulk 失敗→REST fallback を抑制する。fallback 時の progress message は reason を含める
 - `/api/db/sync` と `POST /api/db/stocks/refresh` の時系列アンカー判定・publish/index は DuckDB inspection + time-series store を必須 SoT とし、SQLite `market.db` 時系列テーブルへの fallback を禁止する（inspection 失敗時はエラーで停止）
 - DuckDB time-series store は `publish/index/inspect/close` をプロセス内ロックで直列化し、sync 実行と `/api/db/stats` `/api/db/validate` 参照の同時実行による 500 を防止する
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する

--- a/apps/bt/src/application/services/jquants_bulk_service.py
+++ b/apps/bt/src/application/services/jquants_bulk_service.py
@@ -105,7 +105,13 @@ class JQuantsBulkService:
             estimated_cache_misses=estimated_cache_misses,
         )
 
-    async def fetch_with_plan(self, plan: BulkFetchPlan) -> BulkFetchResult:
+    async def fetch_with_plan(
+        self,
+        plan: BulkFetchPlan,
+        *,
+        on_rows_batch: Callable[[list[dict[str, Any]], BulkFileInfo], Awaitable[None]] | None = None,
+        accumulate_rows: bool = True,
+    ) -> BulkFetchResult:
         rows: list[dict[str, Any]] = []
         api_calls = 0
         cache_hits = 0
@@ -131,7 +137,11 @@ class JQuantsBulkService:
                 cache_path.write_bytes(payload)
                 self._write_cache_meta(file_info)
 
-            rows.extend(self._read_csv_gzip_rows(cache_path))
+            batch_rows = self._read_csv_gzip_rows(cache_path)
+            if on_rows_batch is not None:
+                await on_rows_batch(batch_rows, file_info)
+            if accumulate_rows:
+                rows.extend(batch_rows)
 
         return BulkFetchResult(
             rows=rows,

--- a/apps/bt/src/application/services/sync_strategies.py
+++ b/apps/bt/src/application/services/sync_strategies.py
@@ -18,6 +18,7 @@ from zoneinfo import ZoneInfo
 from loguru import logger
 
 from src.application.services.jquants_bulk_service import (
+    BulkFileInfo,
     BulkFetchPlan,
     BulkFetchResult,
     JQuantsBulkService,
@@ -342,6 +343,39 @@ def _normalize_bulk_fins_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]
     return _normalize_bulk_row_keys(rows, _BULK_FINS_KEY_ALIASES)
 
 
+def _build_target_date_set(dates: list[str]) -> set[str] | None:
+    normalized = {
+        date_text
+        for date_text in (_to_iso_date_text(value) for value in dates)
+        if date_text is not None
+    }
+    return normalized or None
+
+
+async def _ingest_stock_bulk_batch(
+    ctx: SyncContext,
+    *,
+    batch_rows: list[dict[str, Any]],
+    target_dates: set[str] | None,
+) -> int:
+    normalized_rows = _normalize_bulk_stock_rows(batch_rows)
+    if target_dates is not None:
+        normalized_rows = [
+            row
+            for row in normalized_rows
+            if _to_iso_date_text(str(row.get("Date") or "")) in target_dates
+        ]
+    rows = validate_rows_required_fields(
+        _convert_stock_data_rows(normalized_rows),
+        required_fields=("code", "date", "open", "high", "low", "close", "volume"),
+        dedupe_keys=("code", "date"),
+        stage="stock_data",
+    )
+    if not rows:
+        return 0
+    return await _publish_stock_data_rows(ctx, rows)
+
+
 def _is_incremental_cold_start(
     inspection: TimeSeriesInspection,
 ) -> bool:
@@ -401,6 +435,13 @@ def _format_fetch_estimate(value: int | None) -> str:
     return str(value) if value is not None else "n/a"
 
 
+def _summarize_exception(exc: Exception, *, limit: int = 200) -> str:
+    text = str(exc).replace("\n", " ").strip() or exc.__class__.__name__
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3]}..."
+
+
 def _emit_fetch_strategy_progress(
     ctx: SyncContext,
     *,
@@ -434,9 +475,16 @@ def _emit_fetch_execution_progress(
     method: _FetchMethod,
     target_label: str | None = None,
     fallback: bool = False,
+    fallback_reason: str | None = None,
 ) -> None:
     target_text = f", targets={target_label}" if target_label else ""
-    fallback_text = " (bulk fallback)" if fallback else ""
+    fallback_text = ""
+    if fallback:
+        fallback_text = (
+            f" (bulk fallback: {fallback_reason})"
+            if fallback_reason
+            else " (bulk fallback)"
+        )
     ctx.on_progress(
         progress_stage,
         current,
@@ -700,6 +748,7 @@ class InitialSyncStrategy:
             )
 
             used_rest_fallback = False
+            stock_bulk_fallback_reason: str | None = None
             stage_api_calls = 0
             bulk_result: BulkFetchResult | None = None
             if decision.method == "bulk" and decision.plan is not None:
@@ -713,25 +762,26 @@ class InitialSyncStrategy:
                         method="bulk",
                         target_label=f"{len(trading_dates)} dates",
                     )
-                    bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision.plan)
+                    trading_date_set = _build_target_date_set(trading_dates)
+
+                    async def _consume_stock_bulk_rows(
+                        batch_rows: list[dict[str, Any]],
+                        _file_info: BulkFileInfo,
+                    ) -> None:
+                        nonlocal stocks_updated
+                        stocks_updated += await _ingest_stock_bulk_batch(
+                            ctx,
+                            batch_rows=batch_rows,
+                            target_dates=trading_date_set,
+                        )
+
+                    bulk_result = await _get_bulk_service(ctx).fetch_with_plan(
+                        decision.plan,
+                        on_rows_batch=_consume_stock_bulk_rows,
+                        accumulate_rows=False,
+                    )
                     total_calls += bulk_result.api_calls
                     stage_api_calls += bulk_result.api_calls
-                    bulk_rows = _normalize_bulk_stock_rows(bulk_result.rows)
-                    if trading_dates:
-                        trading_date_set = {_to_iso_date_text(value) for value in trading_dates}
-                        bulk_rows = [
-                            row
-                            for row in bulk_rows
-                            if _to_iso_date_text(str(row.get("Date") or "")) in trading_date_set
-                        ]
-                    rows = validate_rows_required_fields(
-                        _convert_stock_data_rows(bulk_rows),
-                        required_fields=("code", "date", "open", "high", "low", "close", "volume"),
-                        dedupe_keys=("code", "date"),
-                        stage="stock_data",
-                    )
-                    if rows:
-                        stocks_updated += await _publish_stock_data_rows(ctx, rows)
                     _log_sync_fetch_execution(
                         stage="stock_data_initial",
                         endpoint="/equities/bars/daily",
@@ -743,7 +793,11 @@ class InitialSyncStrategy:
                     )
                 except Exception as e:
                     used_rest_fallback = True
-                    logger.warning("Initial stock_data bulk fetch failed, falling back to REST: {}", e)
+                    stock_bulk_fallback_reason = _summarize_exception(e)
+                    logger.exception(
+                        "Initial stock_data bulk fetch failed, falling back to REST: {}",
+                        stock_bulk_fallback_reason,
+                    )
 
             if decision.method == "rest" or used_rest_fallback:
                 _emit_fetch_execution_progress(
@@ -755,6 +809,7 @@ class InitialSyncStrategy:
                     method="rest",
                     target_label=f"{len(trading_dates)} dates",
                     fallback=used_rest_fallback,
+                    fallback_reason=stock_bulk_fallback_reason,
                 )
                 consecutive_failures = 0
                 for i, date in enumerate(trading_dates):
@@ -963,6 +1018,7 @@ class IncrementalSyncStrategy:
             )
 
             used_stock_rest_fallback = False
+            stock_bulk_fallback_reason: str | None = None
             stock_stage_api_calls = 0
             stock_bulk_result: BulkFetchResult | None = None
             if decision_stock_data.method == "bulk" and decision_stock_data.plan is not None:
@@ -976,25 +1032,26 @@ class IncrementalSyncStrategy:
                         method="bulk",
                         target_label=f"{len(new_dates)} dates",
                     )
-                    stock_bulk_result = await _get_bulk_service(ctx).fetch_with_plan(decision_stock_data.plan)
+                    new_date_set = _build_target_date_set(new_dates)
+
+                    async def _consume_incremental_stock_bulk_rows(
+                        batch_rows: list[dict[str, Any]],
+                        _file_info: BulkFileInfo,
+                    ) -> None:
+                        nonlocal stocks_updated
+                        stocks_updated += await _ingest_stock_bulk_batch(
+                            ctx,
+                            batch_rows=batch_rows,
+                            target_dates=new_date_set,
+                        )
+
+                    stock_bulk_result = await _get_bulk_service(ctx).fetch_with_plan(
+                        decision_stock_data.plan,
+                        on_rows_batch=_consume_incremental_stock_bulk_rows,
+                        accumulate_rows=False,
+                    )
                     total_calls += stock_bulk_result.api_calls
                     stock_stage_api_calls += stock_bulk_result.api_calls
-                    bulk_rows = _normalize_bulk_stock_rows(stock_bulk_result.rows)
-                    if new_dates:
-                        new_date_set = {_to_iso_date_text(value) for value in new_dates}
-                        bulk_rows = [
-                            row
-                            for row in bulk_rows
-                            if _to_iso_date_text(str(row.get("Date") or "")) in new_date_set
-                        ]
-                    rows = validate_rows_required_fields(
-                        _convert_stock_data_rows(bulk_rows),
-                        required_fields=("code", "date", "open", "high", "low", "close", "volume"),
-                        dedupe_keys=("code", "date"),
-                        stage="stock_data",
-                    )
-                    if rows:
-                        stocks_updated += await _publish_stock_data_rows(ctx, rows)
                     _log_sync_fetch_execution(
                         stage="stock_data_incremental",
                         endpoint="/equities/bars/daily",
@@ -1006,7 +1063,11 @@ class IncrementalSyncStrategy:
                     )
                 except Exception as e:
                     used_stock_rest_fallback = True
-                    logger.warning("Incremental stock_data bulk fetch failed, falling back to REST: {}", e)
+                    stock_bulk_fallback_reason = _summarize_exception(e)
+                    logger.exception(
+                        "Incremental stock_data bulk fetch failed, falling back to REST: {}",
+                        stock_bulk_fallback_reason,
+                    )
 
             if decision_stock_data.method == "rest" or used_stock_rest_fallback:
                 _emit_fetch_execution_progress(
@@ -1018,6 +1079,7 @@ class IncrementalSyncStrategy:
                     method="rest",
                     target_label=f"{len(new_dates)} dates",
                     fallback=used_stock_rest_fallback,
+                    fallback_reason=stock_bulk_fallback_reason,
                 )
                 for i, date in enumerate(new_dates, start=1):
                     if ctx.cancelled.is_set():

--- a/apps/bt/tests/unit/server/services/test_jquants_bulk_service.py
+++ b/apps/bt/tests/unit/server/services/test_jquants_bulk_service.py
@@ -140,6 +140,43 @@ async def test_bulk_service_selects_monthly_file_by_exact_date(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_bulk_service_fetch_with_callback_without_accumulating_rows(tmp_path: Path) -> None:
+    key = "equities_bars_daily_20260210.csv.gz"
+    rows = [{"Code": "72030", "Date": "2026-02-10", "O": "1", "H": "2", "L": "1", "C": "2", "Vo": "1000"}]
+    payload = _gzip_csv_bytes(rows)
+    client = _BulkClient(
+        list_payload=[{"Key": key, "LastModified": "2026-02-11T00:00:00Z", "Size": len(payload)}],
+        signed_urls={key: "https://signed.local/equities-20260210.csv.gz"},
+    )
+
+    async def _downloader(_url: str) -> bytes:
+        return payload
+
+    service = JQuantsBulkService(
+        client,  # type: ignore[arg-type]
+        cache_dir=tmp_path / "bulk-cache",
+        downloader=_downloader,
+    )
+
+    plan = await service.build_plan(endpoint="/equities/bars/daily")
+    seen_batches: list[list[dict[str, Any]]] = []
+
+    async def _on_rows_batch(batch_rows: list[dict[str, Any]], _file_info: Any) -> None:
+        seen_batches.append(batch_rows)
+
+    result = await service.fetch_with_plan(
+        plan,
+        on_rows_batch=_on_rows_batch,
+        accumulate_rows=False,
+    )
+
+    assert len(seen_batches) == 1
+    assert seen_batches[0][0]["Code"] == "72030"
+    assert result.rows == []
+    assert result.api_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_bulk_service_wraps_signed_url_download_error(tmp_path: Path) -> None:
     key = "indices_bars_daily_20260210.csv.gz"
     payload_rows = [{"Date": "2026-02-10", "Code": "0000", "O": "1", "H": "2", "L": "1", "C": "2"}]

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -639,13 +639,29 @@ class _FakeBulkService:
         self.fail_endpoints = fail_endpoints or set()
         self.fetch_calls: list[str] = []
 
-    async def fetch_with_plan(self, plan: BulkFetchPlan) -> BulkFetchResult:
+    async def fetch_with_plan(
+        self,
+        plan: BulkFetchPlan,
+        *,
+        on_rows_batch: Any | None = None,
+        accumulate_rows: bool = True,
+    ) -> BulkFetchResult:
         self.fetch_calls.append(plan.endpoint)
         if plan.endpoint in self.fail_endpoints:
             raise RuntimeError("bulk failed")
         result = self.results_by_endpoint.get(plan.endpoint)
         if result is None:
             return BulkFetchResult(rows=[], api_calls=0, cache_hits=0, cache_misses=0, selected_files=0)
+        if on_rows_batch is not None:
+            await on_rows_batch(result.rows, None)
+        if not accumulate_rows:
+            return BulkFetchResult(
+                rows=[],
+                api_calls=result.api_calls,
+                cache_hits=result.cache_hits,
+                cache_misses=result.cache_misses,
+                selected_files=result.selected_files,
+            )
         return result
 
 


### PR DESCRIPTION
## Summary
- stream stock_data bulk ingestion per bulk file via callback to avoid holding all rows in memory
- include fallback reason in sync progress message when bulk falls back to REST
- log stock bulk fallback with traceback for easier debugging
- refactor duplicated stock bulk ingestion logic and update AGENTS note
- add and adjust tests for callback-based bulk path and sync bulk service test doubles

## Verification
- uv run --project apps/bt ruff check apps/bt/src/application/services/jquants_bulk_service.py apps/bt/src/application/services/sync_strategies.py apps/bt/tests/unit/server/services/test_jquants_bulk_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py
- uv run --project apps/bt pyright apps/bt/src/application/services/jquants_bulk_service.py apps/bt/src/application/services/sync_strategies.py
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_jquants_bulk_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py -q
- uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/server/services/test_jquants_bulk_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py -q