### PR TITLE
fix(bt): normalize mixed 4/5-digit duckdb read paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - Backtest result summary の SoT は成果物セット（`result.html` + `*.metrics.json`）。`/api/backtest/jobs/{id}` と `/api/backtest/result/{id}` は成果物から再解決し、必要時のみ job memory/raw_result をフォールバックとして使う
 - Screening API は非同期ジョブ方式（`POST /api/analytics/screening/jobs` / `GET /api/analytics/screening/jobs/{id}` / `POST /api/analytics/screening/jobs/{id}/cancel` / `GET /api/analytics/screening/result/{id}`）を SoT とする。旧 `GET /api/analytics/screening` は 410
 - Screening 実行時のデータ SoT は `market.duckdb`（`stock_data` / `topix_data` / `indices_data` / `stocks`）とし、dataset へのフォールバックを禁止する
+- `Charts`/`Analysis` の `stock_data` 読み取りは 4桁/5桁コード混在を正規化し、同日重複行は 4桁コード優先で 1 行化する。`stocks` 欠落時でも `stock_data` からの OHLCV 取得を継続する
 - Strategy 設定検証の SoT は backend strict validation（`/api/strategies/{name}/validate` と保存時検証）で、frontend のローカル検証は補助扱い（deprecated）
 - Strategy YAML更新の SoT は `/api/strategies/{name}` で、`production` / `experimental` を更新可能（`production` は既存ファイルの編集のみ許可）。`rename` / `delete` は引き続き `experimental` 限定
 - Strategy `rename` / `delete` の権限判定はトップレベルカテゴリ基準で行い、`experimental/**`（例: `experimental/optuna/foo`）は許可する

--- a/apps/bt/src/application/services/chart_service.py
+++ b/apps/bt/src/application/services/chart_service.py
@@ -240,6 +240,8 @@ class ChartService:
             return None
 
         codes = _db_stock_code_candidates(symbol)
+        if not codes:
+            return None
         placeholders = ",".join("?" for _ in codes)
 
         # 銘柄情報
@@ -248,14 +250,33 @@ class ChartService:
             "ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END LIMIT 1",
             tuple(codes),
         )
-        if stock is None:
-            return None
-        db_code = stock["code"]
+        resolved_codes = _db_stock_code_candidates(stock["code"]) if stock is not None else codes
+        resolved_placeholders = ",".join("?" for _ in resolved_codes)
 
         # OHLCV データ
         rows = self._reader.query(
-            "SELECT date, open, high, low, close, volume FROM stock_data WHERE code = ? ORDER BY date",
-            (db_code,),
+            f"""
+            WITH ranked AS (
+                SELECT
+                    date,
+                    open,
+                    high,
+                    low,
+                    close,
+                    volume,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY date
+                        ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END
+                    ) AS rn
+                FROM stock_data
+                WHERE code IN ({resolved_placeholders})
+            )
+            SELECT date, open, high, low, close, volume
+            FROM ranked
+            WHERE rn = 1
+            ORDER BY date
+            """,
+            tuple(resolved_codes),
         )
         if not rows:
             return None
@@ -274,7 +295,7 @@ class ChartService:
 
         return StockDataResponse(
             symbol=symbol,
-            companyName=stock["company_name"],
+            companyName=stock["company_name"] if stock is not None else "",
             timeframe=timeframe,
             data=data,
             lastUpdated=_now_iso(),

--- a/apps/bt/src/application/services/db_validation_service.py
+++ b/apps/bt/src/application/services/db_validation_service.py
@@ -101,7 +101,6 @@ def validate_market_db(
     ]
     missing_dates = list(inspection.missing_stock_dates)
     missing_dates_count = _resolve_missing_dates_count(inspection)
-    sd_date_count = inspection.stock_date_count
 
     # Adjustment events
     adjustment_events = market_db.get_adjustment_events(limit=20)
@@ -181,7 +180,7 @@ def validate_market_db(
     )
 
     stock_data_val = StockDataValidation(
-        count=sd_date_count,
+        count=inspection.stock_count,
         dateRange=DateRange(
             min=inspection.stock_min,
             max=inspection.stock_max,

--- a/apps/bt/src/application/services/market_ohlcv_loader.py
+++ b/apps/bt/src/application/services/market_ohlcv_loader.py
@@ -28,28 +28,40 @@ def load_stock_ohlcv_df(
 ) -> pd.DataFrame:
     """DuckDB から銘柄 OHLCV を DataFrame で取得する。"""
     candidates = stock_code_candidates(stock_code)
-    placeholders = ",".join("?" for _ in candidates)
-
-    row = reader.query_one(
-        f"SELECT code FROM stocks WHERE code IN ({placeholders}) "
-        "ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END LIMIT 1",
-        tuple(candidates),
-    )
-    if row is None:
+    if not candidates:
         return pd.DataFrame()
 
-    db_code = row["code"]
-    sql = "SELECT date, open, high, low, close, volume FROM stock_data WHERE code = ?"
-    params: list[str] = [db_code]
-
+    placeholders = ",".join("?" for _ in candidates)
+    where_conditions = [f"code IN ({placeholders})"]
+    params: list[str] = list(candidates)
     if start_date:
-        sql += " AND date >= ?"
+        where_conditions.append("date >= ?")
         params.append(start_date)
     if end_date:
-        sql += " AND date <= ?"
+        where_conditions.append("date <= ?")
         params.append(end_date)
 
-    sql += " ORDER BY date"
+    sql = f"""
+        WITH ranked AS (
+            SELECT
+                date,
+                open,
+                high,
+                low,
+                close,
+                volume,
+                ROW_NUMBER() OVER (
+                    PARTITION BY date
+                    ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END
+                ) AS rn
+            FROM stock_data
+            WHERE {" AND ".join(where_conditions)}
+        )
+        SELECT date, open, high, low, close, volume
+        FROM ranked
+        WHERE rn = 1
+        ORDER BY date
+    """
     rows = reader.query(sql, tuple(params))
     if not rows:
         return pd.DataFrame()

--- a/apps/bt/src/application/services/ranking_service.py
+++ b/apps/bt/src/application/services/ranking_service.py
@@ -45,6 +45,83 @@ def _build_market_filter(market_codes: list[str]) -> tuple[str, list[str]]:
     return f" AND s.market_code IN ({placeholders})", market_codes
 
 
+def _normalized_code_sql(column_ref: str) -> str:
+    """4桁/5桁コード混在を吸収する正規化SQL式。"""
+    return (
+        "CASE "
+        f"WHEN length({column_ref}) = 5 AND right({column_ref}, 1) = '0' "
+        f"THEN left({column_ref}, 4) "
+        f"ELSE {column_ref} "
+        "END"
+    )
+
+
+def _prefer_4digit_order_sql(column_ref: str) -> str:
+    return f"CASE WHEN length({column_ref}) = 4 THEN 0 ELSE 1 END"
+
+
+def _stocks_canonical_cte() -> str:
+    normalized = _normalized_code_sql("code")
+    order = _prefer_4digit_order_sql("code")
+    return f"""
+        stocks_canonical AS (
+            SELECT
+                code,
+                company_name,
+                market_code,
+                sector_33_name,
+                normalized_code
+            FROM (
+                SELECT
+                    code,
+                    company_name,
+                    market_code,
+                    sector_33_name,
+                    {normalized} AS normalized_code,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY {normalized}
+                        ORDER BY {order}
+                    ) AS rn
+                FROM stocks
+            )
+            WHERE rn = 1
+        )
+    """
+
+
+def _stock_data_dedup_cte(
+    cte_name: str,
+    *,
+    where_clause: str,
+    code_ref: str = "code",
+    include_ohlc: bool = True,
+) -> str:
+    normalized = _normalized_code_sql(code_ref)
+    order = _prefer_4digit_order_sql(code_ref)
+    select_ohlc = ", open, high, low, close, volume" if include_ohlc else ", close, volume"
+    return f"""
+        {cte_name} AS (
+            SELECT
+                normalized_code,
+                date
+                {select_ohlc}
+            FROM (
+                SELECT
+                    {normalized} AS normalized_code,
+                    date
+                    {select_ohlc},
+                    ROW_NUMBER() OVER (
+                        PARTITION BY {normalized}, date
+                        ORDER BY {order}
+                    ) AS rn
+                FROM stock_data
+                WHERE {where_clause}
+            )
+            WHERE rn = 1
+        )
+    """
+
+
 RANKING_BASE_COLUMNS = "s.code, s.company_name, s.market_code, s.sector_33_name"
 FUNDAMENTAL_BASE_COLUMNS = (
     "s.code, s.company_name, s.market_code, s.sector_33_name, "
@@ -232,11 +309,17 @@ class RankingService:
         market_codes: list[str],
     ) -> list[Mapping[str, Any]]:
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        stock_daily_cte = _stock_data_dedup_cte("stock_daily", where_clause="date = ?")
         sql = f"""
+            WITH
+            {stocks_cte},
+            {stock_daily_cte}
             SELECT {FUNDAMENTAL_BASE_COLUMNS}
-            FROM stocks s
-            JOIN stock_data sd ON sd.code = s.code
-            WHERE sd.date = ?{market_clause}
+            FROM stocks_canonical s
+            JOIN stock_daily sd
+                ON sd.normalized_code = s.normalized_code
+            WHERE 1 = 1{market_clause}
         """
         return self._reader.query(sql, (date, *market_params))
 
@@ -246,20 +329,55 @@ class RankingService:
         market_codes: list[str],
     ) -> list[Mapping[str, Any]]:
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        stock_daily_cte = _stock_data_dedup_cte("stock_daily", where_clause="date = ?")
+        statements_norm = _normalized_code_sql("code")
+        statements_order = _prefer_4digit_order_sql("code")
         sql = f"""
+            WITH
+            {stocks_cte},
+            {stock_daily_cte},
+            statements_canonical AS (
+                SELECT
+                    normalized_code,
+                    disclosed_date,
+                    type_of_current_period,
+                    earnings_per_share,
+                    forecast_eps,
+                    next_year_forecast_earnings_per_share,
+                    shares_outstanding
+                FROM (
+                    SELECT
+                        {statements_norm} AS normalized_code,
+                        disclosed_date,
+                        type_of_current_period,
+                        earnings_per_share,
+                        forecast_eps,
+                        next_year_forecast_earnings_per_share,
+                        shares_outstanding,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY {statements_norm}, disclosed_date
+                            ORDER BY {statements_order}
+                        ) AS rn
+                    FROM statements
+                )
+                WHERE rn = 1
+            )
             SELECT
-                st.code,
+                s.code,
                 st.disclosed_date,
                 st.type_of_current_period,
                 st.earnings_per_share,
                 st.forecast_eps,
                 st.next_year_forecast_earnings_per_share,
                 st.shares_outstanding
-            FROM statements st
-            JOIN stocks s ON s.code = st.code
-            JOIN stock_data sd ON sd.code = st.code
-            WHERE sd.date = ?{market_clause}
-            ORDER BY st.code, st.disclosed_date DESC
+            FROM statements_canonical st
+            JOIN stocks_canonical s
+                ON s.normalized_code = st.normalized_code
+            JOIN stock_daily sd
+                ON sd.normalized_code = st.normalized_code
+            WHERE 1 = 1{market_clause}
+            ORDER BY s.code, st.disclosed_date DESC
         """
         return self._reader.query(sql, (date, *market_params))
 
@@ -389,14 +507,20 @@ class RankingService:
     ) -> list[RankingItem]:
         """売買代金ランキング（単日）"""
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        stock_daily_cte = _stock_data_dedup_cte("stock_daily", where_clause="date = ?")
         sql = f"""
+            WITH
+            {stocks_cte},
+            {stock_daily_cte}
             SELECT {RANKING_BASE_COLUMNS},
                 sd.close as current_price,
                 sd.volume,
                 sd.close * sd.volume as trading_value
-            FROM stock_data sd
-            JOIN stocks s ON s.code = sd.code
-            WHERE sd.date = ?{market_clause}
+            FROM stock_daily sd
+            JOIN stocks_canonical s
+                ON s.normalized_code = sd.normalized_code
+            WHERE 1 = 1{market_clause}
             ORDER BY trading_value DESC LIMIT ?
         """
         rows = self._reader.query(sql, (date, *market_params, limit))
@@ -414,14 +538,23 @@ class RankingService:
             return []
 
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        stock_window_cte = _stock_data_dedup_cte(
+            "stock_window",
+            where_clause="date >= ? AND date <= ?",
+        )
         sql = f"""
+            WITH
+            {stocks_cte},
+            {stock_window_cte}
             SELECT {RANKING_BASE_COLUMNS},
                 MAX(sd.close) as current_price,
                 SUM(sd.volume) as volume,
                 AVG(sd.close * sd.volume) as avg_trading_value
-            FROM stock_data sd
-            JOIN stocks s ON s.code = sd.code
-            WHERE sd.date >= ? AND sd.date <= ?{market_clause}
+            FROM stock_window sd
+            JOIN stocks_canonical s
+                ON s.normalized_code = sd.normalized_code
+            WHERE 1 = 1{market_clause}
             GROUP BY s.code, s.company_name, s.market_code, s.sector_33_name
             ORDER BY avg_trading_value DESC LIMIT ?
         """
@@ -444,18 +577,26 @@ class RankingService:
             return []
 
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        curr_cte = _stock_data_dedup_cte("curr_daily", where_clause="date = ?")
+        prev_cte = _stock_data_dedup_cte("prev_daily", where_clause="date = ?")
         sql = f"""
+            WITH
+            {stocks_cte},
+            {curr_cte},
+            {prev_cte}
             SELECT {RANKING_BASE_COLUMNS},
                 curr.close as current_price,
                 curr.volume,
                 prev.close as previous_price,
                 (curr.close - prev.close) as change_amount,
                 ((curr.close - prev.close) / prev.close * 100) as change_percentage
-            FROM stock_data curr
-            JOIN stock_data prev ON curr.code = prev.code
-            JOIN stocks s ON s.code = curr.code
-            WHERE curr.date = ?
-                AND prev.date = ?
+            FROM curr_daily curr
+            JOIN prev_daily prev
+                ON curr.normalized_code = prev.normalized_code
+            JOIN stocks_canonical s
+                ON s.normalized_code = curr.normalized_code
+            WHERE 1 = 1
                 AND prev.close > 0
                 AND curr.close > 0
                 AND curr.close != prev.close{market_clause}
@@ -481,18 +622,26 @@ class RankingService:
             return []
 
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        curr_cte = _stock_data_dedup_cte("curr_daily", where_clause="date = ?")
+        base_cte = _stock_data_dedup_cte("base_daily", where_clause="date = ?")
         sql = f"""
+            WITH
+            {stocks_cte},
+            {curr_cte},
+            {base_cte}
             SELECT {RANKING_BASE_COLUMNS},
                 curr.close as current_price,
                 curr.volume,
                 base.close as base_price,
                 (curr.close - base.close) as change_amount,
                 ((curr.close - base.close) / base.close * 100) as change_percentage
-            FROM stock_data curr
-            JOIN stock_data base ON curr.code = base.code
-            JOIN stocks s ON s.code = curr.code
-            WHERE curr.date = ?
-                AND base.date = ?
+            FROM curr_daily curr
+            JOIN base_daily base
+                ON curr.normalized_code = base.normalized_code
+            JOIN stocks_canonical s
+                ON s.normalized_code = curr.normalized_code
+            WHERE 1 = 1
                 AND base.close > 0
                 AND curr.close > 0
                 AND curr.close != base.close{market_clause}
@@ -519,12 +668,21 @@ class RankingService:
             return []
 
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        stock_window_cte = _stock_data_dedup_cte(
+            "stock_window",
+            where_clause="date > ? AND date < ?",
+        )
+        curr_cte = _stock_data_dedup_cte("curr_daily", where_clause="date = ?")
         sql = f"""
-            WITH period_high AS (
-                SELECT code, MAX(high) as max_high
-                FROM stock_data
-                WHERE date > ? AND date < ?
-                GROUP BY code
+            WITH
+            {stocks_cte},
+            {stock_window_cte},
+            {curr_cte},
+            period_high AS (
+                SELECT normalized_code, MAX(high) as max_high
+                FROM stock_window
+                GROUP BY normalized_code
             )
             SELECT {RANKING_BASE_COLUMNS},
                 curr.close as current_price,
@@ -533,11 +691,12 @@ class RankingService:
                 ph.max_high as base_price,
                 (curr.close - ph.max_high) as change_amount,
                 ((curr.close - ph.max_high) / ph.max_high * 100) as change_percentage
-            FROM stock_data curr
-            JOIN stocks s ON s.code = curr.code
-            JOIN period_high ph ON ph.code = curr.code
-            WHERE curr.date = ?
-                AND curr.close >= ph.max_high
+            FROM curr_daily curr
+            JOIN stocks_canonical s
+                ON s.normalized_code = curr.normalized_code
+            JOIN period_high ph
+                ON ph.normalized_code = curr.normalized_code
+            WHERE curr.close >= ph.max_high
                 AND ph.max_high > 0{market_clause}
             ORDER BY change_percentage DESC LIMIT ?
         """
@@ -563,12 +722,21 @@ class RankingService:
             return []
 
         market_clause, market_params = _build_market_filter(market_codes)
+        stocks_cte = _stocks_canonical_cte()
+        stock_window_cte = _stock_data_dedup_cte(
+            "stock_window",
+            where_clause="date > ? AND date < ?",
+        )
+        curr_cte = _stock_data_dedup_cte("curr_daily", where_clause="date = ?")
         sql = f"""
-            WITH period_low AS (
-                SELECT code, MIN(low) as min_low
-                FROM stock_data
-                WHERE date > ? AND date < ?
-                GROUP BY code
+            WITH
+            {stocks_cte},
+            {stock_window_cte},
+            {curr_cte},
+            period_low AS (
+                SELECT normalized_code, MIN(low) as min_low
+                FROM stock_window
+                GROUP BY normalized_code
             )
             SELECT {RANKING_BASE_COLUMNS},
                 curr.close as current_price,
@@ -577,11 +745,12 @@ class RankingService:
                 pl.min_low as base_price,
                 (curr.close - pl.min_low) as change_amount,
                 ((curr.close - pl.min_low) / pl.min_low * 100) as change_percentage
-            FROM stock_data curr
-            JOIN stocks s ON s.code = curr.code
-            JOIN period_low pl ON pl.code = curr.code
-            WHERE curr.date = ?
-                AND curr.close <= pl.min_low
+            FROM curr_daily curr
+            JOIN stocks_canonical s
+                ON s.normalized_code = curr.normalized_code
+            JOIN period_low pl
+                ON pl.normalized_code = curr.normalized_code
+            WHERE curr.close <= pl.min_low
                 AND pl.min_low > 0{market_clause}
             ORDER BY change_percentage ASC LIMIT ?
         """

--- a/apps/bt/src/infrastructure/db/market/market_db.py
+++ b/apps/bt/src/infrastructure/db/market/market_db.py
@@ -110,12 +110,24 @@ class MarketDb:
                 return self._conn.execute(sql)
             return self._conn.execute(sql, params)
 
+    def _fetchone(self, sql: str, params: list[Any] | tuple[Any, ...] | None = None) -> Any:
+        with self._lock:
+            if params is None:
+                return self._conn.execute(sql).fetchone()
+            return self._conn.execute(sql, params).fetchone()
+
+    def _fetchall(self, sql: str, params: list[Any] | tuple[Any, ...] | None = None) -> list[Any]:
+        with self._lock:
+            if params is None:
+                return self._conn.execute(sql).fetchall()
+            return self._conn.execute(sql, params).fetchall()
+
     def _executemany(self, sql: str, params_seq: list[tuple[Any, ...]]) -> None:
         with self._lock:
             self._conn.executemany(sql, params_seq)
 
     def _table_exists(self, table_name: str) -> bool:
-        row = self._execute(
+        row = self._fetchone(
             """
             SELECT 1
             FROM information_schema.tables
@@ -123,14 +135,14 @@ class MarketDb:
             LIMIT 1
             """,
             [table_name],
-        ).fetchone()
+        )
         return row is not None
 
     def _count_rows(self, table_name: str) -> int:
         if not self._table_exists(table_name):
             return 0
         escaped = self._quote_identifier(table_name)
-        row = self._execute(f"SELECT COUNT(*) FROM {escaped}").fetchone()
+        row = self._fetchone(f"SELECT COUNT(*) FROM {escaped}")
         return int(row[0] or 0) if row else 0
 
     def ensure_schema(self) -> None:
@@ -260,7 +272,7 @@ class MarketDb:
         """既存 statements テーブルに不足カラムを追加する。"""
         existing_columns = {
             str(row[1])
-            for row in self._execute("PRAGMA table_info('statements')").fetchall()
+            for row in self._fetchall("PRAGMA table_info('statements')")
             if row and len(row) > 1
         }
         for column_name, column_type in _STATEMENTS_ADDITIONAL_COLUMNS:
@@ -280,7 +292,7 @@ class MarketDb:
         """スキーマ検証: 必要なテーブルが存在するか確認。"""
         existing = {
             str(row[0])
-            for row in self._execute("SELECT table_name FROM information_schema.tables").fetchall()
+            for row in self._fetchall("SELECT table_name FROM information_schema.tables")
             if row and row[0]
         }
         required = set(_STATS_TABLES)
@@ -296,37 +308,37 @@ class MarketDb:
         """sync_metadata からキーの値を取得。"""
         if not self._table_exists("sync_metadata"):
             return None
-        row = self._execute(
+        row = self._fetchone(
             "SELECT value FROM sync_metadata WHERE key = ?",
             [key],
-        ).fetchone()
+        )
         return str(row[0]) if row and row[0] is not None else None
 
     def get_latest_trading_date(self) -> str | None:
         """topix_data の最新取引日を取得。"""
         if not self._table_exists("topix_data"):
             return None
-        row = self._execute("SELECT MAX(date) FROM topix_data").fetchone()
+        row = self._fetchone("SELECT MAX(date) FROM topix_data")
         return str(row[0]) if row and row[0] is not None else None
 
     def get_latest_stock_data_date(self) -> str | None:
         """stock_data の最新取引日を取得。"""
         if not self._table_exists("stock_data"):
             return None
-        row = self._execute("SELECT MAX(date) FROM stock_data").fetchone()
+        row = self._fetchone("SELECT MAX(date) FROM stock_data")
         return str(row[0]) if row and row[0] is not None else None
 
     def get_latest_indices_data_dates(self) -> dict[str, str]:
         """indices_data の銘柄コードごとの最新取引日を取得。"""
         if not self._table_exists("indices_data"):
             return {}
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT code, MAX(date) AS max_date
             FROM indices_data
             GROUP BY code
             """
-        ).fetchall()
+        )
         return {
             str(row[0]): str(row[1])
             for row in rows
@@ -337,7 +349,7 @@ class MarketDb:
         """index_master に存在する指数コード一覧を取得。"""
         if not self._table_exists("index_master"):
             return set()
-        rows = self._execute("SELECT code FROM index_master").fetchall()
+        rows = self._fetchall("SELECT code FROM index_master")
         return {
             str(row[0])
             for row in rows
@@ -348,14 +360,14 @@ class MarketDb:
         """statements の最新開示日を取得。"""
         if not self._table_exists("statements"):
             return None
-        row = self._execute("SELECT MAX(disclosed_date) FROM statements").fetchone()
+        row = self._fetchone("SELECT MAX(disclosed_date) FROM statements")
         return str(row[0]) if row and row[0] is not None else None
 
     def get_statement_codes(self) -> set[str]:
         """statements に存在する銘柄コード一覧を取得。"""
         if not self._table_exists("statements"):
             return set()
-        rows = self._execute("SELECT DISTINCT code FROM statements WHERE code IS NOT NULL").fetchall()
+        rows = self._fetchall("SELECT DISTINCT code FROM statements WHERE code IS NOT NULL")
         return {
             str(row[0])
             for row in rows
@@ -369,7 +381,7 @@ class MarketDb:
 
         available = {
             str(row[1])
-            for row in self._execute("PRAGMA table_info('statements')").fetchall()
+            for row in self._fetchall("PRAGMA table_info('statements')")
             if row and len(row) > 1
         }
         counts: dict[str, int] = {}
@@ -378,9 +390,9 @@ class MarketDb:
                 counts[column] = 0
                 continue
             escaped = self._quote_identifier(column)
-            row = self._execute(
+            row = self._fetchone(
                 f"SELECT COUNT(*) FROM statements WHERE {escaped} IS NOT NULL"
-            ).fetchone()
+            )
             counts[column] = int(row[0] or 0) if row else 0
         return counts
 
@@ -388,13 +400,13 @@ class MarketDb:
         """stocks から Prime 銘柄コードを取得（legacy 表記も吸収）。"""
         if not self._table_exists("stocks"):
             return set()
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT code
             FROM stocks
             WHERE lower(trim(market_code)) IN ('0111', 'prime')
             """
-        ).fetchall()
+        )
         return {
             str(row[0])
             for row in rows
@@ -669,9 +681,9 @@ class MarketDb:
         """TOPIX 日付範囲 + 件数。"""
         if not self._table_exists("topix_data"):
             return None
-        row = self._execute(
+        row = self._fetchone(
             "SELECT COUNT(date), MIN(date), MAX(date) FROM topix_data"
-        ).fetchone()
+        )
         if row is None or row[1] is None:
             return None
         return {"count": int(row[0] or 0), "min": str(row[1]), "max": str(row[2])}
@@ -680,7 +692,7 @@ class MarketDb:
         """stock_data 日付範囲 + 統計。"""
         if not self._table_exists("stock_data"):
             return None
-        row = self._execute(
+        row = self._fetchone(
             """
             SELECT
                 COUNT(*),
@@ -689,7 +701,7 @@ class MarketDb:
                 COUNT(DISTINCT date)
             FROM stock_data
             """
-        ).fetchone()
+        )
         if row is None or row[1] is None:
             return None
         count = int(row[0] or 0)
@@ -707,13 +719,13 @@ class MarketDb:
         """市場別の銘柄数。"""
         if not self._table_exists("stocks"):
             return {}
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT market_name, COUNT(code)
             FROM stocks
             GROUP BY market_name
             """
-        ).fetchall()
+        )
         return {
             str(row[0]): int(row[1] or 0)
             for row in rows
@@ -733,7 +745,7 @@ class MarketDb:
                 "byCategory": by_category,
             }
 
-        row = self._execute(
+        row = self._fetchone(
             """
             SELECT
                 COUNT(*),
@@ -742,7 +754,7 @@ class MarketDb:
                 MAX(date)
             FROM indices_data
             """
-        ).fetchone()
+        )
         by_category = self._load_index_master_category_counts()
         if row is None or row[2] is None:
             return {
@@ -763,13 +775,13 @@ class MarketDb:
     def _load_index_master_category_counts(self) -> dict[str, int]:
         if not self._table_exists("index_master"):
             return {}
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT category, COUNT(code)
             FROM index_master
             GROUP BY category
             """
-        ).fetchall()
+        )
         return {
             str(row[0]): int(row[1] or 0)
             for row in rows
@@ -777,9 +789,22 @@ class MarketDb:
         }
 
     def is_initialized(self) -> bool:
-        """sync_metadata に init_completed があるか。"""
+        """DB 初期化済みかを判定する。
+
+        優先判定:
+        1. sync_metadata.init_completed が存在する場合はその値を使用
+        2. metadata 欠落時は既存データ量から推定（移行済みDBの後方互換）
+        """
         val = self.get_sync_metadata(METADATA_KEYS["INIT_COMPLETED"])
-        return val == "true"
+        if val is not None:
+            return val.strip().lower() == "true"
+
+        has_stocks = self._count_rows("stocks") > 0
+        has_time_series = any(
+            self._count_rows(table_name) > 0
+            for table_name in ("stock_data", "topix_data", "indices_data")
+        )
+        return has_stocks and has_time_series
 
     def get_db_file_size(self) -> int:
         """DB ファイルサイズ。"""
@@ -797,7 +822,7 @@ class MarketDb:
         if not self._table_exists("topix_data") or not self._table_exists("stock_data"):
             return []
 
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT t.date
             FROM topix_data t
@@ -807,28 +832,28 @@ class MarketDb:
             LIMIT ?
             """,
             [int(limit)],
-        ).fetchall()
+        )
         return [str(row[0]) for row in rows if row and row[0]]
 
     def get_missing_stock_data_dates_count(self) -> int:
         """TOPIX 日付のうち stock_data に存在しない日付の総数。"""
         if not self._table_exists("topix_data") or not self._table_exists("stock_data"):
             return 0
-        row = self._execute(
+        row = self._fetchone(
             """
             SELECT COUNT(*)
             FROM topix_data t
             LEFT JOIN (SELECT DISTINCT date FROM stock_data) s ON t.date = s.date
             WHERE s.date IS NULL
             """
-        ).fetchone()
+        )
         return int(row[0] or 0) if row else 0
 
     def get_adjustment_events(self, limit: int = 20) -> list[dict[str, Any]]:
         """adjustment_factor != 1.0 のイベント。"""
         if limit <= 0 or not self._table_exists("stock_data"):
             return []
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT code, date, adjustment_factor, close
             FROM stock_data
@@ -838,7 +863,7 @@ class MarketDb:
             LIMIT ?
             """,
             [int(limit)],
-        ).fetchall()
+        )
         return [
             {
                 "code": str(row[0]),
@@ -855,7 +880,7 @@ class MarketDb:
         """調整イベントがある銘柄のうち再取得が必要なもの。"""
         if limit <= 0 or not self._table_exists("stock_data"):
             return []
-        rows = self._execute(
+        rows = self._fetchall(
             """
             SELECT DISTINCT code
             FROM stock_data
@@ -864,12 +889,12 @@ class MarketDb:
             LIMIT ?
             """,
             [int(limit)],
-        ).fetchall()
+        )
         return [str(row[0]) for row in rows if row and row[0]]
 
     def get_stock_data_unique_date_count(self) -> int:
         """stock_data のユニーク日付数。"""
         if not self._table_exists("stock_data"):
             return 0
-        row = self._execute("SELECT COUNT(DISTINCT date) FROM stock_data").fetchone()
+        row = self._fetchone("SELECT COUNT(DISTINCT date) FROM stock_data")
         return int(row[0] or 0) if row else 0

--- a/apps/bt/tests/unit/server/db/test_market_db.py
+++ b/apps/bt/tests/unit/server/db/test_market_db.py
@@ -53,6 +53,78 @@ class TestMarketDbBasics:
         market_db.set_sync_metadata("last_sync", "2024-01-02")
         assert market_db.get_sync_metadata("last_sync") == "2024-01-02"
 
+    def test_is_initialized_falls_back_to_existing_data_when_metadata_is_missing(
+        self, market_db: MarketDb
+    ) -> None:
+        assert market_db.get_sync_metadata("init_completed") is None
+        assert market_db.is_initialized() is False
+
+        market_db.upsert_stocks(
+            [
+                {
+                    "code": "7203",
+                    "company_name": "トヨタ",
+                    "market_code": "0111",
+                    "market_name": "プライム",
+                    "sector_17_code": "6",
+                    "sector_17_name": "自動車",
+                    "sector_33_code": "3700",
+                    "sector_33_name": "輸送用機器",
+                    "listed_date": "1949-05-16",
+                }
+            ]
+        )
+        market_db.upsert_stock_data(
+            [
+                {
+                    "code": "7203",
+                    "date": "2024-01-15",
+                    "open": 2500.0,
+                    "high": 2510.0,
+                    "low": 2490.0,
+                    "close": 2505.0,
+                    "volume": 1000000,
+                }
+            ]
+        )
+
+        assert market_db.is_initialized() is True
+
+    def test_is_initialized_prioritizes_explicit_metadata_flag(
+        self, market_db: MarketDb
+    ) -> None:
+        market_db.upsert_stocks(
+            [
+                {
+                    "code": "7203",
+                    "company_name": "トヨタ",
+                    "market_code": "0111",
+                    "market_name": "プライム",
+                    "sector_17_code": "6",
+                    "sector_17_name": "自動車",
+                    "sector_33_code": "3700",
+                    "sector_33_name": "輸送用機器",
+                    "listed_date": "1949-05-16",
+                }
+            ]
+        )
+        market_db.upsert_stock_data(
+            [
+                {
+                    "code": "7203",
+                    "date": "2024-01-15",
+                    "open": 2500.0,
+                    "high": 2510.0,
+                    "low": 2490.0,
+                    "close": 2505.0,
+                    "volume": 1000000,
+                }
+            ]
+        )
+        market_db.set_sync_metadata("init_completed", "false")
+
+        assert market_db.is_initialized() is False
+
 
 class TestMarketDbUpserts:
     def test_upsert_stocks_and_counts(self, market_db: MarketDb) -> None:

--- a/apps/bt/tests/unit/server/services/test_chart_service.py
+++ b/apps/bt/tests/unit/server/services/test_chart_service.py
@@ -108,3 +108,77 @@ class TestSectorStocksMarketCodeCompatibility:
         assert result is not None
         assert result.markets == ["prime", "standard"]
         assert len(result.stocks) == 4
+
+
+def test_get_stock_from_db_supports_mixed_stock_and_stock_data_codes(tmp_path) -> None:
+    db_path = str(tmp_path / "chart-mixed-codes.db")
+    conn = duckdb.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE stocks (
+            code TEXT PRIMARY KEY,
+            company_name TEXT NOT NULL,
+            company_name_english TEXT,
+            market_code TEXT NOT NULL,
+            market_name TEXT NOT NULL,
+            sector_17_code TEXT NOT NULL,
+            sector_17_name TEXT NOT NULL,
+            sector_33_code TEXT NOT NULL,
+            sector_33_name TEXT NOT NULL,
+            scale_category TEXT,
+            listed_date TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE stock_data (
+            code TEXT NOT NULL,
+            date TEXT NOT NULL,
+            open REAL NOT NULL,
+            high REAL NOT NULL,
+            low REAL NOT NULL,
+            close REAL NOT NULL,
+            volume INTEGER NOT NULL,
+            adjustment_factor REAL,
+            created_at TEXT,
+            PRIMARY KEY (code, date)
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO stocks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "7203",
+            "Toyota",
+            "TOYOTA",
+            "prime",
+            "Market",
+            "S17",
+            "セクター17",
+            "S33",
+            "セクター33",
+            "TOPIX Large70",
+            "2020-01-01",
+            None,
+            None,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("72030", "2026-02-06", 100.0, 110.0, 95.0, 105.0, 100_000, 1.0, None),
+    )
+    conn.close()
+
+    reader = MarketDbReader(db_path)
+    try:
+        service = ChartService(reader, None)
+        result = service._get_stock_from_db("7203", "daily")  # noqa: SLF001
+        assert result is not None
+        assert result.companyName == "Toyota"
+        assert len(result.data) == 1
+        assert result.data[0].close == 105.0
+    finally:
+        reader.close()

--- a/apps/bt/tests/unit/server/services/test_market_ohlcv_loader.py
+++ b/apps/bt/tests/unit/server/services/test_market_ohlcv_loader.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import duckdb
 import pandas as pd
 
 from src.infrastructure.db.market.market_reader import MarketDbReader
@@ -64,6 +67,52 @@ def test_load_stock_ohlcv_df_out_of_range_returns_empty(market_db_path: str) -> 
             end_date="2030-12-31",
         )
         assert df.empty
+    finally:
+        reader.close()
+
+
+def test_load_stock_ohlcv_df_handles_mixed_code_formats(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "mixed-stock-codes.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE stock_data (
+                code TEXT NOT NULL,
+                date TEXT NOT NULL,
+                open DOUBLE NOT NULL,
+                high DOUBLE NOT NULL,
+                low DOUBLE NOT NULL,
+                close DOUBLE NOT NULL,
+                volume BIGINT NOT NULL,
+                adjustment_factor DOUBLE,
+                created_at TEXT,
+                PRIMARY KEY (code, date)
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("72030", "2024-01-15", 2500.0, 2520.0, 2490.0, 2510.0, 1_000_000, 1.0, None),
+        )
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("72030", "2024-01-16", 2510.0, 2530.0, 2500.0, 2512.0, 1_100_000, 1.0, None),
+        )
+        # 同日重複（4桁/5桁混在）時は4桁を優先する。
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("7203", "2024-01-16", 2512.0, 2535.0, 2505.0, 2515.0, 1_200_000, 1.0, None),
+        )
+    finally:
+        conn.close()
+
+    reader = MarketDbReader(db_path)
+    try:
+        df = load_stock_ohlcv_df(reader, "7203")
+        assert len(df) == 2
+        assert float(df.loc[pd.Timestamp("2024-01-15"), "Close"]) == 2510.0
+        assert float(df.loc[pd.Timestamp("2024-01-16"), "Close"]) == 2515.0
     finally:
         reader.close()
 

--- a/apps/bt/tests/unit/server/services/test_ranking_service.py
+++ b/apps/bt/tests/unit/server/services/test_ranking_service.py
@@ -96,6 +96,8 @@ def ranking_db(tmp_path):
     conn.execute("INSERT INTO stocks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                  ("44440", "No Forecast Prime", "NOFC", "prime", "P", "S17", "情報", "S33", "情報通信", None, "2000-01-01", None, None))
     conn.execute("INSERT INTO stocks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                 ("5555", "Mixed Format Prime", "MIXED", "prime", "P", "S17", "情報", "S33", "情報通信", None, "2000-01-01", None, None))
+    conn.execute("INSERT INTO stocks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                  ("99840", "テスト", "TEST", "standard", "S", "S17", "情報", "S33", "情報通信", None, "2000-01-01", None, None))
 
     # 5日分のOHLCVデータ
@@ -109,6 +111,7 @@ def ranking_db(tmp_path):
         ("22220", 800000),
         ("33330", 780000),
         ("44440", 760000),
+        ("55550", 1700000),
         ("99840", 100000),
     ]:
         for i, d in enumerate(dates):
@@ -249,6 +252,16 @@ def ranking_db(tmp_path):
         """,
         ("44440", "2024-05-22", 140.0, "FY", None, None, 100.0),
     )
+    conn.execute(
+        """
+        INSERT INTO statements (
+            code, disclosed_date, earnings_per_share, type_of_current_period,
+            next_year_forecast_earnings_per_share, forecast_eps, shares_outstanding
+        )
+        VALUES (?,?,?,?,?,?,?)
+        """,
+        ("5555", "2024-05-25", 50.0, "FY", 60.0, 60.0, 100.0),
+    )
 
     conn.commit()
     conn.close()
@@ -307,6 +320,34 @@ class TestGetRankings:
         market_codes = {item.marketCode for item in result.rankings.tradingValue}
         assert "prime" in market_codes
         assert "0111" in market_codes
+
+    def test_rankings_support_mixed_stock_and_stock_data_code_formats(self, service):
+        result = service.get_rankings(markets="prime", limit=50)
+        codes = {item.code for item in result.rankings.tradingValue}
+        assert "5555" in codes
+
+    def test_price_change_prefers_4digit_row_when_mixed_codes_exist(self, ranking_db):
+        conn = duckdb.connect(ranking_db)
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?,?,?,?,?,?,?,?,?)",
+            ("5555", "2024-01-18", 100.0, 101.0, 99.0, 100.0, 100_000, 1.0, None),
+        )
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?,?,?,?,?,?,?,?,?)",
+            ("5555", "2024-01-19", 110.0, 111.0, 109.0, 110.0, 120_000, 1.0, None),
+        )
+        conn.close()
+
+        reader = MarketDbReader(ranking_db)
+        svc = RankingService(reader)
+        result = svc.get_rankings(date="2024-01-19", markets="prime", limit=100)
+        rows = [item for item in result.rankings.gainers if item.code == "5555"]
+        reader.close()
+
+        assert len(rows) == 1
+        assert rows[0].previousPrice == pytest.approx(100.0)
+        assert rows[0].currentPrice == pytest.approx(110.0)
+        assert rows[0].changePercentage == pytest.approx(10.0)
 
     def test_lookback_days(self, service):
         result = service.get_rankings(lookback_days=3)
@@ -393,6 +434,38 @@ class TestGetFundamentalRankings:
         market_codes = {item.marketCode for item in result.rankings.ratioHigh}
         assert "prime" in market_codes
         assert "0111" in market_codes
+
+    def test_fundamental_rankings_support_mixed_stock_and_stock_data_code_formats(self, service):
+        result = service.get_fundamental_rankings(markets="prime", limit=100)
+        codes = {item.code for item in result.rankings.ratioHigh}
+        assert "5555" in codes
+
+    def test_fundamental_rankings_deduplicate_mixed_codes(self, ranking_db):
+        conn = duckdb.connect(ranking_db)
+        conn.execute(
+            "INSERT INTO stock_data VALUES (?,?,?,?,?,?,?,?,?)",
+            ("5555", "2024-01-19", 600.0, 620.0, 590.0, 610.0, 500_000, 1.0, None),
+        )
+        conn.execute(
+            """
+            INSERT INTO statements (
+                code, disclosed_date, earnings_per_share, type_of_current_period,
+                next_year_forecast_earnings_per_share, forecast_eps, shares_outstanding
+            )
+            VALUES (?,?,?,?,?,?,?)
+            """,
+            ("55550", "2024-05-25", 400.0, "FY", 200.0, 200.0, 100.0),
+        )
+        conn.close()
+
+        reader = MarketDbReader(ranking_db)
+        svc = RankingService(reader)
+        result = svc.get_fundamental_rankings(markets="prime", limit=100)
+        rows = [item for item in result.rankings.ratioHigh if item.code == "5555"]
+        reader.close()
+
+        assert len(rows) == 1
+        assert rows[0].epsValue == pytest.approx(1.2)
 
     def test_skips_stocks_without_statements_and_invalid_ratio(self, service):
         result = service.get_fundamental_rankings(markets="prime", limit=100)


### PR DESCRIPTION
## Summary
- fix Charts/loader/ranking read paths to handle mixed 4-digit and 5-digit stock codes consistently
- deduplicate same-day stock_data rows by normalized code with 4-digit precedence to avoid cross-join inflation in ranking
- harden MarketDb initialization fallback when sync metadata is missing, and fix validation stockData.count mapping
- add/extend unit tests for chart, ohlcv loader, ranking, and market db fallback behavior
- update AGENTS.md with mixed-code read rule for Charts/Analysis

## Verification
- UV_CACHE_DIR=/tmp/uvcache uv run --project apps/bt ruff check src/application/services/chart_service.py src/application/services/db_validation_service.py src/application/services/market_ohlcv_loader.py src/application/services/ranking_service.py src/infrastructure/db/market/market_db.py tests/unit/server/services/test_chart_service.py tests/unit/server/services/test_market_ohlcv_loader.py tests/unit/server/services/test_ranking_service.py tests/unit/server/db/test_market_db.py
- UV_CACHE_DIR=/tmp/uvcache uv run --project apps/bt pytest tests/unit/server/services/test_chart_service.py tests/unit/server/services/test_market_ohlcv_loader.py tests/unit/server/services/test_ranking_service.py tests/unit/server/db/test_market_db.py -q
- UV_CACHE_DIR=/tmp/uvcache uv run --project apps/bt pyright src/application/services/ranking_service.py src/application/services/chart_service.py src/application/services/market_ohlcv_loader.py src/infrastructure/db/market/market_db.py
