### PR TITLE
perf(bt): optimize market sync post-bulk processing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `stock_data` の bulk ingest は bulk file 単位で publish し、大量期間同期時のメモリピークによる bulk 失敗→REST fallback を抑制する。fallback 時の progress message は reason を含める
 - `/api/db/sync` と `POST /api/db/stocks/refresh` の時系列アンカー判定・publish/index は DuckDB inspection + time-series store を必須 SoT とし、SQLite `market.db` 時系列テーブルへの fallback を禁止する（inspection 失敗時はエラーで停止）
 - DuckDB time-series store は `publish/index/inspect/close` をプロセス内ロックで直列化し、sync 実行と `/api/db/stats` `/api/db/validate` 参照の同時実行による 500 を防止する
+- DuckDB time-series store の Parquet export は `stock_data` / `indices_data` で全件 `ORDER BY` を行わず、同期スループットを優先する（row order 非依存を前提とする）
 - `market.db` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする

--- a/apps/bt/src/application/services/jquants_bulk_service.py
+++ b/apps/bt/src/application/services/jquants_bulk_service.py
@@ -11,6 +11,7 @@ import gzip
 import hashlib
 import json
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -299,7 +300,9 @@ class JQuantsBulkService:
         )
 
     def _read_csv_gzip_rows(self, path: Path) -> list[dict[str, Any]]:
-        rows: list[dict[str, Any]] = []
+        return list(self._iter_csv_gzip_rows(path))
+
+    def _iter_csv_gzip_rows(self, path: Path) -> Iterator[dict[str, Any]]:
         with gzip.open(path, mode="rt", encoding="utf-8-sig", newline="") as fh:
             reader = csv.DictReader(fh)
             for row in reader:
@@ -317,8 +320,7 @@ class JQuantsBulkService:
                     else:
                         cleaned[key] = raw_value
                 if cleaned:
-                    rows.append(cleaned)
-        return rows
+                    yield cleaned
 
     def _data_cache_path(self, key: str) -> Path:
         digest = hashlib.sha256(key.encode("utf-8")).hexdigest()

--- a/apps/bt/src/application/services/sync_strategies.py
+++ b/apps/bt/src/application/services/sync_strategies.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -340,17 +341,31 @@ def _normalize_bulk_row_keys(
     rows: list[dict[str, Any]],
     aliases: dict[str, str],
 ) -> list[dict[str, Any]]:
+    if not rows:
+        return rows
+
+    # CSV のヘッダは通常全行で共通なので、キー変換は先頭行だけで解決する。
+    first_row = rows[0]
+    remap: dict[str, str] = {}
+    for raw_key in first_row.keys():
+        canonical = _canonicalize_key(str(raw_key))
+        target = aliases.get(canonical)
+        if target and target != raw_key:
+            remap[str(raw_key)] = target
+
+    if not remap:
+        return rows
+
     normalized_rows: list[dict[str, Any]] = []
     for row in rows:
         normalized = dict(row)
-        for raw_key, raw_value in row.items():
-            canonical = _canonicalize_key(str(raw_key))
-            target = aliases.get(canonical)
-            if not target:
+        for raw_key, target in remap.items():
+            if _has_non_empty_value(normalized.get(target)):
                 continue
-            existing = normalized.get(target)
-            if existing is None or (isinstance(existing, str) and not existing.strip()):
-                normalized[target] = raw_value
+            raw_value = row.get(raw_key)
+            if raw_value is None:
+                continue
+            normalized[target] = raw_value
         normalized_rows.append(normalized)
     return normalized_rows
 
@@ -367,10 +382,159 @@ def _normalize_bulk_fins_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]
     return _normalize_bulk_row_keys(rows, _BULK_FINS_KEY_ALIASES)
 
 
+def _has_non_empty_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _normalize_iso_date_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    if (
+        len(text) == 10
+        and text[4] == "-"
+        and text[7] == "-"
+        and text[:4].isdigit()
+        and text[5:7].isdigit()
+        and text[8:10].isdigit()
+    ):
+        try:
+            date(int(text[:4]), int(text[5:7]), int(text[8:10]))
+        except ValueError:
+            return None
+        return text
+
+    if len(text) == 8 and text.isdigit():
+        try:
+            date(int(text[:4]), int(text[4:6]), int(text[6:8]))
+        except ValueError:
+            return None
+        return f"{text[:4]}-{text[4:6]}-{text[6:8]}"
+
+    return _to_iso_date_text(text)
+
+
+def _coerce_float_fast(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = float(text)
+        except ValueError:
+            return None
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+
+def _coerce_int_fast(value: Any) -> int | None:
+    parsed = _coerce_float_fast(value)
+    if parsed is None:
+        return None
+    return int(parsed)
+
+
+def _collect_sample_code(sample_codes: list[str], code: str) -> None:
+    if code in sample_codes:
+        return
+    if len(sample_codes) >= 5:
+        return
+    sample_codes.append(code)
+
+
+def _convert_stock_bulk_rows(
+    data: list[dict[str, Any]],
+    *,
+    target_dates: set[str] | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    skipped = 0
+    sample_codes: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    date_cache: dict[str, str | None] = {}
+    created_at = datetime.now(UTC).isoformat()
+
+    for row in data:
+        code = normalize_stock_code(row.get("Code", row.get("code", "")))
+        if not code:
+            continue
+
+        raw_date_value = row.get("Date", row.get("date"))
+        if isinstance(raw_date_value, date):
+            cache_key = raw_date_value.isoformat()
+        else:
+            cache_key = str(raw_date_value)
+        if cache_key in date_cache:
+            date_text = date_cache[cache_key]
+        else:
+            date_text = _normalize_iso_date_text(raw_date_value)
+            date_cache[cache_key] = date_text
+        if date_text is None:
+            skipped += 1
+            _collect_sample_code(sample_codes, code)
+            continue
+
+        if target_dates is not None and date_text not in target_dates:
+            continue
+
+        open_value = _coerce_float_fast(row.get("AdjO", row.get("O", row.get("open"))))
+        high_value = _coerce_float_fast(row.get("AdjH", row.get("H", row.get("high"))))
+        low_value = _coerce_float_fast(row.get("AdjL", row.get("L", row.get("low"))))
+        close_value = _coerce_float_fast(row.get("AdjC", row.get("C", row.get("close"))))
+        volume_value = _coerce_int_fast(row.get("AdjVo", row.get("Vo", row.get("volume"))))
+        if any(v is None for v in (open_value, high_value, low_value, close_value, volume_value)):
+            skipped += 1
+            _collect_sample_code(sample_codes, code)
+            continue
+
+        row_key = (code, date_text)
+        if row_key in seen:
+            continue
+        seen.add(row_key)
+
+        rows.append(
+            {
+                "code": code,
+                "date": date_text,
+                "open": open_value,
+                "high": high_value,
+                "low": low_value,
+                "close": close_value,
+                "volume": volume_value,
+                "adjustment_factor": _coerce_float_fast(row.get("AdjFactor")),
+                "created_at": created_at,
+            }
+        )
+
+    if skipped > 0:
+        sample = ", ".join(sample_codes) if sample_codes else "unknown"
+        logger.warning(
+            "Skipped {} daily quotes with incomplete OHLCV data (sample codes: {})",
+            skipped,
+            sample,
+        )
+    return rows
+
+
 def _build_target_date_set(dates: list[str]) -> set[str] | None:
     normalized = {
         date_text
-        for date_text in (_to_iso_date_text(value) for value in dates)
+        for date_text in (_normalize_iso_date_text(value) for value in dates)
         if date_text is not None
     }
     return normalized or None
@@ -383,18 +547,7 @@ async def _ingest_stock_bulk_batch(
     target_dates: set[str] | None,
 ) -> int:
     normalized_rows = _normalize_bulk_stock_rows(batch_rows)
-    if target_dates is not None:
-        normalized_rows = [
-            row
-            for row in normalized_rows
-            if _to_iso_date_text(str(row.get("Date") or "")) in target_dates
-        ]
-    rows = validate_rows_required_fields(
-        _convert_stock_data_rows(normalized_rows),
-        required_fields=("code", "date", "open", "high", "low", "close", "volume"),
-        dedupe_keys=("code", "date"),
-        stage="stock_data",
-    )
+    rows = _convert_stock_bulk_rows(normalized_rows, target_dates=target_dates)
     if not rows:
         return 0
     return await _publish_stock_data_rows(ctx, rows)

--- a/apps/bt/src/infrastructure/db/market/time_series_store.py
+++ b/apps/bt/src/infrastructure/db/market/time_series_store.py
@@ -36,7 +36,7 @@ class MarketTimeSeriesStore(Protocol):
 class _TableSpec:
     table_name: str
     parquet_name: str
-    order_by: str
+    order_by: str | None = None
 
 
 @dataclass
@@ -69,8 +69,9 @@ class DuckDbParquetTimeSeriesStore:
 
     _TABLE_SPECS = {
         "topix_data": _TableSpec("topix_data", "topix_data.parquet", "date"),
-        "stock_data": _TableSpec("stock_data", "stock_data.parquet", "date, code"),
-        "indices_data": _TableSpec("indices_data", "indices_data.parquet", "date, code"),
+        # 高カーディナリティ表は export 時の全件 sort が支配的になりやすいため非ソートで出力する。
+        "stock_data": _TableSpec("stock_data", "stock_data.parquet"),
+        "indices_data": _TableSpec("indices_data", "indices_data.parquet"),
         "statements": _TableSpec("statements", "statements.parquet", "disclosed_date, code"),
     }
 
@@ -503,10 +504,11 @@ class DuckDbParquetTimeSeriesStore:
                 output_path.unlink()
 
             escaped = str(output_path).replace("'", "''")
-            self._conn.execute(
-                f"COPY (SELECT * FROM {spec.table_name} ORDER BY {spec.order_by}) "
-                f"TO '{escaped}' (FORMAT PARQUET)"
-            )
+            if spec.order_by:
+                source_sql = f"(SELECT * FROM {spec.table_name} ORDER BY {spec.order_by})"
+            else:
+                source_sql = spec.table_name
+            self._conn.execute(f"COPY {source_sql} TO '{escaped}' (FORMAT PARQUET)")
             self._dirty_tables.discard(table_name)
 
     def close(self) -> None:

--- a/apps/bt/tests/unit/server/services/test_sync_strategies.py
+++ b/apps/bt/tests/unit/server/services/test_sync_strategies.py
@@ -23,6 +23,7 @@ from src.application.services.sync_strategies import (
     _collect_unique_codes,
     _convert_index_master_rows,
     _convert_indices_data_rows,
+    _convert_stock_bulk_rows,
     _convert_stock_rows,
     _date_sort_key,
     _dedupe_preserve_order,
@@ -33,6 +34,7 @@ from src.application.services.sync_strategies import (
     _latest_date,
     _load_metadata_json_list,
     _normalize_date_list,
+    _normalize_iso_date_text,
     _plan_fetch_method,
     _parse_date,
     _to_jquants_date_param,
@@ -2312,6 +2314,31 @@ def test_data_conversion_helpers_handle_aliases_and_invalid_rows() -> None:
     )
     assert len(index_rows_from_lower_hex_code) == 1
     assert index_rows_from_lower_hex_code[0]["code"] == "004A"
+
+
+def test_convert_stock_bulk_rows_skips_invalid_dates_and_dedupes() -> None:
+    rows = _convert_stock_bulk_rows(
+        [
+            {"Code": "72030", "Date": "20260210", "O": "1", "H": "2", "L": "1", "C": "2", "Vo": "100"},
+            {"Code": "72030", "Date": "20260210", "O": "9", "H": "9", "L": "9", "C": "9", "Vo": "999"},
+            {"Code": "72030", "Date": "20260230", "O": "1", "H": "2", "L": "1", "C": "2", "Vo": "100"},
+            {"Code": "72030", "Date": "2026-13-01", "O": "1", "H": "2", "L": "1", "C": "2", "Vo": "100"},
+        ],
+        target_dates={"2026-02-10"},
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["code"] == "7203"
+    assert rows[0]["date"] == "2026-02-10"
+    assert rows[0]["open"] == 1.0
+    assert rows[0]["volume"] == 100
+
+
+def test_normalize_iso_date_text_validates_yyyymmdd_and_hyphen_formats() -> None:
+    assert _normalize_iso_date_text("20260210") == "2026-02-10"
+    assert _normalize_iso_date_text("2026-02-10") == "2026-02-10"
+    assert _normalize_iso_date_text("20260230") is None
+    assert _normalize_iso_date_text("2026-13-01") is None
 
 
 def test_build_fallback_index_master_rows_deduplicates_and_keeps_inputs_immutable() -> None:


### PR DESCRIPTION
## Summary
- optimize stock_data bulk ingest post-fetch path in sync strategy (single-pass conversion/filter/dedupe)
- speed up bulk row-key normalization by resolving header remap once per batch
- reduce DuckDB parquet export cost by skipping full-table ORDER BY for stock_data/indices_data
- add tests for bulk stock conversion date validation and dedupe behavior
- document parquet export ordering policy in AGENTS.md

## Testing
- uv run --project apps/bt ruff check apps/bt/src/application/services/jquants_bulk_service.py apps/bt/src/application/services/sync_strategies.py apps/bt/src/infrastructure/db/market/time_series_store.py apps/bt/tests/unit/server/services/test_sync_strategies.py
- uv run --project apps/bt pyright apps/bt/src/application/services/jquants_bulk_service.py apps/bt/src/application/services/sync_strategies.py apps/bt/src/infrastructure/db/market/time_series_store.py
- uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_jquants_bulk_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/db/test_time_series_store.py
- uv run --project apps/bt coverage run --branch -m pytest apps/bt/tests/unit/server/services/test_jquants_bulk_service.py apps/bt/tests/unit/server/services/test_sync_strategies.py apps/bt/tests/unit/server/db/test_time_series_store.py
- uv run --project apps/bt coverage report -m --show-missing --include='apps/bt/src/application/services/jquants_bulk_service.py,apps/bt/src/application/services/sync_strategies.py,apps/bt/src/infrastructure/db/market/time_series_store.py'