### PR TITLE
fix(bt): exclude invalid flat TOPIX bars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ JQUANTS API ──→ FastAPI (:3002) ──→ Data Plane
 - `/api/db/sync` と `POST /api/db/stocks/refresh` の時系列アンカー判定・publish/index は DuckDB inspection + time-series store を必須 SoT とし、旧 SQLite 時系列テーブルへの fallback を禁止する（inspection 失敗時はエラーで停止）
 - DuckDB time-series store は `publish/index/inspect/close` をプロセス内ロックで直列化し、sync 実行と `/api/db/stats` `/api/db/validate` 参照の同時実行による 500 を防止する
 - DuckDB time-series store の Parquet export は `stock_data` / `indices_data` で全件 `ORDER BY` を行わず、同期スループットを優先する（row order 非依存を前提とする）
+- DuckDB `topix_data` は `open=high=low=close` かつ `open=前日close` の異常日足を除外する（取込時 + 起動時クリーンアップ）
 - `market.duckdb` の `statements` upsert は `(code, disclosed_date)` 衝突時に非NULL優先マージ（`coalesce(excluded, existing)`）とし、同日別ドキュメント取り込み時の forecast 欠損上書きを防止する
 - Backtest 実行パスは `BT_DATA_ACCESS_MODE=direct` で DatasetDb/MarketDb を直接参照し、FastAPI 内部HTTPを経由しない
 - DatasetDb の `statements` 読み取りは legacy snapshot（配当/配当性向の forecast 列欠落）でも `NULL` 補完で継続し、必須列 `code` / `disclosed_date` 欠落時はエラーにする

--- a/apps/bt/src/infrastructure/db/market/time_series_store.py
+++ b/apps/bt/src/infrastructure/db/market/time_series_store.py
@@ -102,6 +102,29 @@ class DuckDbParquetTimeSeriesStore:
         "treasury_shares",
     )
 
+    _INVALID_TOPIX_DATE_SUBQUERY = """
+        SELECT date
+        FROM (
+            SELECT
+                date,
+                open,
+                high,
+                low,
+                close,
+                LAG(close) OVER (ORDER BY date) AS prev_close
+            FROM topix_data
+        ) ordered_rows
+        WHERE open IS NOT NULL
+          AND high IS NOT NULL
+          AND low IS NOT NULL
+          AND close IS NOT NULL
+          AND prev_close IS NOT NULL
+          AND open = high
+          AND high = low
+          AND low = close
+          AND open = prev_close
+    """
+
     def __init__(
         self,
         *,
@@ -126,6 +149,7 @@ class DuckDbParquetTimeSeriesStore:
         self._lock = RLock()
         self._dirty_tables: set[str] = set()
         self._ensure_schema()
+        self._cleanup_invalid_topix_rows_on_startup()
 
     def _ensure_schema(self) -> None:
         with self._lock:
@@ -234,8 +258,45 @@ class DuckDbParquetTimeSeriesStore:
                 """,
                 values,
             )
+            removed_count = self._remove_invalid_topix_rows()
+            if removed_count > 0:
+                logger.warning(
+                    "Removed {} invalid TOPIX rows (flat OHLC equal to previous close)",
+                    removed_count,
+                )
             self._dirty_tables.add("topix_data")
         return len(rows)
+
+    def _cleanup_invalid_topix_rows_on_startup(self) -> None:
+        with self._lock:
+            removed_count = self._remove_invalid_topix_rows()
+            if removed_count <= 0:
+                return
+            logger.warning(
+                "Removed {} invalid TOPIX rows from existing snapshot (flat OHLC equal to previous close)",
+                removed_count,
+            )
+            self._dirty_tables.add("topix_data")
+            self._export_if_dirty("topix_data")
+
+    def _remove_invalid_topix_rows(self) -> int:
+        count_row = self._conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM ({self._INVALID_TOPIX_DATE_SUBQUERY}) invalid_dates
+            """
+        ).fetchone()
+        invalid_count = int(count_row[0] or 0) if count_row else 0
+        if invalid_count <= 0:
+            return 0
+
+        self._conn.execute(
+            f"""
+            DELETE FROM topix_data
+            WHERE date IN ({self._INVALID_TOPIX_DATE_SUBQUERY})
+            """
+        )
+        return invalid_count
 
     def publish_stock_data(self, rows: list[dict[str, Any]]) -> int:
         if not rows:

--- a/apps/bt/tests/unit/server/db/test_time_series_store.py
+++ b/apps/bt/tests/unit/server/db/test_time_series_store.py
@@ -27,6 +27,13 @@ def _stock_row() -> dict[str, object]:
     }
 
 
+def _stock_row_for(date: str) -> dict[str, object]:
+    row = _stock_row()
+    row["date"] = date
+    row["created_at"] = f"{date}T00:00:00+00:00"
+    return row
+
+
 def _topix_rows() -> list[dict[str, object]]:
     return [
         {"date": "2026-02-10", "open": 1.0, "high": 2.0, "low": 1.0, "close": 2.0},
@@ -131,6 +138,100 @@ def test_duckdb_store_inspect_reports_core_stats(tmp_path: Path) -> None:
     assert inspection.statement_non_null_counts["unknown_column"] == 0
 
     store.close()
+
+
+def test_publish_topix_data_excludes_flat_row_equal_to_previous_close(tmp_path: Path) -> None:
+    store = create_time_series_store(
+        backend="duckdb-parquet",
+        duckdb_path=str(tmp_path / "market-timeseries" / "market.duckdb"),
+        parquet_dir=str(tmp_path / "market-timeseries" / "parquet"),
+    )
+    assert store is not None
+
+    published = store.publish_topix_data(
+        [
+            {
+                "date": "2020-09-30",
+                "open": 1650.32,
+                "high": 1654.18,
+                "low": 1625.49,
+                "close": 1625.49,
+                "created_at": "2026-03-05T00:00:00+00:00",
+            },
+            {
+                "date": "2020-10-01",
+                "open": 1625.49,
+                "high": 1625.49,
+                "low": 1625.49,
+                "close": 1625.49,
+                "created_at": "2026-03-05T00:00:00+00:00",
+            },
+            {
+                "date": "2020-10-02",
+                "open": 1633.02,
+                "high": 1638.80,
+                "low": 1603.32,
+                "close": 1609.22,
+                "created_at": "2026-03-05T00:00:00+00:00",
+            },
+        ]
+    )
+    assert published == 3
+
+    store.publish_stock_data(
+        [
+            _stock_row_for("2020-09-30"),
+            _stock_row_for("2020-10-02"),
+        ]
+    )
+    inspection = store.inspect(missing_stock_dates_limit=10)
+
+    assert inspection.topix_count == 2
+    assert inspection.topix_min == "2020-09-30"
+    assert inspection.topix_max == "2020-10-02"
+    assert inspection.missing_stock_dates_count == 0
+    assert inspection.missing_stock_dates == []
+
+    store.close()
+
+
+def test_store_startup_cleans_existing_invalid_topix_rows(tmp_path: Path) -> None:
+    duckdb_path = tmp_path / "market-timeseries" / "market.duckdb"
+    parquet_dir = tmp_path / "market-timeseries" / "parquet"
+
+    first = create_time_series_store(
+        backend="duckdb-parquet",
+        duckdb_path=str(duckdb_path),
+        parquet_dir=str(parquet_dir),
+    )
+    assert isinstance(first, DuckDbParquetTimeSeriesStore)
+
+    first._conn.executemany(
+        """
+        INSERT INTO topix_data (date, open, high, low, close, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("2020-09-30", 1650.32, 1654.18, 1625.49, 1625.49, "2026-03-05T00:00:00+00:00"),
+            ("2020-10-01", 1625.49, 1625.49, 1625.49, 1625.49, "2026-03-05T00:00:00+00:00"),
+            ("2020-10-02", 1633.02, 1638.80, 1603.32, 1609.22, "2026-03-05T00:00:00+00:00"),
+        ],
+    )
+    first.close()
+
+    second = create_time_series_store(
+        backend="duckdb-parquet",
+        duckdb_path=str(duckdb_path),
+        parquet_dir=str(parquet_dir),
+    )
+    assert second is not None
+    inspection = second.inspect(missing_stock_dates_limit=10)
+
+    assert inspection.topix_count == 2
+    assert inspection.topix_min == "2020-09-30"
+    assert inspection.topix_max == "2020-10-02"
+
+    second.close()
 
 
 class _ResultCursor:


### PR DESCRIPTION
## Summary
- exclude invalid topix_data rows where open=high=low=close and equal previous close
- run cleanup on startup to remove existing invalid rows from DuckDB snapshots
- add unit tests for ingestion-time filtering and startup cleanup
- document the new TOPIX filtering rule in AGENTS.md

## Test
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/db/test_time_series_store.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/services/test_db_validation_service.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/infrastructure/db/market/time_series_store.py apps/bt/tests/unit/server/db/test_time_series_store.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pyright apps/bt/src/infrastructure/db/market/time_series_store.py