### PR TITLE
fix(sync): enforce bulk-only stock_data sync and auto-refresh snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `POST /api/db/sync` の `dataPlane` override は `backend=duckdb-parquet` のみ受け付ける
 - `GET /api/db/stats` / `GET /api/db/validate` の時系列スナップショット SoT は DuckDB inspection（`timeSeriesSource` を返却）
 - `market.db` の `incremental sync` は `topix_data` / `stock_data` だけでなく `indices_data` も更新する。`index_master` はローカル catalog を SoT として補完し、`indices_data` は code 指定同期（catalog + 既存DBコード）を基本に、日付指定同期で新規コードを補完する（`indices-only` は指数再同期専用モード）。不足 `index_master` はプレースホルダ補完し、FK 制約付きの既存DBでも継続可能にする
-- `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
+- `/api/db/sync`（`initial` / `incremental`）は `Bulk+REST hybrid` を stage 単位で選択し、予測外部request数が最小の手法を優先する。`stock_data` stage は bulk 必須とし、bulk 不可時は REST fallback せず理由付きでエラー終了する。`incremental` で DuckDB inspection の `topix/stock/indices` が空かつアンカー不在なら cold-start bootstrap を選び、全日付 fallback 暴走を回避する
 - `/api/db/sync/jobs/active` は実行中ジョブの再取得 SoT とし、web は再読み込み/再訪時に localStorage と組み合わせて active job 追跡を復元する。`/api/db/sync/jobs/{jobId}` が 404 の場合は stale な jobId を破棄する
 - `stock_data` の bulk ingest は bulk file 単位で publish し、大量期間同期時のメモリピークによる bulk 失敗→REST fallback を抑制する。fallback 時の progress message は reason を含める
 - `/api/db/sync` と `POST /api/db/stocks/refresh` の時系列アンカー判定・publish/index は DuckDB inspection + time-series store を必須 SoT とし、SQLite `market.db` 時系列テーブルへの fallback を禁止する（inspection 失敗時はエラーで停止）
@@ -168,7 +168,7 @@ bun run --filter @trading25/web e2e:smoke  # web E2E smoke（Playwright）
 - Charts の sidebar 設定はカテゴリ別 Dialog（Chart Settings / Panel Layout / Fundamental Metrics / FY History Metrics / Overlay / Sub-Chart / Signal Overlay）で編集する。Fundamental 系パネル（Fundamentals / FY History / Margin Pressure / Factor Regression）は `fundamentalsPanelOrder` で表示順を保持・編集し、Fundamentals パネル内部の指標は `fundamentalsMetricOrder` / `fundamentalsMetricVisibility`、FY History パネル内部の指標は `fundamentalsHistoryMetricOrder` / `fundamentalsHistoryMetricVisibility` で順序・表示ON/OFFを保持する。Fundamentals パネル高さは表示中指標数に応じて動的に変化する
 - Portfolio / Watchlist の銘柄追加入力はチャート検索と同等の銘柄サーチ（コード/銘柄名）を使う。追加送信 payload は `companyName` 必須（候補選択時は候補名、未選択時はコードをフォールバック）。Watchlist 追加の送信は 4 桁コードのみ許可する
 - Fundamentals summary の予想EPS表示は `revisedForecastEps > adjustedForecastEps > forecastEps` の優先順位を SoT とする
-- web `Settings > Database Sync` は DuckDB SoT 同期 + DuckDB Snapshot 表示を提供し、sync中は stageごとの fetch strategy（bulk/rest と endpoint）を進捗表示する。active sync job は `localStorage + /api/db/sync/jobs/active` で再読み込み/再訪時も復元する
+- web `Settings > Database Sync` は DuckDB SoT 同期 + DuckDB Snapshot 表示を提供し、sync中は stageごとの fetch strategy（bulk/rest と endpoint）を進捗表示する。active sync job は `localStorage + /api/db/sync/jobs/active` で再読み込み/再訪時も復元し、running中は snapshot (`/api/db/stats` `/api/db/validate`) を短周期ポーリング + 進捗更新トリガで自動再取得する
 
 主要技術: TypeScript, Bun, React 19, Vite, Tailwind CSS v4, Biome, OpenAPI generated types
 

--- a/apps/bt/src/application/services/sync_service.py
+++ b/apps/bt/src/application/services/sync_service.py
@@ -84,6 +84,7 @@ async def start_sync(
             time_series_store=time_series_store,
             cancelled=job.cancelled,
             on_progress=on_progress,
+            enforce_bulk_for_stock_data=True,
         )
         try:
             result = await asyncio.wait_for(strategy.execute(ctx), timeout=SYNC_JOB_TIMEOUT_MINUTES * 60)

--- a/apps/bt/src/application/services/sync_strategies.py
+++ b/apps/bt/src/application/services/sync_strategies.py
@@ -207,6 +207,7 @@ async def _plan_fetch_method(
     date_to: str | None = None,
     exact_dates: list[str] | None = None,
     min_rest_calls_to_probe_bulk: int = 3,
+    require_bulk: bool = False,
 ) -> _StageFetchDecision:
     if ctx.bulk_probe_disabled:
         plan_hint = _get_plan_hint(ctx.client)
@@ -221,6 +222,7 @@ async def _plan_fetch_method(
             estimatedBulkCalls=None,
             plannerApiCalls=0,
             planHint=plan_hint or None,
+            requireBulk=require_bulk,
         )
         return _StageFetchDecision(
             method="rest",
@@ -232,7 +234,7 @@ async def _plan_fetch_method(
             reason_detail=ctx.bulk_probe_failure_reason,
         )
 
-    if estimated_rest_calls < min_rest_calls_to_probe_bulk:
+    if not require_bulk and estimated_rest_calls < min_rest_calls_to_probe_bulk:
         plan_hint = _get_plan_hint(ctx.client)
         logger.info(
             "sync fetch strategy selected",
@@ -245,6 +247,7 @@ async def _plan_fetch_method(
             estimatedBulkCalls=None,
             plannerApiCalls=0,
             planHint=plan_hint or None,
+            requireBulk=require_bulk,
         )
         return _StageFetchDecision(
             method="rest",
@@ -284,6 +287,7 @@ async def _plan_fetch_method(
             estimatedBulkCalls=None,
             plannerApiCalls=1,
             planHint=plan_hint or None,
+            requireBulk=require_bulk,
         )
         return _StageFetchDecision(
             method="rest",
@@ -295,8 +299,12 @@ async def _plan_fetch_method(
             reason_detail=ctx.bulk_probe_failure_reason,
         )
 
-    selected: _FetchMethod = "bulk" if plan.estimated_api_calls < estimated_rest_calls else "rest"
-    reason = "bulk_estimate_lower" if selected == "bulk" else "rest_estimate_lower_or_equal"
+    if require_bulk:
+        selected: _FetchMethod = "bulk"
+        reason = "bulk_required"
+    else:
+        selected = "bulk" if plan.estimated_api_calls < estimated_rest_calls else "rest"
+        reason = "bulk_estimate_lower" if selected == "bulk" else "rest_estimate_lower_or_equal"
 
     logger.info(
         "sync fetch strategy selected",
@@ -312,6 +320,7 @@ async def _plan_fetch_method(
         estimatedCacheMisses=plan.estimated_cache_misses,
         selectedFiles=len(plan.files),
         planHint=plan_hint or None,
+        requireBulk=require_bulk,
     )
     return _StageFetchDecision(
         method=selected,
@@ -835,6 +844,7 @@ class InitialSyncStrategy:
                 date_from=from_date,
                 date_to=to_date,
                 exact_dates=trading_dates,
+                require_bulk=ctx.enforce_bulk_for_stock_data,
             )
             total_calls += decision.planner_api_calls
             _emit_fetch_strategy_progress(
@@ -1127,6 +1137,7 @@ class IncrementalSyncStrategy:
                 date_from=from_date_new,
                 date_to=to_date_new,
                 exact_dates=new_dates,
+                require_bulk=ctx.enforce_bulk_for_stock_data,
             )
             total_calls += decision_stock_data.planner_api_calls
             _emit_fetch_strategy_progress(

--- a/apps/bt/src/application/services/sync_strategies.py
+++ b/apps/bt/src/application/services/sync_strategies.py
@@ -12,7 +12,7 @@ import json
 import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from typing import Any, Awaitable, Callable, Literal, Protocol, cast
+from typing import Any, Awaitable, Callable, Literal, NoReturn, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from loguru import logger
@@ -56,6 +56,8 @@ class SyncContext:
     time_series_store: MarketTimeSeriesStore | None = None
     bulk_service: JQuantsBulkService | None = None
     bulk_probe_disabled: bool = False
+    bulk_probe_failure_reason: str | None = None
+    enforce_bulk_for_stock_data: bool = False
 
 
 class SyncStrategy(Protocol):
@@ -77,6 +79,12 @@ class _StageFetchDecision:
     estimated_rest_calls: int
     estimated_bulk_calls: int | None
     plan: BulkFetchPlan | None = None
+    reason: str = "unspecified"
+    reason_detail: str | None = None
+
+
+class BulkFetchRequiredError(RuntimeError):
+    """Raised when stock_data sync requires bulk but planner/execution cannot use it."""
 
 
 _BULK_STOCK_KEY_ALIASES: dict[str, str] = {
@@ -220,6 +228,8 @@ async def _plan_fetch_method(
             estimated_rest_calls=estimated_rest_calls,
             estimated_bulk_calls=None,
             plan=None,
+            reason="bulk_probe_disabled",
+            reason_detail=ctx.bulk_probe_failure_reason,
         )
 
     if estimated_rest_calls < min_rest_calls_to_probe_bulk:
@@ -242,6 +252,7 @@ async def _plan_fetch_method(
             estimated_rest_calls=estimated_rest_calls,
             estimated_bulk_calls=None,
             plan=None,
+            reason="rest_estimate_too_small",
         )
 
     bulk_service = _get_bulk_service(ctx)
@@ -257,6 +268,7 @@ async def _plan_fetch_method(
         # free/unknown plan や一時障害で /bulk/list が失敗した場合は
         # 同期ジョブ全体を止めず、以降は REST に固定して継続する。
         ctx.bulk_probe_disabled = True
+        ctx.bulk_probe_failure_reason = _summarize_exception(e)
         logger.warning(
             "sync bulk plan probe failed, falling back to REST for this job: {}",
             e,
@@ -279,6 +291,8 @@ async def _plan_fetch_method(
             estimated_rest_calls=estimated_rest_calls,
             estimated_bulk_calls=None,
             plan=None,
+            reason="bulk_probe_failed",
+            reason_detail=ctx.bulk_probe_failure_reason,
         )
 
     selected: _FetchMethod = "bulk" if plan.estimated_api_calls < estimated_rest_calls else "rest"
@@ -305,6 +319,7 @@ async def _plan_fetch_method(
         estimated_rest_calls=estimated_rest_calls,
         estimated_bulk_calls=plan.estimated_api_calls,
         plan=plan,
+        reason=reason,
     )
 
 
@@ -440,6 +455,91 @@ def _summarize_exception(exc: Exception, *, limit: int = 200) -> str:
     if len(text) <= limit:
         return text
     return f"{text[: limit - 3]}..."
+
+
+def _describe_bulk_unavailable_reason(
+    *,
+    reason: str,
+    reason_detail: str | None = None,
+) -> str:
+    reason_map = {
+        "bulk_probe_disabled": "bulk probe is disabled after a previous probe failure",
+        "bulk_probe_failed": "bulk plan probe failed",
+        "rest_estimate_too_small": "rest estimate is below bulk probe threshold",
+        "rest_estimate_lower_or_equal": "planner selected REST based on API-call estimate",
+        "bulk_plan_missing": "bulk plan is missing",
+        "bulk_plan_empty": "bulk/list returned no matching files for requested dates",
+        "bulk_fetch_failed": "bulk fetch execution failed",
+    }
+    base = reason_map.get(reason, f"bulk unavailable ({reason})")
+    if not reason_detail:
+        return base
+    return f"{base}: {reason_detail}"
+
+
+def _raise_stock_bulk_required_error(
+    ctx: SyncContext,
+    *,
+    progress_stage: str,
+    current: int,
+    total: int,
+    endpoint: str,
+    reason: str,
+    reason_detail: str | None = None,
+) -> NoReturn:
+    detail = _describe_bulk_unavailable_reason(reason=reason, reason_detail=reason_detail)
+    message = (
+        f"Bulk fetch required for {endpoint} but unavailable ({detail}). "
+        "REST fallback is disabled for stock_data sync."
+    )
+    ctx.on_progress(progress_stage, current, total, message)
+    raise BulkFetchRequiredError(message)
+
+
+def _enforce_stock_bulk_plan_available(
+    ctx: SyncContext,
+    *,
+    decision: _StageFetchDecision,
+    endpoint: str,
+    progress_stage: str,
+    current: int,
+    total: int,
+    target_count: int,
+) -> None:
+    if not ctx.enforce_bulk_for_stock_data or target_count <= 0:
+        return
+
+    if decision.method != "bulk":
+        _raise_stock_bulk_required_error(
+            ctx,
+            progress_stage=progress_stage,
+            current=current,
+            total=total,
+            endpoint=endpoint,
+            reason=decision.reason,
+            reason_detail=decision.reason_detail,
+        )
+
+    if decision.plan is None:
+        _raise_stock_bulk_required_error(
+            ctx,
+            progress_stage=progress_stage,
+            current=current,
+            total=total,
+            endpoint=endpoint,
+            reason="bulk_plan_missing",
+        )
+
+    if len(decision.plan.files) == 0:
+        _raise_stock_bulk_required_error(
+            ctx,
+            progress_stage=progress_stage,
+            current=current,
+            total=total,
+            endpoint=endpoint,
+            reason="bulk_plan_empty",
+            reason_detail=f"targets={target_count} dates",
+        )
 
 
 def _emit_fetch_strategy_progress(
@@ -747,6 +847,16 @@ class InitialSyncStrategy:
                 target_label=f"{len(trading_dates)} dates",
             )
 
+            _enforce_stock_bulk_plan_available(
+                ctx,
+                decision=decision,
+                endpoint="/equities/bars/daily",
+                progress_stage="stock_data",
+                current=3,
+                total=6,
+                target_count=len(trading_dates),
+            )
+
             used_rest_fallback = False
             stock_bulk_fallback_reason: str | None = None
             stage_api_calls = 0
@@ -792,6 +902,16 @@ class InitialSyncStrategy:
                         bulk_result=bulk_result,
                     )
                 except Exception as e:
+                    if ctx.enforce_bulk_for_stock_data and len(trading_dates) > 0:
+                        _raise_stock_bulk_required_error(
+                            ctx,
+                            progress_stage="stock_data",
+                            current=3,
+                            total=6,
+                            endpoint="/equities/bars/daily",
+                            reason="bulk_fetch_failed",
+                            reason_detail=_summarize_exception(e),
+                        )
                     used_rest_fallback = True
                     stock_bulk_fallback_reason = _summarize_exception(e)
                     logger.exception(
@@ -894,6 +1014,8 @@ class InitialSyncStrategy:
                 failedDates=failed_dates,
                 errors=errors,
             )
+        except BulkFetchRequiredError:
+            raise
         except Exception as e:
             return SyncResult(success=False, totalApiCalls=total_calls, errors=[str(e)])
 
@@ -1017,6 +1139,16 @@ class IncrementalSyncStrategy:
                 target_label=f"{len(new_dates)} dates",
             )
 
+            _enforce_stock_bulk_plan_available(
+                ctx,
+                decision=decision_stock_data,
+                endpoint="/equities/bars/daily",
+                progress_stage="stock_data",
+                current=2,
+                total=5,
+                target_count=len(new_dates),
+            )
+
             used_stock_rest_fallback = False
             stock_bulk_fallback_reason: str | None = None
             stock_stage_api_calls = 0
@@ -1062,6 +1194,16 @@ class IncrementalSyncStrategy:
                         bulk_result=stock_bulk_result,
                     )
                 except Exception as e:
+                    if ctx.enforce_bulk_for_stock_data and len(new_dates) > 0:
+                        _raise_stock_bulk_required_error(
+                            ctx,
+                            progress_stage="stock_data",
+                            current=2,
+                            total=5,
+                            endpoint="/equities/bars/daily",
+                            reason="bulk_fetch_failed",
+                            reason_detail=_summarize_exception(e),
+                        )
                     used_stock_rest_fallback = True
                     stock_bulk_fallback_reason = _summarize_exception(e)
                     logger.exception(
@@ -1404,6 +1546,8 @@ class IncrementalSyncStrategy:
                 fundamentalsDatesProcessed=fundamentals_dates_processed,
                 errors=errors,
             )
+        except BulkFetchRequiredError:
+            raise
         except Exception as e:
             return SyncResult(success=False, totalApiCalls=total_calls, errors=[str(e)])
 

--- a/apps/bt/tests/unit/server/services/test_sync_service.py
+++ b/apps/bt/tests/unit/server/services/test_sync_service.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.application.services import sync_service
+from src.application.services.generic_job_manager import GenericJobManager
+from src.application.services.sync_service import SyncMode
+from src.entrypoints.http.schemas.db import SyncResult
+from src.infrastructure.db.market.market_db import METADATA_KEYS
+
+
+class DummyMarketDb:
+    def __init__(self, last_sync_date: str | None = None) -> None:
+        self._last_sync_date = last_sync_date
+        self.ensure_schema_calls = 0
+
+    def get_sync_metadata(self, key: str) -> str | None:
+        if key != METADATA_KEYS["LAST_SYNC_DATE"]:
+            return None
+        return self._last_sync_date
+
+    def ensure_schema(self) -> None:
+        self.ensure_schema_calls += 1
+
+
+class DummyTimeSeriesStore:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class StrategyProbe:
+    def __init__(
+        self,
+        *,
+        result: SyncResult | None = None,
+        error: Exception | None = None,
+        emit_progress: bool = True,
+    ) -> None:
+        self._result = result or SyncResult(success=True, totalApiCalls=1)
+        self._error = error
+        self._emit_progress = emit_progress
+        self.captured_ctx: Any = None
+
+    async def execute(self, ctx: Any) -> SyncResult:
+        self.captured_ctx = ctx
+        if self._emit_progress:
+            ctx.on_progress("stock_data", 1, 2, "running")
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+@pytest.fixture
+def isolated_manager(monkeypatch: pytest.MonkeyPatch) -> GenericJobManager:
+    manager: GenericJobManager = GenericJobManager()
+    monkeypatch.setattr(sync_service, "sync_job_manager", manager)
+    return manager
+
+
+def test_resolve_mode_prefers_requested_non_auto() -> None:
+    market_db = DummyMarketDb(last_sync_date=None)
+    assert sync_service._resolve_mode(SyncMode.INDICES_ONLY, market_db) == "indices-only"
+
+
+def test_resolve_mode_auto_uses_metadata_anchor() -> None:
+    assert sync_service._resolve_mode(SyncMode.AUTO, DummyMarketDb(last_sync_date="2026-03-01T00:00:00+00:00")) == "incremental"
+    assert sync_service._resolve_mode(SyncMode.AUTO, DummyMarketDb(last_sync_date=None)) == "initial"
+
+
+@pytest.mark.asyncio
+async def test_start_sync_requires_duckdb_store(isolated_manager: GenericJobManager) -> None:
+    del isolated_manager
+    with pytest.raises(RuntimeError, match="DuckDB time-series store is required for sync"):
+        await sync_service.start_sync(
+            SyncMode.AUTO,
+            DummyMarketDb(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            time_series_store=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_sync_returns_none_when_manager_rejects_job(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_manager: GenericJobManager,
+) -> None:
+    strategy = StrategyProbe()
+    monkeypatch.setattr(sync_service, "get_strategy", lambda _mode: strategy)
+
+    async def _reject_new_job(_data: Any) -> None:
+        return None
+
+    monkeypatch.setattr(isolated_manager, "create_job", _reject_new_job)
+
+    job = await sync_service.start_sync(
+        SyncMode.AUTO,
+        DummyMarketDb(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        time_series_store=DummyTimeSeriesStore(),  # type: ignore[arg-type]
+    )
+    assert job is None
+
+
+@pytest.mark.asyncio
+async def test_start_sync_completes_job_and_passes_bulk_enforcement(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_manager: GenericJobManager,
+) -> None:
+    strategy = StrategyProbe()
+    monkeypatch.setattr(sync_service, "get_strategy", lambda _mode: strategy)
+
+    market_db = DummyMarketDb(last_sync_date="2026-03-01T00:00:00+00:00")
+    store = DummyTimeSeriesStore()
+    job = await sync_service.start_sync(
+        SyncMode.AUTO,
+        market_db,  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        time_series_store=store,  # type: ignore[arg-type]
+        close_time_series_store=True,
+    )
+    assert job is not None
+    assert job.task is not None
+    await job.task
+
+    stored = isolated_manager.get_job(job.job_id)
+    assert stored is not None
+    assert stored.status.value == "completed"
+    assert stored.result is not None and stored.result.success is True
+    assert stored.progress is not None and stored.progress.percentage == 50.0
+    assert strategy.captured_ctx is not None
+    assert strategy.captured_ctx.enforce_bulk_for_stock_data is True
+    assert market_db.ensure_schema_calls == 1
+    assert store.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_sync_marks_failed_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_manager: GenericJobManager,
+) -> None:
+    strategy = StrategyProbe(emit_progress=False)
+    monkeypatch.setattr(sync_service, "get_strategy", lambda _mode: strategy)
+
+    async def _timeout(coro: Any, *, timeout: float) -> Any:
+        del timeout
+        coro.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(sync_service.asyncio, "wait_for", _timeout)
+
+    job = await sync_service.start_sync(
+        SyncMode.INITIAL,
+        DummyMarketDb(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        time_series_store=DummyTimeSeriesStore(),  # type: ignore[arg-type]
+    )
+    assert job is not None and job.task is not None
+    await job.task
+
+    stored = isolated_manager.get_job(job.job_id)
+    assert stored is not None
+    assert stored.status.value == "failed"
+    assert stored.error is not None and "timed out" in stored.error
+
+
+@pytest.mark.asyncio
+async def test_start_sync_marks_failed_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_manager: GenericJobManager,
+) -> None:
+    strategy = StrategyProbe(error=RuntimeError("boom"))
+    monkeypatch.setattr(sync_service, "get_strategy", lambda _mode: strategy)
+
+    job = await sync_service.start_sync(
+        SyncMode.INCREMENTAL,
+        DummyMarketDb(last_sync_date="2026-03-01T00:00:00+00:00"),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        time_series_store=DummyTimeSeriesStore(),  # type: ignore[arg-type]
+    )
+    assert job is not None and job.task is not None
+    await job.task
+
+    stored = isolated_manager.get_job(job.job_id)
+    assert stored is not None
+    assert stored.status.value == "failed"
+    assert stored.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_start_sync_skips_completion_when_job_already_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_manager: GenericJobManager,
+) -> None:
+    strategy = StrategyProbe()
+    monkeypatch.setattr(sync_service, "get_strategy", lambda _mode: strategy)
+    monkeypatch.setattr(isolated_manager, "is_cancelled", lambda _job_id: True)
+
+    job = await sync_service.start_sync(
+        SyncMode.INITIAL,
+        DummyMarketDb(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        time_series_store=DummyTimeSeriesStore(),  # type: ignore[arg-type]
+    )
+    assert job is not None and job.task is not None
+    await job.task
+
+    stored = isolated_manager.get_job(job.job_id)
+    assert stored is not None
+    # on_progress updates pending -> running, but complete should be skipped.
+    assert stored.status.value == "running"
+    assert stored.result is None

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -12,6 +12,7 @@ from src.application.services.jquants_bulk_service import BulkFetchPlan, BulkFet
 from src.infrastructure.db.market.market_db import METADATA_KEYS
 from src.infrastructure.db.market.time_series_store import TimeSeriesInspection
 from src.application.services.sync_strategies import (
+    BulkFetchRequiredError,
     IncrementalSyncStrategy,
     IndicesOnlySyncStrategy,
     InitialSyncStrategy,
@@ -356,6 +357,7 @@ def _build_ctx(
     time_series_store: DummyTimeSeriesStore | None = None,
     bulk_service: Any = None,
     bulk_probe_disabled: bool = True,
+    enforce_bulk_for_stock_data: bool = False,
 ) -> SyncContext:
     resolved_cancelled = cancelled or asyncio.Event()
     resolved_on_progress = on_progress or (lambda *_: None)
@@ -368,6 +370,7 @@ def _build_ctx(
         time_series_store=resolved_store,  # type: ignore[arg-type]
         bulk_service=bulk_service,  # type: ignore[arg-type]
         bulk_probe_disabled=bulk_probe_disabled,
+        enforce_bulk_for_stock_data=enforce_bulk_for_stock_data,
     )
 
 
@@ -1671,6 +1674,64 @@ async def test_initial_sync_stock_data_bulk_failure_falls_back_to_rest(
     daily_calls = [call for call in client.calls if call[0] == "/equities/bars/daily"]
     assert len(daily_calls) == len(topix_dates)
     assert "/equities/bars/daily" in bulk_service.fetch_calls
+
+
+@pytest.mark.asyncio
+async def test_initial_sync_stock_data_bulk_failure_raises_when_bulk_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    topix_dates = [f"2026-02-{day:02d}" for day in range(10, 13)]
+    market_db = DummyMarketDb()
+    client = InitialSyncClient(topix_dates=topix_dates)
+    bulk_service = _FakeBulkService(fail_endpoints={"/equities/bars/daily"})
+    bulk_plan = BulkFetchPlan(
+        endpoint="/equities/bars/daily",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=3,
+        estimated_cache_hits=0,
+        estimated_cache_misses=1,
+    )
+
+    async def _plan_stub(
+        _ctx: SyncContext,
+        *,
+        stage: str,
+        endpoint: str,
+        estimated_rest_calls: int,
+        **_kwargs: Any,
+    ) -> _StageFetchDecision:
+        if stage == "stock_data_initial":
+            return _StageFetchDecision(
+                method="bulk",
+                planner_api_calls=0,
+                estimated_rest_calls=estimated_rest_calls,
+                estimated_bulk_calls=3,
+                plan=bulk_plan,
+            )
+        return _rest_decision(estimated_rest_calls)
+
+    monkeypatch.setattr("src.application.services.sync_strategies._plan_fetch_method", _plan_stub)
+    monkeypatch.setattr(
+        "src.application.services.sync_strategies._get_bulk_service",
+        lambda _ctx: bulk_service,
+    )
+
+    progress_messages: list[str] = []
+    ctx = _build_ctx(
+        client=client,  # type: ignore[arg-type]
+        market_db=market_db,  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda _stage, _current, _total, message: progress_messages.append(message),
+        enforce_bulk_for_stock_data=True,
+    )
+
+    with pytest.raises(BulkFetchRequiredError, match="REST fallback is disabled"):
+        await InitialSyncStrategy().execute(ctx)
+
+    daily_calls = [call for call in client.calls if call[0] == "/equities/bars/daily"]
+    assert daily_calls == []
+    assert any("Bulk fetch required for /equities/bars/daily" in message for message in progress_messages)
 
 
 @pytest.mark.asyncio

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -805,6 +805,40 @@ async def test_plan_fetch_method_disables_future_probe_after_bulk_probe_failure(
 
 
 @pytest.mark.asyncio
+async def test_plan_fetch_method_requires_bulk_even_when_rest_estimate_is_small() -> None:
+    bulk_plan = BulkFetchPlan(
+        endpoint="/equities/bars/daily",
+        files=[],
+        list_api_calls=1,
+        estimated_api_calls=5,
+        estimated_cache_hits=0,
+        estimated_cache_misses=1,
+    )
+    bulk_service = _PlanOnlyBulkService(bulk_plan)
+    ctx = _build_ctx(
+        client=_PlanOnlyClient("premium"),  # type: ignore[arg-type]
+        market_db=DummyMarketDb(),  # type: ignore[arg-type]
+        cancelled=asyncio.Event(),
+        on_progress=lambda *_: None,
+        bulk_service=bulk_service,  # type: ignore[arg-type]
+        bulk_probe_disabled=False,
+    )
+
+    decision = await _plan_fetch_method(
+        ctx,
+        stage="stock_data_incremental",
+        endpoint="/equities/bars/daily",
+        estimated_rest_calls=1,
+        require_bulk=True,
+    )
+
+    assert decision.method == "bulk"
+    assert decision.reason == "bulk_required"
+    assert decision.planner_api_calls == 1
+    assert bulk_service.build_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_incremental_sync_handles_mixed_date_formats() -> None:
     market_db = DummyMarketDb(latest_trading_date="20260206")
     client = DummyClient()

--- a/apps/ts/packages/web/src/hooks/useDbSync.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useDbSync.test.tsx
@@ -129,7 +129,7 @@ describe('useDbSync hooks', () => {
     const { queryClient, wrapper } = createTestWrapper();
     renderHook(() => useDbStats({ isSyncRunning: true }), { wrapper });
 
-    const query = queryClient.getQueryCache().find({ queryKey: ['db-stats'] });
+    const query = queryClient.getQueryCache().find({ queryKey: ['db-stats', 'running'] });
     const options = query?.options as { refetchInterval?: unknown; staleTime?: unknown } | undefined;
     expect(options?.refetchInterval).toBe(2000);
     expect(options?.staleTime).toBe(0);
@@ -140,7 +140,7 @@ describe('useDbSync hooks', () => {
     const { queryClient, wrapper } = createTestWrapper();
     renderHook(() => useDbValidation({ isSyncRunning: false }), { wrapper });
 
-    const query = queryClient.getQueryCache().find({ queryKey: ['db-validation'] });
+    const query = queryClient.getQueryCache().find({ queryKey: ['db-validation', 'idle'] });
     const options = query?.options as { refetchInterval?: unknown; staleTime?: unknown } | undefined;
     expect(options?.refetchInterval).toBe(30000);
     expect(options?.staleTime).toBe(5000);

--- a/apps/ts/packages/web/src/hooks/useDbSync.ts
+++ b/apps/ts/packages/web/src/hooks/useDbSync.ts
@@ -108,6 +108,13 @@ export function useActiveSyncJob() {
     queryKey: ['sync-job-active'],
     queryFn: fetchActiveJobStatus,
     staleTime: 0,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status === 'pending' || status === 'running') {
+        return 1000;
+      }
+      return 5000;
+    },
   });
 }
 
@@ -129,10 +136,11 @@ export function useDbStats(options?: SnapshotPollingOptions) {
   const isSyncRunning = options?.isSyncRunning ?? false;
   const timing = resolveSnapshotQueryTiming(isSyncRunning);
   return useQuery({
-    queryKey: ['db-stats'],
+    queryKey: ['db-stats', isSyncRunning ? 'running' : 'idle'],
     queryFn: fetchDbStats,
     refetchInterval: timing.refetchInterval,
     staleTime: timing.staleTime,
+    refetchIntervalInBackground: true,
   });
 }
 
@@ -140,10 +148,11 @@ export function useDbValidation(options?: SnapshotPollingOptions) {
   const isSyncRunning = options?.isSyncRunning ?? false;
   const timing = resolveSnapshotQueryTiming(isSyncRunning);
   return useQuery({
-    queryKey: ['db-validation'],
+    queryKey: ['db-validation', isSyncRunning ? 'running' : 'idle'],
     queryFn: fetchDbValidation,
     refetchInterval: timing.refetchInterval,
     staleTime: timing.staleTime,
+    refetchIntervalInBackground: true,
   });
 }
 

--- a/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
@@ -92,6 +92,7 @@ beforeEach(() => {
     },
     isLoading: false,
     error: null,
+    refetch: vi.fn(),
   });
   mockUseDbValidation.mockReturnValue({
     data: {
@@ -101,6 +102,7 @@ beforeEach(() => {
     },
     isLoading: false,
     error: null,
+    refetch: vi.fn(),
   });
   mockStartSyncState.mutate.mockImplementation((_, options) => {
     options?.onSuccess?.({ jobId: 'job-1', status: 'running', mode: 'auto' });
@@ -357,11 +359,13 @@ describe('SettingsPage', () => {
       data: null,
       isLoading: true,
       error: null,
+      refetch: vi.fn(),
     });
     mockUseDbValidation.mockReturnValue({
       data: null,
       isLoading: true,
       error: null,
+      refetch: vi.fn(),
     });
 
     render(<SettingsPage />);
@@ -374,11 +378,13 @@ describe('SettingsPage', () => {
       data: null,
       isLoading: false,
       error: new Error('Failed to load db stats'),
+      refetch: vi.fn(),
     });
     mockUseDbValidation.mockReturnValue({
       data: null,
       isLoading: false,
       error: null,
+      refetch: vi.fn(),
     });
 
     render(<SettingsPage />);

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -273,11 +273,29 @@ export function SettingsPage() {
     setActiveJobId(null);
   }, [syncJobError]);
 
-  const isRunning = jobStatus?.status === 'pending' || jobStatus?.status === 'running';
-  const { data: dbStats, isLoading: isStatsLoading, error: statsError } = useDbStats({ isSyncRunning: isRunning });
-  const { data: dbValidation, isLoading: isValidationLoading, error: validationError } = useDbValidation({
-    isSyncRunning: isRunning,
-  });
+  const isJobStatusRunning = jobStatus?.status === 'pending' || jobStatus?.status === 'running';
+  const isActiveJobRunning = activeSyncJob?.status === 'pending' || activeSyncJob?.status === 'running';
+  const isRunning = startSync.isPending || isJobStatusRunning || (!jobStatus && isActiveJobRunning);
+  const {
+    data: dbStats,
+    isLoading: isStatsLoading,
+    error: statsError,
+    refetch: refetchDbStats,
+  } = useDbStats({ isSyncRunning: isRunning });
+  const {
+    data: dbValidation,
+    isLoading: isValidationLoading,
+    error: validationError,
+    refetch: refetchDbValidation,
+  } = useDbValidation({ isSyncRunning: isRunning });
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+    void refetchDbStats();
+    void refetchDbValidation();
+  }, [isRunning, jobStatus?.progress?.stage, jobStatus?.progress?.current, refetchDbStats, refetchDbValidation]);
 
   const handleStartSync = () => {
     const request: StartSyncRequest = { mode: syncMode };


### PR DESCRIPTION
## Summary
- enforce bulk-only behavior for stock_data stage in /api/db/sync and disable REST fallback
- surface explicit failure reasons when bulk planning/execution is unavailable
- fix Settings > Database Sync snapshot auto-refresh by improving running-state detection and polling/refetch behavior
- add backend/frontend tests for the new sync behavior and snapshot refresh flow
- update AGENTS.md SoT notes for the new sync/runtime behavior

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_sync_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/application/services/sync_service.py apps/bt/src/application/services/sync_strategies.py apps/bt/tests/unit/server/services/test_sync_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pyright apps/bt/src/application/services/sync_service.py apps/bt/src/application/services/sync_strategies.py
- cd apps/ts && bun run --filter @trading25/web test -- src/hooks/useDbSync.test.tsx src/pages/SettingsPage.test.tsx
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/server/services/test_sync_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py && UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt coverage report -m apps/bt/src/application/services/sync_service.py apps/bt/src/application/services/sync_strategies.py
- cd apps/ts/packages/web && bunx vitest run --coverage src/hooks/useDbSync.test.tsx src/pages/SettingsPage.test.tsx --coverage.include=src/hooks/useDbSync.ts --coverage.include=src/pages/SettingsPage.tsx