### PR TITLE
perf(ci): speed up coverage-gate by reusing bt coverage artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           name: bt-coverage-unit
           path: apps/bt/.coverage.unit
+          include-hidden-files: true
           if-no-files-found: error
 
   app-integration-tests:
@@ -191,6 +192,7 @@ jobs:
         with:
           name: bt-coverage-app
           path: apps/bt/.coverage.app
+          include-hidden-files: true
           if-no-files-found: error
 
   secret-scan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
   coverage-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    needs:
+      - package-unit-tests
+      - app-integration-tests
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,10 +111,17 @@ jobs:
       - name: Install deps (apps/bt)
         run: uv sync --locked
         working-directory: apps/bt
+      - name: Download bt coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bt-coverage-*
+          path: /tmp/bt-coverage
+          merge-multiple: true
       - name: Run coverage gate
         run: ./scripts/coverage-gate.sh
         env:
           CI_DEPS_READY: "1"
+          BT_COVERAGE_INPUT_DIR: /tmp/bt-coverage
 
   package-unit-tests:
     runs-on: ubuntu-latest
@@ -139,6 +149,14 @@ jobs:
         run: ./scripts/test-packages.sh
         env:
           CI_DEPS_READY: "1"
+          BT_COVERAGE_DATA_FILE: ".coverage.unit"
+      - name: Upload bt coverage artifact (unit)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bt-coverage-unit
+          path: apps/bt/.coverage.unit
+          if-no-files-found: error
 
   app-integration-tests:
     runs-on: ubuntu-latest
@@ -166,6 +184,14 @@ jobs:
         run: ./scripts/test-apps.sh
         env:
           CI_DEPS_READY: "1"
+          BT_COVERAGE_DATA_FILE: ".coverage.app"
+      - name: Upload bt coverage artifact (app)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bt-coverage-app
+          path: apps/bt/.coverage.app
+          if-no-files-found: error
 
   secret-scan:
     runs-on: ubuntu-latest

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -27,7 +27,18 @@ echo "[coverage] Run TypeScript coverage suites"
 )
 
 echo "[coverage] Run bt coverage suite"
-BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage run -m pytest tests/
+if [[ -n "${BT_COVERAGE_INPUT_DIR:-}" ]]; then
+  mapfile -t bt_coverage_files < <(find "${BT_COVERAGE_INPUT_DIR}" -type f -name '.coverage*' | sort)
+  if [[ ${#bt_coverage_files[@]} -eq 0 ]]; then
+    echo "[coverage] ERROR: no bt coverage files found in ${BT_COVERAGE_INPUT_DIR}" >&2
+    exit 1
+  fi
+  echo "[coverage] Combine bt coverage files (${#bt_coverage_files[@]})"
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage erase
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage combine "${bt_coverage_files[@]}"
+else
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage run -m pytest tests/
+fi
 BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage report --fail-under=70
 
 echo "[coverage] PASS"

--- a/scripts/test-apps.sh
+++ b/scripts/test-apps.sh
@@ -13,5 +13,12 @@ fi
 echo "[apps/ts] bun run apps:test"
 ( cd "${repo_root}/apps/ts" && bun run apps:test )
 
-echo "[apps/bt] pytest tests/api tests/integration tests/paths tests/security tests/server"
-BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" pytest tests/api tests/integration tests/paths tests/security tests/server
+if [[ -n "${BT_COVERAGE_DATA_FILE:-}" ]]; then
+  echo "[apps/bt] coverage run --data-file=${BT_COVERAGE_DATA_FILE} -m pytest tests/api tests/integration tests/paths tests/security tests/server"
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage run \
+    --data-file="${BT_COVERAGE_DATA_FILE}" \
+    -m pytest tests/api tests/integration tests/paths tests/security tests/server
+else
+  echo "[apps/bt] pytest tests/api tests/integration tests/paths tests/security tests/server"
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" pytest tests/api tests/integration tests/paths tests/security tests/server
+fi

--- a/scripts/test-packages.sh
+++ b/scripts/test-packages.sh
@@ -13,5 +13,12 @@ fi
 echo "[apps/ts] bun run packages:test"
 ( cd "${repo_root}/apps/ts" && bun run packages:test )
 
-echo "[apps/bt] pytest tests/unit"
-BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" pytest tests/unit
+if [[ -n "${BT_COVERAGE_DATA_FILE:-}" ]]; then
+  echo "[apps/bt] coverage run --data-file=${BT_COVERAGE_DATA_FILE} -m pytest tests/unit"
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" coverage run \
+    --data-file="${BT_COVERAGE_DATA_FILE}" \
+    -m pytest tests/unit
+else
+  echo "[apps/bt] pytest tests/unit"
+  BT_USE_UV=1 "${repo_root}/scripts/bt-run.sh" pytest tests/unit
+fi


### PR DESCRIPTION
## Summary
- avoid rerunning the full bt pytest suite inside `coverage-gate`
- run bt tests in existing jobs with coverage data output (unit/app split)
- upload bt coverage artifacts and combine them in `coverage-gate` before threshold check
- keep TypeScript coverage execution and threshold checks unchanged

## Testing
- bash -n scripts/coverage-gate.sh scripts/test-packages.sh scripts/test-apps.sh
