### PR TITLE
refactor(web): remove biome-ignore suppressions in large UI components

### DIFF
--- a/apps/ts/packages/utils/src/utils/dataset-paths.test.ts
+++ b/apps/ts/packages/utils/src/utils/dataset-paths.test.ts
@@ -17,6 +17,10 @@ import {
   resolveDatasetPath,
 } from './dataset-paths';
 
+function unsetXdgDataHome(): void {
+  Reflect.deleteProperty(process.env, 'XDG_DATA_HOME');
+}
+
 describe('Dataset Paths', () => {
   describe('getMarketDbPath', () => {
     let originalXdgDataHome: string | undefined;
@@ -29,16 +33,14 @@ describe('Dataset Paths', () => {
     afterEach(() => {
       // Restore original environment variable
       if (originalXdgDataHome === undefined) {
-        // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-        delete process.env.XDG_DATA_HOME;
+        unsetXdgDataHome();
       } else {
         process.env.XDG_DATA_HOME = originalXdgDataHome;
       }
     });
 
     test('should return default XDG path when XDG_DATA_HOME is not set', () => {
-      // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-      delete process.env.XDG_DATA_HOME;
+      unsetXdgDataHome();
 
       const dbPath = getMarketDbPath();
       const expectedPath = path.join(
@@ -166,16 +168,14 @@ describe('Dataset Paths', () => {
 
     afterEach(() => {
       if (originalXdgDataHome === undefined) {
-        // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-        delete process.env.XDG_DATA_HOME;
+        unsetXdgDataHome();
       } else {
         process.env.XDG_DATA_HOME = originalXdgDataHome;
       }
     });
 
     test('should return default XDG path when XDG_DATA_HOME not set', () => {
-      // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-      delete process.env.XDG_DATA_HOME;
+      unsetXdgDataHome();
       const dbPath = getDatasetV2Path('prime.db');
       const expectedPath = path.join(os.homedir(), '.local', 'share', 'trading25', 'datasets', 'prime.db');
       expect(dbPath).toBe(expectedPath);
@@ -353,8 +353,7 @@ describe('Dataset Paths', () => {
 
     afterEach(() => {
       if (originalXdgDataHome === undefined) {
-        // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-        delete process.env.XDG_DATA_HOME;
+        unsetXdgDataHome();
       } else {
         process.env.XDG_DATA_HOME = originalXdgDataHome;
       }
@@ -371,8 +370,7 @@ describe('Dataset Paths', () => {
     });
 
     test('uses default XDG path when not set', () => {
-      // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-      delete process.env.XDG_DATA_HOME;
+      unsetXdgDataHome();
       const result = getPortfolioDbPath();
       const expected = path.join(os.homedir(), '.local', 'share', 'trading25', 'portfolio.db');
       expect(result).toBe(expected);
@@ -421,8 +419,7 @@ describe('Dataset Paths', () => {
 
     afterEach(() => {
       if (originalXdgDataHome === undefined) {
-        // biome-ignore lint/performance/noDelete: Need to actually delete env var for testing
-        delete process.env.XDG_DATA_HOME;
+        unsetXdgDataHome();
       } else {
         process.env.XDG_DATA_HOME = originalXdgDataHome;
       }

--- a/apps/ts/packages/web/src/components/Backtest/BacktestRunner.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/BacktestRunner.tsx
@@ -24,10 +24,220 @@ import { OptimizationJobProgressCard } from './OptimizationJobProgressCard';
 import { StrategySelector } from './StrategySelector';
 import { extractGridParameterEntries, formatGridParameterValue } from './optimizationGridParams';
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: UI component with conditional rendering
+type BacktestJobStatusData = ReturnType<typeof useJobStatus>['data'];
+type OptimizationJobStatusData = ReturnType<typeof useOptimizationJobStatus>['data'];
+type RunBacktestMutation = ReturnType<typeof useRunBacktest>;
+type RunOptimizationMutation = ReturnType<typeof useRunOptimization>;
+type CancelBacktestMutation = ReturnType<typeof useCancelBacktest>;
+
+function isRunningStatus(status: string | null | undefined): boolean {
+  return status === 'running' || status === 'pending';
+}
+
+function isBacktestTerminalStatus(status: string | null | undefined): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function isOptimizationTerminalStatus(status: string | null | undefined): boolean {
+  return status === 'completed' || status === 'failed';
+}
+
+function StrategyInfoCard({
+  displayName,
+  name,
+  category,
+  description,
+}: {
+  displayName?: string | null;
+  name: string;
+  category: string;
+  description?: string | null;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">{displayName || name}</CardTitle>
+        <CardDescription>Category: {category}</CardDescription>
+      </CardHeader>
+      <CardContent>{description && <p className="text-sm text-muted-foreground">{description}</p>}</CardContent>
+    </Card>
+  );
+}
+
+function GridConfigSummary({
+  paramCount,
+  combinations,
+  entries,
+}: {
+  paramCount: number;
+  combinations: number;
+  entries: Array<{ path: string; values: unknown[] }>;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground">
+        Grid config: {paramCount} params, {combinations} combinations
+      </p>
+      {entries.length > 0 && (
+        <div className="max-h-32 overflow-auto rounded-md border border-border/50 bg-muted/20 p-2">
+          <ul className="space-y-1">
+            {entries.map((entry) => (
+              <li key={entry.path} className="text-xs font-mono text-muted-foreground break-all">
+                {entry.path}: [{entry.values.map((value) => formatGridParameterValue(value)).join(', ')}]
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function useInvalidateBacktestHtmlOnTerminalStatus(status: string | null | undefined): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!isBacktestTerminalStatus(status)) return;
+    queryClient.invalidateQueries({ queryKey: backtestKeys.htmlFiles() });
+  }, [status, queryClient]);
+}
+
+function useInvalidateOptimizationHtmlOnTerminalStatus(status: string | null | undefined): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!isOptimizationTerminalStatus(status)) return;
+    queryClient.invalidateQueries({ queryKey: optimizationKeys.htmlFiles() });
+  }, [status, queryClient]);
+}
+
+async function runBacktestForSelectedStrategy({
+  selectedStrategy,
+  runBacktest,
+  setActiveJobId,
+}: {
+  selectedStrategy: string | null;
+  runBacktest: RunBacktestMutation;
+  setActiveJobId: (jobId: string | null) => void;
+}): Promise<void> {
+  if (!selectedStrategy) return;
+  const result = await runBacktest.mutateAsync({ strategy_name: selectedStrategy });
+  setActiveJobId(result.job_id);
+}
+
+async function runOptimizationForSelectedStrategy({
+  selectedStrategy,
+  runOptimization,
+  setActiveOptimizationJobId,
+}: {
+  selectedStrategy: string | null;
+  runOptimization: RunOptimizationMutation;
+  setActiveOptimizationJobId: (jobId: string | null) => void;
+}): Promise<void> {
+  if (!selectedStrategy) return;
+  const result = await runOptimization.mutateAsync({ strategy_name: selectedStrategy });
+  setActiveOptimizationJobId(result.job_id);
+}
+
+function BacktestExecutionSection({
+  selectedStrategy,
+  isRunning,
+  runBacktest,
+  activeJobId,
+  jobStatus,
+  isLoadingJob,
+  cancelBacktest,
+  onRunBacktest,
+}: {
+  selectedStrategy: string | null;
+  isRunning: boolean;
+  runBacktest: RunBacktestMutation;
+  activeJobId: string | null;
+  jobStatus: BacktestJobStatusData;
+  isLoadingJob: boolean;
+  cancelBacktest: CancelBacktestMutation;
+  onRunBacktest: () => Promise<void>;
+}) {
+  return (
+    <>
+      <Button onClick={onRunBacktest} disabled={!selectedStrategy || isRunning} className="w-full gap-2">
+        <Play className="h-4 w-4" />
+        {isRunning ? 'Running...' : 'Run Backtest'}
+      </Button>
+
+      <JobProgressCard
+        job={jobStatus}
+        isLoading={isLoadingJob || runBacktest.isPending}
+        onCancel={activeJobId ? () => cancelBacktest.mutate(activeJobId) : undefined}
+        isCancelling={cancelBacktest.isPending}
+      />
+
+      {runBacktest.isError && (
+        <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{runBacktest.error.message}</div>
+      )}
+    </>
+  );
+}
+
+function OptimizationSection({
+  gridConfig,
+  gridParameterEntries,
+  selectedStrategy,
+  isOptRunning,
+  onRunOptimization,
+  optimizationJobStatus,
+  isLoadingOptJob,
+  runOptimization,
+}: {
+  gridConfig: ReturnType<typeof useOptimizationGridConfig>['data'];
+  gridParameterEntries: Array<{ path: string; values: unknown[] }>;
+  selectedStrategy: string | null;
+  isOptRunning: boolean;
+  onRunOptimization: () => Promise<void>;
+  optimizationJobStatus: OptimizationJobStatusData;
+  isLoadingOptJob: boolean;
+  runOptimization: RunOptimizationMutation;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Settings2 className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Optimization</span>
+      </div>
+
+      {gridConfig ? (
+        <GridConfigSummary
+          paramCount={gridConfig.param_count}
+          combinations={gridConfig.combinations}
+          entries={gridParameterEntries}
+        />
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          No grid config found. Configure in Strategies &gt; Optimize tab.
+        </p>
+      )}
+
+      <Button
+        onClick={onRunOptimization}
+        disabled={!selectedStrategy || !gridConfig || isOptRunning}
+        variant="outline"
+        className="w-full gap-2"
+      >
+        <Settings2 className="h-4 w-4" />
+        {isOptRunning ? 'Optimizing...' : 'Run Optimization'}
+      </Button>
+
+      <OptimizationJobProgressCard job={optimizationJobStatus} isLoading={isLoadingOptJob || runOptimization.isPending} />
+
+      {runOptimization.isError && (
+        <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{runOptimization.error.message}</div>
+      )}
+    </div>
+  );
+}
+
 export function BacktestRunner() {
   const [defaultConfigOpen, setDefaultConfigOpen] = useState(false);
-  const queryClient = useQueryClient();
   const {
     selectedStrategy,
     setSelectedStrategy,
@@ -53,42 +263,25 @@ export function BacktestRunner() {
     [gridConfig]
   );
 
-  useEffect(() => {
-    if (jobStatus?.status === 'completed' || jobStatus?.status === 'failed' || jobStatus?.status === 'cancelled') {
-      queryClient.invalidateQueries({ queryKey: backtestKeys.htmlFiles() });
-    }
-  }, [jobStatus?.status, queryClient]);
+  useInvalidateBacktestHtmlOnTerminalStatus(jobStatus?.status);
+  useInvalidateOptimizationHtmlOnTerminalStatus(optimizationJobStatus?.status);
 
-  useEffect(() => {
-    if (optimizationJobStatus?.status === 'completed' || optimizationJobStatus?.status === 'failed') {
-      queryClient.invalidateQueries({ queryKey: optimizationKeys.htmlFiles() });
-    }
-  }, [optimizationJobStatus?.status, queryClient]);
-
-  const handleRunBacktest = async () => {
-    if (!selectedStrategy) return;
-
-    const result = await runBacktest.mutateAsync({
-      strategy_name: selectedStrategy,
+  const handleRunBacktest = () =>
+    runBacktestForSelectedStrategy({
+      selectedStrategy,
+      runBacktest,
+      setActiveJobId,
     });
-    setActiveJobId(result.job_id);
-  };
 
-  const handleRunOptimization = async () => {
-    if (!selectedStrategy) return;
-
-    const result = await runOptimization.mutateAsync({
-      strategy_name: selectedStrategy,
+  const handleRunOptimization = () =>
+    runOptimizationForSelectedStrategy({
+      selectedStrategy,
+      runOptimization,
+      setActiveOptimizationJobId,
     });
-    setActiveOptimizationJobId(result.job_id);
-  };
 
-  const isRunning = runBacktest.isPending || jobStatus?.status === 'running' || jobStatus?.status === 'pending';
-
-  const isOptRunning =
-    runOptimization.isPending ||
-    optimizationJobStatus?.status === 'running' ||
-    optimizationJobStatus?.status === 'pending';
+  const isRunning = runBacktest.isPending || isRunningStatus(jobStatus?.status);
+  const isOptRunning = runOptimization.isPending || isRunningStatus(optimizationJobStatus?.status);
 
   return (
     <div className="space-y-4">
@@ -106,17 +299,12 @@ export function BacktestRunner() {
 
       {/* Strategy Info */}
       {strategyDetail && (
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base">{strategyDetail.display_name || strategyDetail.name}</CardTitle>
-            <CardDescription>Category: {strategyDetail.category}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {strategyDetail.description && (
-              <p className="text-sm text-muted-foreground">{strategyDetail.description}</p>
-            )}
-          </CardContent>
-        </Card>
+        <StrategyInfoCard
+          displayName={strategyDetail.display_name}
+          name={strategyDetail.name}
+          category={strategyDetail.category}
+          description={strategyDetail.description}
+        />
       )}
 
       {/* Default Config */}
@@ -126,76 +314,30 @@ export function BacktestRunner() {
       </Button>
       <DefaultConfigEditor open={defaultConfigOpen} onOpenChange={setDefaultConfigOpen} />
 
-      {/* Run Button */}
-      <Button onClick={handleRunBacktest} disabled={!selectedStrategy || isRunning} className="w-full gap-2">
-        <Play className="h-4 w-4" />
-        {isRunning ? 'Running...' : 'Run Backtest'}
-      </Button>
-
-      {/* Progress Card */}
-      <JobProgressCard
-        job={jobStatus}
-        isLoading={isLoadingJob || runBacktest.isPending}
-        onCancel={activeJobId ? () => cancelBacktest.mutate(activeJobId) : undefined}
-        isCancelling={cancelBacktest.isPending}
+      <BacktestExecutionSection
+        selectedStrategy={selectedStrategy}
+        isRunning={isRunning}
+        runBacktest={runBacktest}
+        activeJobId={activeJobId}
+        jobStatus={jobStatus}
+        isLoadingJob={isLoadingJob}
+        cancelBacktest={cancelBacktest}
+        onRunBacktest={handleRunBacktest}
       />
-
-      {/* Error Message */}
-      {runBacktest.isError && (
-        <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{runBacktest.error.message}</div>
-      )}
 
       {/* Optimization Section */}
       <div className="border-t" />
 
-      <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Settings2 className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium">Optimization</span>
-        </div>
-
-        {gridConfig ? (
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">
-              Grid config: {gridConfig.param_count} params, {gridConfig.combinations} combinations
-            </p>
-            {gridParameterEntries.length > 0 && (
-              <div className="max-h-32 overflow-auto rounded-md border border-border/50 bg-muted/20 p-2">
-                <ul className="space-y-1">
-                  {gridParameterEntries.map((entry) => (
-                    <li key={entry.path} className="text-xs font-mono text-muted-foreground break-all">
-                      {entry.path}: [{entry.values.map((value) => formatGridParameterValue(value)).join(', ')}]
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </div>
-        ) : (
-          <p className="text-xs text-muted-foreground">
-            No grid config found. Configure in Strategies &gt; Optimize tab.
-          </p>
-        )}
-
-        <Button
-          onClick={handleRunOptimization}
-          disabled={!selectedStrategy || !gridConfig || isOptRunning}
-          variant="outline"
-          className="w-full gap-2"
-        >
-          <Settings2 className="h-4 w-4" />
-          {isOptRunning ? 'Optimizing...' : 'Run Optimization'}
-        </Button>
-
-        <OptimizationJobProgressCard
-          job={optimizationJobStatus}
-          isLoading={isLoadingOptJob || runOptimization.isPending}
-        />
-
-        {runOptimization.isError && (
-          <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{runOptimization.error.message}</div>
-        )}
-      </div>
+      <OptimizationSection
+        gridConfig={gridConfig}
+        gridParameterEntries={gridParameterEntries}
+        selectedStrategy={selectedStrategy}
+        isOptRunning={isOptRunning}
+        onRunOptimization={handleRunOptimization}
+        optimizationJobStatus={optimizationJobStatus}
+        isLoadingOptJob={isLoadingOptJob}
+        runOptimization={runOptimization}
+      />
     </div>
   );
 }

--- a/apps/ts/packages/web/src/components/Backtest/HtmlFileBrowser.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/HtmlFileBrowser.tsx
@@ -1,5 +1,5 @@
 import { Check, ExternalLink, File, Loader2, Pencil, Search, Trash2, X } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -113,7 +113,303 @@ function MetricsGrid({ metrics }: { metrics: HtmlFileMetrics }) {
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: UI component with file list, preview, rename/delete dialogs
+function resolveStrategies(files: HtmlFileInfo[] | undefined): string[] {
+  if (!files) return [];
+  return Array.from(new Set(files.map((file) => file.strategy_name))).sort();
+}
+
+function resolveFilteredFiles(files: HtmlFileInfo[] | undefined, searchQuery: string): HtmlFileInfo[] {
+  if (!files) return [];
+  if (!searchQuery) return files;
+  const query = searchQuery.toLowerCase();
+  return files.filter(
+    (file) =>
+      file.filename.toLowerCase().includes(query) ||
+      file.dataset_name.toLowerCase().includes(query) ||
+      file.strategy_name.toLowerCase().includes(query)
+  );
+}
+
+function resolveSortedFiles(files: HtmlFileInfo[]): HtmlFileInfo[] {
+  return [...files].sort((left, right) => new Date(right.created_at).getTime() - new Date(left.created_at).getTime());
+}
+
+function openHtmlInNewTab(decodedHtml: string): void {
+  const blob = new Blob([decodedHtml], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener,noreferrer');
+  setTimeout(() => URL.revokeObjectURL(url), 60000);
+}
+
+type RenameAction =
+  | { type: 'ignore' }
+  | { type: 'cancel' }
+  | {
+      type: 'rename';
+      newFilename: string;
+    };
+
+function resolveRenameAction(selectedFile: HtmlFileInfo | null, renameValue: string): RenameAction {
+  if (!selectedFile) {
+    return { type: 'ignore' };
+  }
+
+  const trimmed = renameValue.trim();
+  if (!trimmed) {
+    return { type: 'ignore' };
+  }
+
+  const newFilename = trimmed.endsWith('.html') ? trimmed : `${trimmed}.html`;
+  if (newFilename === selectedFile.filename) {
+    return { type: 'cancel' };
+  }
+
+  return { type: 'rename', newFilename };
+}
+
+interface FileListCardProps {
+  isLoadingFiles: boolean;
+  filteredFiles: HtmlFileInfo[];
+  sortedFiles: HtmlFileInfo[];
+  totalFiles: number | undefined;
+  selectedFile: HtmlFileInfo | null;
+  onSelectFile: (file: HtmlFileInfo) => void;
+}
+
+function FileListCard({
+  isLoadingFiles,
+  filteredFiles,
+  sortedFiles,
+  totalFiles,
+  selectedFile,
+  onSelectFile,
+}: FileListCardProps) {
+  if (isLoadingFiles) {
+    return (
+      <Card className="lg:col-span-1">
+        <CardContent className="pt-4">
+          <div className="flex items-center justify-center h-48">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (filteredFiles.length === 0) {
+    return (
+      <Card className="lg:col-span-1">
+        <CardContent className="pt-4">
+          <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
+            <File className="h-12 w-12 mb-2" />
+            <p className="text-sm">No HTML files found</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="lg:col-span-1">
+      <CardContent className="pt-4">
+        <div className="space-y-4 max-h-[600px] overflow-y-auto">
+          <p className="text-sm text-muted-foreground">
+            {filteredFiles.length} files {totalFiles && totalFiles > filteredFiles.length ? `(${totalFiles} total)` : ''}
+          </p>
+
+          {sortedFiles.map((file) => (
+            <FileListItem
+              key={`${file.strategy_name}/${file.filename}`}
+              file={file}
+              isSelected={selectedFile?.strategy_name === file.strategy_name && selectedFile?.filename === file.filename}
+              onSelect={() => onSelectFile(file)}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface PreviewCardProps {
+  selectedFile: HtmlFileInfo | null;
+  isRenaming: boolean;
+  renameValue: string;
+  setRenameValue: (value: string) => void;
+  renameInputRef: RefObject<HTMLInputElement | null>;
+  onConfirmRename: () => void;
+  onCancelRename: () => void;
+  onStartRename: () => void;
+  onOpenDeleteDialog: () => void;
+  onOpenInNewTab: () => void;
+  isRenamePending: boolean;
+  renameErrorMessage: string | null;
+  htmlContentBase64: string | null | undefined;
+  metrics: HtmlFileMetrics | null | undefined;
+  isLoadingContent: boolean;
+}
+
+function PreviewCard({
+  selectedFile,
+  isRenaming,
+  renameValue,
+  setRenameValue,
+  renameInputRef,
+  onConfirmRename,
+  onCancelRename,
+  onStartRename,
+  onOpenDeleteDialog,
+  onOpenInNewTab,
+  isRenamePending,
+  renameErrorMessage,
+  htmlContentBase64,
+  metrics,
+  isLoadingContent,
+}: PreviewCardProps) {
+  if (!selectedFile) {
+    return (
+      <Card className="lg:col-span-2">
+        <CardContent className="pt-4">
+          <div className="flex flex-col items-center justify-center h-[400px] text-muted-foreground">
+            <File className="h-12 w-12 mb-2" />
+            <p className="text-sm">Select a file to preview</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const decodedHtmlContent = htmlContentBase64 ? safeAtob(htmlContentBase64) : null;
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardContent className="pt-4">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="min-w-0 flex-1">
+              {isRenaming ? (
+                <div className="flex items-center gap-2">
+                  <Input
+                    ref={renameInputRef}
+                    value={renameValue}
+                    onChange={(event) => setRenameValue(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') onConfirmRename();
+                      if (event.key === 'Escape') onCancelRename();
+                    }}
+                    className="h-8 text-sm"
+                    disabled={isRenamePending}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    onClick={onConfirmRename}
+                    disabled={isRenamePending}
+                  >
+                    <Check className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    onClick={onCancelRename}
+                    disabled={isRenamePending}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <h3 className="font-medium truncate">{selectedFile.filename}</h3>
+                  <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={onStartRename}>
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                    onClick={onOpenDeleteDialog}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              )}
+              <p className="text-sm text-muted-foreground">
+                {selectedFile.strategy_name} | {selectedFile.dataset_name} | {formatDate(selectedFile.created_at)}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onOpenInNewTab}
+              disabled={!htmlContentBase64}
+              className="shrink-0 ml-2"
+            >
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Open in new tab
+            </Button>
+          </div>
+          {renameErrorMessage && <div className="rounded-md bg-red-500/10 p-2 text-sm text-red-500">{renameErrorMessage}</div>}
+          {metrics && <MetricsGrid metrics={metrics} />}
+          <ResultHtmlViewer htmlContent={decodedHtmlContent} isLoading={isLoadingContent} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface DeleteDialogProps {
+  open: boolean;
+  selectedFilename: string | undefined;
+  isPending: boolean;
+  errorMessage: string | null;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+}
+
+function DeleteDialog({
+  open,
+  selectedFilename,
+  isPending,
+  errorMessage,
+  onOpenChange,
+  onDelete,
+}: DeleteDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Trash2 className="h-5 w-5 text-destructive" />
+            Delete HTML File
+          </DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete <span className="font-semibold text-foreground">{selectedFilename}</span>?
+            This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onDelete} disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </DialogFooter>
+        {errorMessage && <p className="text-sm text-destructive">Error: {errorMessage}</p>}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function HtmlFileBrowser() {
   const [selectedStrategy, setSelectedStrategy] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState('');
@@ -133,30 +429,9 @@ export function HtmlFileBrowser() {
   const deleteHtmlFile = useDeleteHtmlFile();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-  // Get unique strategies
-  const strategies = useMemo(() => {
-    if (!htmlFilesData?.files) return [];
-    const strategySet = new Set(htmlFilesData.files.map((f) => f.strategy_name));
-    return Array.from(strategySet).sort();
-  }, [htmlFilesData]);
-
-  // Filter files by search query
-  const filteredFiles = useMemo(() => {
-    if (!htmlFilesData?.files) return [];
-    if (!searchQuery) return htmlFilesData.files;
-    const query = searchQuery.toLowerCase();
-    return htmlFilesData.files.filter(
-      (f) =>
-        f.filename.toLowerCase().includes(query) ||
-        f.dataset_name.toLowerCase().includes(query) ||
-        f.strategy_name.toLowerCase().includes(query)
-    );
-  }, [htmlFilesData, searchQuery]);
-
-  // Sort files by created_at descending
-  const sortedFiles = useMemo(() => {
-    return [...filteredFiles].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-  }, [filteredFiles]);
+  const strategies = useMemo(() => resolveStrategies(htmlFilesData?.files), [htmlFilesData?.files]);
+  const filteredFiles = useMemo(() => resolveFilteredFiles(htmlFilesData?.files, searchQuery), [htmlFilesData?.files, searchQuery]);
+  const sortedFiles = useMemo(() => resolveSortedFiles(filteredFiles), [filteredFiles]);
 
   const handleStartRename = () => {
     if (!selectedFile) return;
@@ -182,17 +457,21 @@ export function HtmlFileBrowser() {
   };
 
   const handleConfirmRename = () => {
-    if (!selectedFile || !renameValue.trim()) return;
-    const newFilename = renameValue.trim().endsWith('.html') ? renameValue.trim() : `${renameValue.trim()}.html`;
-    if (newFilename === selectedFile.filename) {
+    const action = resolveRenameAction(selectedFile, renameValue);
+    if (action.type === 'ignore') {
+      return;
+    }
+    if (action.type === 'cancel') {
       handleCancelRename();
       return;
     }
+    if (!selectedFile) return;
+
     renameHtmlFile.mutate(
       {
         strategy: selectedFile.strategy_name,
         filename: selectedFile.filename,
-        request: { new_filename: newFilename },
+        request: { new_filename: action.newFilename },
       },
       {
         onSuccess: (data) => {
@@ -208,13 +487,9 @@ export function HtmlFileBrowser() {
   };
 
   const handleOpenInNewTab = () => {
-    if (!selectedFile || !htmlContent?.html_content) return;
-    const htmlString = safeAtob(htmlContent.html_content);
-    if (!htmlString) return;
-    const blob = new Blob([htmlString], { type: 'text/html' });
-    const url = URL.createObjectURL(blob);
-    window.open(url, '_blank', 'noopener,noreferrer');
-    setTimeout(() => URL.revokeObjectURL(url), 60000);
+    const decodedHtml = htmlContent?.html_content ? safeAtob(htmlContent.html_content) : null;
+    if (!decodedHtml) return;
+    openHtmlInNewTab(decodedHtml);
   };
 
   const handleDeleteFile = () => {
@@ -264,165 +539,41 @@ export function HtmlFileBrowser() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* File List */}
-        <Card className="lg:col-span-1">
-          <CardContent className="pt-4">
-            {isLoadingFiles ? (
-              <div className="flex items-center justify-center h-48">
-                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-              </div>
-            ) : filteredFiles.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
-                <File className="h-12 w-12 mb-2" />
-                <p className="text-sm">No HTML files found</p>
-              </div>
-            ) : (
-              <div className="space-y-4 max-h-[600px] overflow-y-auto">
-                <p className="text-sm text-muted-foreground">
-                  {filteredFiles.length} files{' '}
-                  {htmlFilesData?.total && htmlFilesData.total > filteredFiles.length
-                    ? `(${htmlFilesData.total} total)`
-                    : ''}
-                </p>
-
-                {sortedFiles.map((file) => (
-                  <FileListItem
-                    key={`${file.strategy_name}/${file.filename}`}
-                    file={file}
-                    isSelected={
-                      selectedFile?.strategy_name === file.strategy_name && selectedFile?.filename === file.filename
-                    }
-                    onSelect={() => setSelectedFile(file)}
-                  />
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Preview */}
-        <Card className="lg:col-span-2">
-          <CardContent className="pt-4">
-            {selectedFile ? (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="min-w-0 flex-1">
-                    {isRenaming ? (
-                      <div className="flex items-center gap-2">
-                        <Input
-                          ref={renameInputRef}
-                          value={renameValue}
-                          onChange={(e) => setRenameValue(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') handleConfirmRename();
-                            if (e.key === 'Escape') handleCancelRename();
-                          }}
-                          className="h-8 text-sm"
-                          disabled={renameHtmlFile.isPending}
-                        />
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 shrink-0"
-                          onClick={handleConfirmRename}
-                          disabled={renameHtmlFile.isPending}
-                        >
-                          <Check className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 shrink-0"
-                          onClick={handleCancelRename}
-                          disabled={renameHtmlFile.isPending}
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-medium truncate">{selectedFile.filename}</h3>
-                        <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={handleStartRename}>
-                          <Pencil className="h-3.5 w-3.5" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
-                          onClick={() => setIsDeleteDialogOpen(true)}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </Button>
-                      </div>
-                    )}
-                    <p className="text-sm text-muted-foreground">
-                      {selectedFile.strategy_name} | {selectedFile.dataset_name} | {formatDate(selectedFile.created_at)}
-                    </p>
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleOpenInNewTab}
-                    disabled={!htmlContent?.html_content}
-                    className="shrink-0 ml-2"
-                  >
-                    <ExternalLink className="h-4 w-4 mr-2" />
-                    Open in new tab
-                  </Button>
-                </div>
-                {renameHtmlFile.isError && (
-                  <div className="rounded-md bg-red-500/10 p-2 text-sm text-red-500">
-                    {renameHtmlFile.error.message}
-                  </div>
-                )}
-                {htmlContent?.metrics && <MetricsGrid metrics={htmlContent.metrics} />}
-                <ResultHtmlViewer
-                  htmlContent={htmlContent?.html_content ? safeAtob(htmlContent.html_content) : null}
-                  isLoading={isLoadingContent}
-                />
-              </div>
-            ) : (
-              <div className="flex flex-col items-center justify-center h-[400px] text-muted-foreground">
-                <File className="h-12 w-12 mb-2" />
-                <p className="text-sm">Select a file to preview</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <FileListCard
+          isLoadingFiles={isLoadingFiles}
+          filteredFiles={filteredFiles}
+          sortedFiles={sortedFiles}
+          totalFiles={htmlFilesData?.total}
+          selectedFile={selectedFile}
+          onSelectFile={setSelectedFile}
+        />
+        <PreviewCard
+          selectedFile={selectedFile}
+          isRenaming={isRenaming}
+          renameValue={renameValue}
+          setRenameValue={setRenameValue}
+          renameInputRef={renameInputRef}
+          onConfirmRename={handleConfirmRename}
+          onCancelRename={handleCancelRename}
+          onStartRename={handleStartRename}
+          onOpenDeleteDialog={() => setIsDeleteDialogOpen(true)}
+          onOpenInNewTab={handleOpenInNewTab}
+          isRenamePending={renameHtmlFile.isPending}
+          renameErrorMessage={renameHtmlFile.isError ? renameHtmlFile.error.message : null}
+          htmlContentBase64={htmlContent?.html_content}
+          metrics={htmlContent?.metrics}
+          isLoadingContent={isLoadingContent}
+        />
       </div>
 
-      {/* Delete Confirm Dialog */}
-      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Trash2 className="h-5 w-5 text-destructive" />
-              Delete HTML File
-            </DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete{' '}
-              <span className="font-semibold text-foreground">{selectedFile?.filename}</span>? This action cannot be
-              undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleDeleteFile} disabled={deleteHtmlFile.isPending}>
-              {deleteHtmlFile.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                'Delete'
-              )}
-            </Button>
-          </DialogFooter>
-          {deleteHtmlFile.isError && <p className="text-sm text-destructive">Error: {deleteHtmlFile.error.message}</p>}
-        </DialogContent>
-      </Dialog>
+      <DeleteDialog
+        open={isDeleteDialogOpen}
+        selectedFilename={selectedFile?.filename}
+        isPending={deleteHtmlFile.isPending}
+        errorMessage={deleteHtmlFile.isError ? deleteHtmlFile.error.message : null}
+        onOpenChange={setIsDeleteDialogOpen}
+        onDelete={handleDeleteFile}
+      />
     </div>
   );
 }

--- a/apps/ts/packages/web/src/components/Backtest/OptimizationHtmlFileBrowser.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/OptimizationHtmlFileBrowser.tsx
@@ -1,5 +1,5 @@
 import { Check, ExternalLink, File, Loader2, Pencil, Search, Trash2, X } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -70,7 +70,291 @@ function FileListItem({
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: UI component with file list, preview, rename/delete dialogs
+function resolveStrategies(files: OptimizationHtmlFileInfo[] | undefined): string[] {
+  if (!files) return [];
+  return Array.from(new Set(files.map((file) => file.strategy_name))).sort();
+}
+
+function resolveFilteredFiles(files: OptimizationHtmlFileInfo[] | undefined, searchQuery: string): OptimizationHtmlFileInfo[] {
+  if (!files) return [];
+  if (!searchQuery) return files;
+  const query = searchQuery.toLowerCase();
+  return files.filter(
+    (file) =>
+      file.filename.toLowerCase().includes(query) ||
+      file.dataset_name.toLowerCase().includes(query) ||
+      file.strategy_name.toLowerCase().includes(query)
+  );
+}
+
+function resolveSortedFiles(files: OptimizationHtmlFileInfo[]): OptimizationHtmlFileInfo[] {
+  return [...files].sort((left, right) => new Date(right.created_at).getTime() - new Date(left.created_at).getTime());
+}
+
+function openHtmlInNewTab(decodedHtml: string): void {
+  const blob = new Blob([decodedHtml], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener,noreferrer');
+  setTimeout(() => URL.revokeObjectURL(url), 60000);
+}
+
+type RenameAction =
+  | { type: 'ignore' }
+  | { type: 'cancel' }
+  | {
+      type: 'rename';
+      newFilename: string;
+    };
+
+function resolveRenameAction(selectedFile: OptimizationHtmlFileInfo | null, renameValue: string): RenameAction {
+  if (!selectedFile) {
+    return { type: 'ignore' };
+  }
+  const trimmed = renameValue.trim();
+  if (!trimmed) {
+    return { type: 'ignore' };
+  }
+
+  const newFilename = trimmed.endsWith('.html') ? trimmed : `${trimmed}.html`;
+  if (newFilename === selectedFile.filename) {
+    return { type: 'cancel' };
+  }
+  return { type: 'rename', newFilename };
+}
+
+function OptimizationFileListCard({
+  isLoadingFiles,
+  filteredFiles,
+  sortedFiles,
+  totalFiles,
+  selectedFile,
+  onSelectFile,
+}: {
+  isLoadingFiles: boolean;
+  filteredFiles: OptimizationHtmlFileInfo[];
+  sortedFiles: OptimizationHtmlFileInfo[];
+  totalFiles: number | undefined;
+  selectedFile: OptimizationHtmlFileInfo | null;
+  onSelectFile: (file: OptimizationHtmlFileInfo) => void;
+}) {
+  if (isLoadingFiles) {
+    return (
+      <Card className="lg:col-span-1">
+        <CardContent className="pt-4">
+          <div className="flex items-center justify-center h-48">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (filteredFiles.length === 0) {
+    return (
+      <Card className="lg:col-span-1">
+        <CardContent className="pt-4">
+          <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
+            <File className="h-12 w-12 mb-2" />
+            <p className="text-sm">No optimization result files found</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="lg:col-span-1">
+      <CardContent className="pt-4">
+        <div className="space-y-4 max-h-[600px] overflow-y-auto">
+          <p className="text-sm text-muted-foreground">
+            {filteredFiles.length} files {totalFiles && totalFiles > filteredFiles.length ? `(${totalFiles} total)` : ''}
+          </p>
+          {sortedFiles.map((file) => (
+            <FileListItem
+              key={`${file.strategy_name}/${file.filename}`}
+              file={file}
+              isSelected={selectedFile?.strategy_name === file.strategy_name && selectedFile?.filename === file.filename}
+              onSelect={() => onSelectFile(file)}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function OptimizationPreviewCard({
+  selectedFile,
+  isRenaming,
+  renameValue,
+  setRenameValue,
+  renameInputRef,
+  onConfirmRename,
+  onCancelRename,
+  onStartRename,
+  onOpenDeleteDialog,
+  onOpenInNewTab,
+  isRenamePending,
+  renameErrorMessage,
+  htmlContentBase64,
+  isLoadingContent,
+}: {
+  selectedFile: OptimizationHtmlFileInfo | null;
+  isRenaming: boolean;
+  renameValue: string;
+  setRenameValue: (value: string) => void;
+  renameInputRef: RefObject<HTMLInputElement | null>;
+  onConfirmRename: () => void;
+  onCancelRename: () => void;
+  onStartRename: () => void;
+  onOpenDeleteDialog: () => void;
+  onOpenInNewTab: () => void;
+  isRenamePending: boolean;
+  renameErrorMessage: string | null;
+  htmlContentBase64: string | null | undefined;
+  isLoadingContent: boolean;
+}) {
+  if (!selectedFile) {
+    return (
+      <Card className="lg:col-span-2">
+        <CardContent className="pt-4">
+          <div className="flex flex-col items-center justify-center h-[400px] text-muted-foreground">
+            <File className="h-12 w-12 mb-2" />
+            <p className="text-sm">Select a file to preview</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const decodedHtmlContent = htmlContentBase64 ? safeAtob(htmlContentBase64) : null;
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardContent className="pt-4">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="min-w-0 flex-1">
+              {isRenaming ? (
+                <div className="flex items-center gap-2">
+                  <Input
+                    ref={renameInputRef}
+                    value={renameValue}
+                    onChange={(event) => setRenameValue(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') onConfirmRename();
+                      if (event.key === 'Escape') onCancelRename();
+                    }}
+                    className="h-8 text-sm"
+                    disabled={isRenamePending}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    onClick={onConfirmRename}
+                    disabled={isRenamePending}
+                  >
+                    <Check className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    onClick={onCancelRename}
+                    disabled={isRenamePending}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <h3 className="font-medium truncate">{selectedFile.filename}</h3>
+                  <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={onStartRename}>
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                    onClick={onOpenDeleteDialog}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              )}
+              <p className="text-sm text-muted-foreground">
+                {selectedFile.strategy_name} | {selectedFile.dataset_name} | {formatDate(selectedFile.created_at)}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onOpenInNewTab}
+              disabled={!htmlContentBase64}
+              className="shrink-0 ml-2"
+            >
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Open in new tab
+            </Button>
+          </div>
+          {renameErrorMessage && <div className="rounded-md bg-red-500/10 p-2 text-sm text-red-500">{renameErrorMessage}</div>}
+          <ResultHtmlViewer htmlContent={decodedHtmlContent} isLoading={isLoadingContent} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DeleteDialog({
+  open,
+  selectedFilename,
+  isPending,
+  errorMessage,
+  onOpenChange,
+  onDelete,
+}: {
+  open: boolean;
+  selectedFilename: string | undefined;
+  isPending: boolean;
+  errorMessage: string | null;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Trash2 className="h-5 w-5 text-destructive" />
+            Delete Optimization HTML File
+          </DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete <span className="font-semibold text-foreground">{selectedFilename}</span>?
+            This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onDelete} disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </DialogFooter>
+        {errorMessage && <p className="text-sm text-destructive">Error: {errorMessage}</p>}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function OptimizationHtmlFileBrowser() {
   const [selectedStrategy, setSelectedStrategy] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState('');
@@ -90,27 +374,12 @@ export function OptimizationHtmlFileBrowser() {
   const renameHtmlFile = useRenameOptimizationHtmlFile();
   const deleteHtmlFile = useDeleteOptimizationHtmlFile();
 
-  const strategies = useMemo(() => {
-    if (!htmlFilesData?.files) return [];
-    const strategySet = new Set(htmlFilesData.files.map((f) => f.strategy_name));
-    return Array.from(strategySet).sort();
-  }, [htmlFilesData]);
-
-  const filteredFiles = useMemo(() => {
-    if (!htmlFilesData?.files) return [];
-    if (!searchQuery) return htmlFilesData.files;
-    const query = searchQuery.toLowerCase();
-    return htmlFilesData.files.filter(
-      (f) =>
-        f.filename.toLowerCase().includes(query) ||
-        f.dataset_name.toLowerCase().includes(query) ||
-        f.strategy_name.toLowerCase().includes(query)
-    );
-  }, [htmlFilesData, searchQuery]);
-
-  const sortedFiles = useMemo(() => {
-    return [...filteredFiles].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-  }, [filteredFiles]);
+  const strategies = useMemo(() => resolveStrategies(htmlFilesData?.files), [htmlFilesData?.files]);
+  const filteredFiles = useMemo(
+    () => resolveFilteredFiles(htmlFilesData?.files, searchQuery),
+    [htmlFilesData?.files, searchQuery]
+  );
+  const sortedFiles = useMemo(() => resolveSortedFiles(filteredFiles), [filteredFiles]);
 
   const handleStartRename = () => {
     if (!selectedFile) return;
@@ -136,17 +405,21 @@ export function OptimizationHtmlFileBrowser() {
   };
 
   const handleConfirmRename = () => {
-    if (!selectedFile || !renameValue.trim()) return;
-    const newFilename = renameValue.trim().endsWith('.html') ? renameValue.trim() : `${renameValue.trim()}.html`;
-    if (newFilename === selectedFile.filename) {
+    const action = resolveRenameAction(selectedFile, renameValue);
+    if (action.type === 'ignore') {
+      return;
+    }
+    if (action.type === 'cancel') {
       handleCancelRename();
       return;
     }
+    if (!selectedFile) return;
+
     renameHtmlFile.mutate(
       {
         strategy: selectedFile.strategy_name,
         filename: selectedFile.filename,
-        request: { new_filename: newFilename },
+        request: { new_filename: action.newFilename },
       },
       {
         onSuccess: (data) => {
@@ -162,13 +435,9 @@ export function OptimizationHtmlFileBrowser() {
   };
 
   const handleOpenInNewTab = () => {
-    if (!selectedFile || !htmlContent?.html_content) return;
-    const htmlString = safeAtob(htmlContent.html_content);
-    if (!htmlString) return;
-    const blob = new Blob([htmlString], { type: 'text/html' });
-    const url = URL.createObjectURL(blob);
-    window.open(url, '_blank', 'noopener,noreferrer');
-    setTimeout(() => URL.revokeObjectURL(url), 60000);
+    const decodedHtml = htmlContent?.html_content ? safeAtob(htmlContent.html_content) : null;
+    if (!decodedHtml) return;
+    openHtmlInNewTab(decodedHtml);
   };
 
   const handleDeleteFile = () => {
@@ -218,163 +487,40 @@ export function OptimizationHtmlFileBrowser() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* File List */}
-        <Card className="lg:col-span-1">
-          <CardContent className="pt-4">
-            {isLoadingFiles ? (
-              <div className="flex items-center justify-center h-48">
-                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-              </div>
-            ) : filteredFiles.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
-                <File className="h-12 w-12 mb-2" />
-                <p className="text-sm">No optimization result files found</p>
-              </div>
-            ) : (
-              <div className="space-y-4 max-h-[600px] overflow-y-auto">
-                <p className="text-sm text-muted-foreground">
-                  {filteredFiles.length} files{' '}
-                  {htmlFilesData?.total && htmlFilesData.total > filteredFiles.length
-                    ? `(${htmlFilesData.total} total)`
-                    : ''}
-                </p>
-                {sortedFiles.map((file) => (
-                  <FileListItem
-                    key={`${file.strategy_name}/${file.filename}`}
-                    file={file}
-                    isSelected={
-                      selectedFile?.strategy_name === file.strategy_name && selectedFile?.filename === file.filename
-                    }
-                    onSelect={() => setSelectedFile(file)}
-                  />
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Preview */}
-        <Card className="lg:col-span-2">
-          <CardContent className="pt-4">
-            {selectedFile ? (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="min-w-0 flex-1">
-                    {isRenaming ? (
-                      <div className="flex items-center gap-2">
-                        <Input
-                          ref={renameInputRef}
-                          value={renameValue}
-                          onChange={(e) => setRenameValue(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') handleConfirmRename();
-                            if (e.key === 'Escape') handleCancelRename();
-                          }}
-                          className="h-8 text-sm"
-                          disabled={renameHtmlFile.isPending}
-                        />
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 shrink-0"
-                          onClick={handleConfirmRename}
-                          disabled={renameHtmlFile.isPending}
-                        >
-                          <Check className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 shrink-0"
-                          onClick={handleCancelRename}
-                          disabled={renameHtmlFile.isPending}
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-medium truncate">{selectedFile.filename}</h3>
-                        <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={handleStartRename}>
-                          <Pencil className="h-3.5 w-3.5" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
-                          onClick={() => setIsDeleteDialogOpen(true)}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </Button>
-                      </div>
-                    )}
-                    <p className="text-sm text-muted-foreground">
-                      {selectedFile.strategy_name} | {selectedFile.dataset_name} | {formatDate(selectedFile.created_at)}
-                    </p>
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleOpenInNewTab}
-                    disabled={!htmlContent?.html_content}
-                    className="shrink-0 ml-2"
-                  >
-                    <ExternalLink className="h-4 w-4 mr-2" />
-                    Open in new tab
-                  </Button>
-                </div>
-                {renameHtmlFile.isError && (
-                  <div className="rounded-md bg-red-500/10 p-2 text-sm text-red-500">
-                    {renameHtmlFile.error.message}
-                  </div>
-                )}
-                <ResultHtmlViewer
-                  htmlContent={htmlContent?.html_content ? safeAtob(htmlContent.html_content) : null}
-                  isLoading={isLoadingContent}
-                />
-              </div>
-            ) : (
-              <div className="flex flex-col items-center justify-center h-[400px] text-muted-foreground">
-                <File className="h-12 w-12 mb-2" />
-                <p className="text-sm">Select a file to preview</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <OptimizationFileListCard
+          isLoadingFiles={isLoadingFiles}
+          filteredFiles={filteredFiles}
+          sortedFiles={sortedFiles}
+          totalFiles={htmlFilesData?.total}
+          selectedFile={selectedFile}
+          onSelectFile={setSelectedFile}
+        />
+        <OptimizationPreviewCard
+          selectedFile={selectedFile}
+          isRenaming={isRenaming}
+          renameValue={renameValue}
+          setRenameValue={setRenameValue}
+          renameInputRef={renameInputRef}
+          onConfirmRename={handleConfirmRename}
+          onCancelRename={handleCancelRename}
+          onStartRename={handleStartRename}
+          onOpenDeleteDialog={() => setIsDeleteDialogOpen(true)}
+          onOpenInNewTab={handleOpenInNewTab}
+          isRenamePending={renameHtmlFile.isPending}
+          renameErrorMessage={renameHtmlFile.isError ? renameHtmlFile.error.message : null}
+          htmlContentBase64={htmlContent?.html_content}
+          isLoadingContent={isLoadingContent}
+        />
       </div>
 
-      {/* Delete Confirm Dialog */}
-      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Trash2 className="h-5 w-5 text-destructive" />
-              Delete Optimization HTML File
-            </DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete{' '}
-              <span className="font-semibold text-foreground">{selectedFile?.filename}</span>? This action cannot be
-              undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleDeleteFile} disabled={deleteHtmlFile.isPending}>
-              {deleteHtmlFile.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                'Delete'
-              )}
-            </Button>
-          </DialogFooter>
-          {deleteHtmlFile.isError && <p className="text-sm text-destructive">Error: {deleteHtmlFile.error.message}</p>}
-        </DialogContent>
-      </Dialog>
+      <DeleteDialog
+        open={isDeleteDialogOpen}
+        selectedFilename={selectedFile?.filename}
+        isPending={deleteHtmlFile.isPending}
+        errorMessage={deleteHtmlFile.isError ? deleteHtmlFile.error.message : null}
+        onOpenChange={setIsDeleteDialogOpen}
+        onDelete={handleDeleteFile}
+      />
     </div>
   );
 }

--- a/apps/ts/packages/web/src/components/Backtest/StrategyEditor.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/StrategyEditor.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import yaml from 'js-yaml';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StrategyEditor } from './StrategyEditor';
@@ -94,7 +95,14 @@ vi.mock('@/components/ui/button', () => ({
 }));
 
 vi.mock('./SignalReferencePanel', () => ({
-  SignalReferencePanel: () => <div>Signal Reference</div>,
+  SignalReferencePanel: ({ onCopySnippet }: { onCopySnippet: (snippet: string) => void }) => (
+    <div>
+      <div>Signal Reference</div>
+      <button type="button" onClick={() => onCopySnippet('entry_filter_params:\n  snippet: true')}>
+        Insert Snippet
+      </button>
+    </div>
+  ),
 }));
 
 describe('StrategyEditor', () => {
@@ -183,6 +191,25 @@ describe('StrategyEditor', () => {
     expect(await screen.findByText(/YAML parse error:/)).toBeInTheDocument();
   });
 
+  it('shows object parse error when YAML is not an object', async () => {
+    const user = userEvent.setup();
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value).toContain('entry_filter_params');
+    });
+
+    await user.clear(screen.getByLabelText('YAML Editor'));
+    fireEvent.change(screen.getByLabelText('YAML Editor'), {
+      target: { value: '42' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(mockValidateMutateAsync).not.toHaveBeenCalled();
+    expect(await screen.findByText('Invalid YAML: Must be an object')).toBeInTheDocument();
+  });
+
   it('shows validation passed with warnings from backend response', async () => {
     const user = userEvent.setup();
     mockValidateMutateAsync.mockResolvedValueOnce({
@@ -259,5 +286,40 @@ describe('StrategyEditor', () => {
     render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
 
     expect(screen.getByText('Error: update failed')).toBeInTheDocument();
+  });
+
+  it('falls back to JSON stringify when yaml.dump throws', async () => {
+    const dumpSpy = vi.spyOn(yaml, 'dump').mockImplementation(() => {
+      throw new Error('dump failed');
+    });
+    mockBacktestHooks.strategyData = {
+      config: {
+        foo: 'bar',
+      },
+    };
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value).toContain('"foo": "bar"');
+    });
+
+    dumpSpy.mockRestore();
+  });
+
+  it('appends copied snippet to current yaml', async () => {
+    const user = userEvent.setup();
+
+    render(<StrategyEditor open onOpenChange={vi.fn()} strategyName="experimental/sample" />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value).toContain('entry_filter_params');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Insert Snippet' }));
+
+    const value = (screen.getByLabelText('YAML Editor') as HTMLTextAreaElement).value;
+    expect(value).toContain('entry_filter_params:');
+    expect(value).toContain('snippet: true');
   });
 });

--- a/apps/ts/packages/web/src/components/Backtest/StrategyEditor.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/StrategyEditor.tsx
@@ -23,7 +23,173 @@ interface StrategyEditorProps {
   onSuccess?: () => void;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex component with multiple validation states
+function parseYamlConfig(content: string): { config: Record<string, unknown> | null; parseError: string | null } {
+  try {
+    const parsed = yaml.load(content);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { config: null, parseError: 'Invalid YAML: Must be an object' };
+    }
+    return { config: parsed as Record<string, unknown>, parseError: null };
+  } catch (error) {
+    return {
+      config: null,
+      parseError: `YAML parse error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+}
+
+async function requestBackendValidation({
+  mutateAsync,
+  strategyName,
+  config,
+}: {
+  mutateAsync: ReturnType<typeof useValidateStrategy>['mutateAsync'];
+  strategyName: string;
+  config: Record<string, unknown>;
+}): Promise<StrategyValidationResponse> {
+  try {
+    return await mutateAsync({
+      name: strategyName,
+      request: { config },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown validation error';
+    return {
+      valid: false,
+      errors: [`Validation request failed: ${message}`],
+      warnings: [],
+    };
+  }
+}
+
+function resolveValidationViewState(validationResult: StrategyValidationResponse) {
+  const hasValidationErrors = !validationResult.valid;
+  const hasValidationWarnings = validationResult.warnings.length > 0;
+
+  if (hasValidationErrors) {
+    return {
+      containerClass: 'bg-destructive/10',
+      icon: <AlertCircle className="h-4 w-4 text-destructive" />,
+      titleClass: 'text-destructive',
+      title: 'Validation failed',
+    };
+  }
+  if (hasValidationWarnings) {
+    return {
+      containerClass: 'bg-yellow-500/10',
+      icon: <CheckCircle2 className="h-4 w-4 text-yellow-500" />,
+      titleClass: 'text-yellow-500',
+      title: 'Validation passed with warnings',
+    };
+  }
+  return {
+    containerClass: 'bg-green-500/10',
+    icon: <CheckCircle2 className="h-4 w-4 text-green-500" />,
+    titleClass: 'text-green-500',
+    title: 'Validation passed',
+  };
+}
+
+function ValidationFeedback({
+  parseError,
+  validationResult,
+  updateErrorMessage,
+}: {
+  parseError: string | null;
+  validationResult: StrategyValidationResponse | null;
+  updateErrorMessage: string | null;
+}) {
+  const validationViewState = validationResult ? resolveValidationViewState(validationResult) : null;
+
+  return (
+    <div className="mt-4 space-y-2">
+      {parseError && (
+        <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 text-destructive">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span className="text-sm">{parseError}</span>
+        </div>
+      )}
+
+      {validationResult && (
+        <div className={cn('p-3 rounded-md space-y-2', validationViewState?.containerClass)}>
+          <div className="flex items-center gap-2">
+            {validationViewState?.icon}
+            <span className={cn('text-sm font-medium', validationViewState?.titleClass)}>
+              {validationViewState?.title}
+            </span>
+          </div>
+          {validationResult.errors.length > 0 && (
+            <ul className="list-disc list-inside text-sm text-destructive space-y-1">
+              {validationResult.errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          )}
+          {validationResult.warnings.length > 0 && (
+            <ul className="list-disc list-inside text-sm text-yellow-600 space-y-1">
+              {validationResult.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {updateErrorMessage && (
+        <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 text-destructive">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span className="text-sm">Error: {updateErrorMessage}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EditorContent({
+  isLoadingStrategy,
+  yamlContent,
+  onYamlChange,
+  onCopySnippet,
+  parseError,
+  validationResult,
+  updateErrorMessage,
+}: {
+  isLoadingStrategy: boolean;
+  yamlContent: string;
+  onYamlChange: (value: string) => void;
+  onCopySnippet: (snippet: string) => void;
+  parseError: string | null;
+  validationResult: StrategyValidationResponse | null;
+  updateErrorMessage: string | null;
+}) {
+  if (isLoadingStrategy) {
+    return (
+      <div className="flex items-center justify-center h-[500px]">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 h-[500px]">
+      <div className="lg:col-span-2 flex flex-col min-h-0">
+        <div className="flex-1 min-h-0">
+          <MonacoYamlEditor value={yamlContent} onChange={onYamlChange} height="400px" />
+        </div>
+        <ValidationFeedback
+          parseError={parseError}
+          validationResult={validationResult}
+          updateErrorMessage={updateErrorMessage}
+        />
+      </div>
+
+      <div className="lg:col-span-1 border rounded-md overflow-hidden min-h-0">
+        <SignalReferencePanel onCopySnippet={onCopySnippet} />
+      </div>
+    </div>
+  );
+}
+
 export function StrategyEditor({ open, onOpenChange, strategyName, onSuccess }: StrategyEditorProps) {
   const [yamlContent, setYamlContent] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
@@ -44,35 +210,21 @@ export function StrategyEditor({ open, onOpenChange, strategyName, onSuccess }: 
   }, [strategyDetail]);
 
   const parseYaml = useCallback((): Record<string, unknown> | null => {
-    try {
-      const parsed = yaml.load(yamlContent);
-      if (typeof parsed !== 'object' || parsed === null) {
-        setParseError('Invalid YAML: Must be an object');
-        return null;
-      }
-      setParseError(null);
-      return parsed as Record<string, unknown>;
-    } catch (e) {
-      setParseError(`YAML parse error: ${e instanceof Error ? e.message : 'Unknown error'}`);
+    const parsed = parseYamlConfig(yamlContent);
+    setParseError(parsed.parseError);
+    if (!parsed.config) {
       return null;
     }
+    return parsed.config;
   }, [yamlContent]);
 
   const validateWithBackend = useCallback(
     async (config: Record<string, unknown>): Promise<StrategyValidationResponse> => {
-      try {
-        return await validateStrategy.mutateAsync({
-          name: strategyName,
-          request: { config },
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown validation error';
-        return {
-          valid: false,
-          errors: [`Validation request failed: ${message}`],
-          warnings: [],
-        };
-      }
+      return requestBackendValidation({
+        mutateAsync: validateStrategy.mutateAsync,
+        strategyName,
+        config,
+      });
     },
     [strategyName, validateStrategy]
   );
@@ -135,9 +287,6 @@ export function StrategyEditor({ open, onOpenChange, strategyName, onSuccess }: 
     [yamlContent]
   );
 
-  const hasValidationErrors = validationResult && !validationResult.valid;
-  const hasValidationWarnings = validationResult?.warnings && validationResult.warnings.length > 0;
-
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-6xl max-h-[90vh] flex flex-col">
@@ -152,95 +301,15 @@ export function StrategyEditor({ open, onOpenChange, strategyName, onSuccess }: 
         </DialogHeader>
 
         <div className="flex-1 min-h-0 py-4 overflow-hidden">
-          {isLoadingStrategy ? (
-            <div className="flex items-center justify-center h-[500px]">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 h-[500px]">
-              {/* Monaco Editor */}
-              <div className="lg:col-span-2 flex flex-col min-h-0">
-                <div className="flex-1 min-h-0">
-                  <MonacoYamlEditor value={yamlContent} onChange={handleYamlChange} height="400px" />
-                </div>
-
-                {/* Error/Validation Messages */}
-                <div className="mt-4 space-y-2">
-                  {parseError && (
-                    <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 text-destructive">
-                      <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-                      <span className="text-sm">{parseError}</span>
-                    </div>
-                  )}
-
-                  {validationResult && (
-                    <div
-                      className={cn(
-                        'p-3 rounded-md space-y-2',
-                        hasValidationErrors
-                          ? 'bg-destructive/10'
-                          : hasValidationWarnings
-                            ? 'bg-yellow-500/10'
-                            : 'bg-green-500/10'
-                      )}
-                    >
-                      <div className="flex items-center gap-2">
-                        {hasValidationErrors ? (
-                          <AlertCircle className="h-4 w-4 text-destructive" />
-                        ) : (
-                          <CheckCircle2
-                            className={cn('h-4 w-4', hasValidationWarnings ? 'text-yellow-500' : 'text-green-500')}
-                          />
-                        )}
-                        <span
-                          className={cn(
-                            'text-sm font-medium',
-                            hasValidationErrors
-                              ? 'text-destructive'
-                              : hasValidationWarnings
-                                ? 'text-yellow-500'
-                                : 'text-green-500'
-                          )}
-                        >
-                          {hasValidationErrors
-                            ? 'Validation failed'
-                            : hasValidationWarnings
-                              ? 'Validation passed with warnings'
-                              : 'Validation passed'}
-                        </span>
-                      </div>
-                      {validationResult.errors.length > 0 && (
-                        <ul className="list-disc list-inside text-sm text-destructive space-y-1">
-                          {validationResult.errors.map((error) => (
-                            <li key={error}>{error}</li>
-                          ))}
-                        </ul>
-                      )}
-                      {validationResult.warnings.length > 0 && (
-                        <ul className="list-disc list-inside text-sm text-yellow-600 space-y-1">
-                          {validationResult.warnings.map((warning) => (
-                            <li key={warning}>{warning}</li>
-                          ))}
-                        </ul>
-                      )}
-                    </div>
-                  )}
-
-                  {updateStrategy.isError && (
-                    <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 text-destructive">
-                      <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-                      <span className="text-sm">Error: {updateStrategy.error.message}</span>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Signal Reference Panel */}
-              <div className="lg:col-span-1 border rounded-md overflow-hidden min-h-0">
-                <SignalReferencePanel onCopySnippet={handleCopySnippet} />
-              </div>
-            </div>
-          )}
+          <EditorContent
+            isLoadingStrategy={isLoadingStrategy}
+            yamlContent={yamlContent}
+            onYamlChange={handleYamlChange}
+            onCopySnippet={handleCopySnippet}
+            parseError={parseError}
+            validationResult={validationResult}
+            updateErrorMessage={updateStrategy.isError ? updateStrategy.error.message : null}
+          />
         </div>
 
         <DialogFooter className="gap-2">

--- a/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
+++ b/apps/ts/packages/web/src/components/Backtest/strategyValidation.ts
@@ -50,45 +50,51 @@ type FundamentalSpec = {
 
 const FUNDAMENTAL_PARENT_FIELD_FALLBACK = ['enabled', 'period_type', 'use_adjusted'];
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Inference combines parse/fallback/intersection checks.
+function intersectFieldNames(left: Set<string>, right: Set<string>): Set<string> {
+  return new Set([...left].filter((fieldName) => right.has(fieldName)));
+}
+
+function deriveFundamentalParentFields(signal: SignalDefinition): Set<string> {
+  try {
+    const parsed = yaml.load(signal.yaml_snippet);
+    const parsedRecord = isPlainObject(parsed) ? parsed : null;
+    const snippetRoot =
+      parsedRecord && isPlainObject(parsedRecord.fundamental)
+        ? parsedRecord.fundamental
+        : null;
+    const childKey = signal.key.replace(/^fundamental_/, '');
+    return new Set(snippetRoot ? Object.keys(snippetRoot).filter((key) => key !== childKey) : []);
+  } catch {
+    // Ignore snippet parse failures and fall back to known parent fields.
+    return new Set<string>();
+  }
+}
+
+function resolveFallbackFundamentalParentFields(fundamentalDefs: SignalDefinition[]): string[] {
+  return FUNDAMENTAL_PARENT_FIELD_FALLBACK.filter((fieldName) =>
+    fundamentalDefs.every((signal) => signal.fields.some((field) => field.name === fieldName))
+  );
+}
+
 function extractFundamentalParentFieldNames(fundamentalDefs: SignalDefinition[]): string[] {
   let inferredParentFields: Set<string> | null = null;
 
   for (const signal of fundamentalDefs) {
-    try {
-      const parsed = yaml.load(signal.yaml_snippet);
-      const parsedRecord = isPlainObject(parsed) ? parsed : null;
-      const snippetRoot =
-        parsedRecord && isPlainObject(parsedRecord.fundamental)
-          ? parsedRecord.fundamental
-          : null;
-      const childKey = signal.key.replace(/^fundamental_/, '');
-      const currentParentFields = new Set(
-        snippetRoot ? Object.keys(snippetRoot).filter((key) => key !== childKey) : []
-      );
-
-      if (currentParentFields.size === 0) {
-        continue;
-      }
-      if (!inferredParentFields) {
-        inferredParentFields = currentParentFields;
-        continue;
-      }
-      inferredParentFields = new Set(
-        [...inferredParentFields].filter((fieldName) => currentParentFields.has(fieldName))
-      );
-    } catch {
-      // Ignore snippet parse failures and fall back to known parent fields.
+    const currentParentFields = deriveFundamentalParentFields(signal);
+    if (currentParentFields.size === 0) {
+      continue;
     }
+
+    inferredParentFields = inferredParentFields
+      ? intersectFieldNames(inferredParentFields, currentParentFields)
+      : currentParentFields;
   }
 
-  if (inferredParentFields && inferredParentFields.size > 0) {
-    return [...inferredParentFields];
+  if (inferredParentFields?.size) {
+    return Array.from(inferredParentFields);
   }
 
-  return FUNDAMENTAL_PARENT_FIELD_FALLBACK.filter((fieldName) =>
-    fundamentalDefs.every((signal) => signal.fields.some((field) => field.name === fieldName))
-  );
+  return resolveFallbackFundamentalParentFields(fundamentalDefs);
 }
 
 function buildFundamentalSpec(signalDefinitions: SignalDefinition[]): FundamentalSpec {
@@ -172,7 +178,32 @@ function validateFundamentalSection(
   }
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Validation logic needs explicit branch handling
+function validateNumericFieldConstraints(
+  fieldPath: string,
+  value: number,
+  field: SignalFieldDefinition,
+  errors: string[]
+): void {
+  const constraints = field.constraints;
+  const gt = constraints?.gt;
+  const ge = constraints?.ge;
+  const lt = constraints?.lt;
+  const le = constraints?.le;
+
+  if (isNumericConstraint(gt) && value <= gt) {
+    errors.push(`${fieldPath} must be > ${gt}`);
+  }
+  if (isNumericConstraint(ge) && value < ge) {
+    errors.push(`${fieldPath} must be >= ${ge}`);
+  }
+  if (isNumericConstraint(lt) && value >= lt) {
+    errors.push(`${fieldPath} must be < ${lt}`);
+  }
+  if (isNumericConstraint(le) && value > le) {
+    errors.push(`${fieldPath} must be <= ${le}`);
+  }
+}
+
 function validateFieldValue(
   sectionName: string,
   signalKey: string,
@@ -182,45 +213,31 @@ function validateFieldValue(
 ): void {
   const fieldPath = `${sectionName}.${signalKey}.${field.name}`;
 
-  if (field.type === 'boolean' && typeof value !== 'boolean') {
-    errors.push(`${fieldPath} must be a boolean`);
-    return;
-  }
-
-  if (field.type === 'number') {
-    if (typeof value !== 'number' || Number.isNaN(value)) {
-      errors.push(`${fieldPath} must be a number`);
+  switch (field.type) {
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        errors.push(`${fieldPath} must be a boolean`);
+      }
       return;
-    }
-
-    const constraints = field.constraints;
-    const gt = constraints?.gt;
-    const ge = constraints?.ge;
-    const lt = constraints?.lt;
-    const le = constraints?.le;
-
-    if (isNumericConstraint(gt) && value <= gt) {
-      errors.push(`${fieldPath} must be > ${gt}`);
-    }
-    if (isNumericConstraint(ge) && value < ge) {
-      errors.push(`${fieldPath} must be >= ${ge}`);
-    }
-    if (isNumericConstraint(lt) && value >= lt) {
-      errors.push(`${fieldPath} must be < ${lt}`);
-    }
-    if (isNumericConstraint(le) && value > le) {
-      errors.push(`${fieldPath} must be <= ${le}`);
-    }
-    return;
-  }
-
-  if ((field.type === 'string' || field.type === 'select') && typeof value !== 'string') {
-    errors.push(`${fieldPath} must be a string`);
-    return;
-  }
-
-  if (field.type === 'select' && field.options && typeof value === 'string' && !field.options.includes(value)) {
-    errors.push(`${fieldPath} must be one of: ${field.options.join(', ')}`);
+    case 'number':
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        errors.push(`${fieldPath} must be a number`);
+        return;
+      }
+      validateNumericFieldConstraints(fieldPath, value, field, errors);
+      return;
+    case 'string':
+    case 'select':
+      if (typeof value !== 'string') {
+        errors.push(`${fieldPath} must be a string`);
+        return;
+      }
+      if (field.type === 'select' && field.options && !field.options.includes(value)) {
+        errors.push(`${fieldPath} must be one of: ${field.options.join(', ')}`);
+      }
+      return;
+    default:
+      return;
   }
 }
 
@@ -274,11 +291,37 @@ function validateSignalSection(
   }
 }
 
+function validateSharedConfig(sharedConfig: unknown, errors: string[]): void {
+  if (!isPlainObject(sharedConfig)) {
+    errors.push('shared_config must be an object');
+    return;
+  }
+
+  for (const key of Object.keys(sharedConfig)) {
+    if (!ALLOWED_SHARED_CONFIG_KEYS.has(key)) {
+      errors.push(`shared_config.${key} is not a valid parameter name`);
+    }
+  }
+
+  const kelly = sharedConfig.kelly_fraction;
+  if (kelly === undefined) {
+    return;
+  }
+
+  if (typeof kelly !== 'number' || Number.isNaN(kelly)) {
+    errors.push('shared_config.kelly_fraction must be a number');
+    return;
+  }
+
+  if (kelly < 0 || kelly > 2) {
+    errors.push('shared_config.kelly_fraction must be between 0 and 2');
+  }
+}
+
 /**
  * @deprecated Backend strict validation (`/api/strategies/{name}/validate`) is the source of truth.
  * Keep this only for temporary compatibility and tests.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Validation combines schema/key/type/range checks in one pass.
 export function validateStrategyConfigLocally(
   config: Record<string, unknown>,
   signalDefinitions: SignalDefinition[]
@@ -289,7 +332,7 @@ export function validateStrategyConfigLocally(
   const entryFilter = config.entry_filter_params;
   const exitTrigger = config.exit_trigger_params;
 
-  if (!entryFilter && !exitTrigger) {
+  if (entryFilter === undefined && exitTrigger === undefined) {
     errors.push('entry_filter_params or exit_trigger_params is required');
   }
 
@@ -302,24 +345,7 @@ export function validateStrategyConfigLocally(
   }
 
   if (config.shared_config !== undefined) {
-    if (!isPlainObject(config.shared_config)) {
-      errors.push('shared_config must be an object');
-    } else {
-      for (const key of Object.keys(config.shared_config)) {
-        if (!ALLOWED_SHARED_CONFIG_KEYS.has(key)) {
-          errors.push(`shared_config.${key} is not a valid parameter name`);
-        }
-      }
-
-      const kelly = config.shared_config.kelly_fraction;
-      if (kelly !== undefined) {
-        if (typeof kelly !== 'number' || Number.isNaN(kelly)) {
-          errors.push('shared_config.kelly_fraction must be a number');
-        } else if (kelly < 0 || kelly > 2) {
-          errors.push('shared_config.kelly_fraction must be between 0 and 2');
-        }
-      }
-    }
+    validateSharedConfig(config.shared_config, errors);
   }
 
   if (signalDefinitions.length === 0) {

--- a/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
+++ b/apps/ts/packages/web/src/components/Chart/FundamentalsPanel.tsx
@@ -19,6 +19,19 @@ interface FundamentalsPanelProps {
   metricVisibility?: Record<FundamentalMetricId, boolean>;
 }
 
+type DailyValuationPoint = {
+  per?: number | null;
+  pbr?: number | null;
+  close?: number | null;
+};
+
+type FundamentalsViewData = {
+  data: ApiFundamentalDataPoint[];
+  latestMetrics?: ApiFundamentalDataPoint | null;
+  dailyValuation?: DailyValuationPoint[] | null;
+  forecastEpsLookbackFyCount?: number | null;
+};
+
 function resolveChangeRate(
   actualValue: number | null | undefined,
   forecastValue: number | null | undefined
@@ -65,6 +78,159 @@ function resolveForecastEpsAboveRecentFyActuals(
   return forecastValue > Math.max(...recentActuals);
 }
 
+function findLatestFiscalYearWithActualData(rows: ApiFundamentalDataPoint[]): ApiFundamentalDataPoint | undefined {
+  return rows.find((item) => isFiscalYear(item.periodType) && hasActualFinancialData(item));
+}
+
+function firstNonNull<T>(...values: Array<T | null | undefined>): T | null {
+  for (const value of values) {
+    if (value != null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function resolveForecastEpsFields(
+  fyData: ApiFundamentalDataPoint,
+  latestMetrics: ApiFundamentalDataPoint | null | undefined
+) {
+  const revisedForecastEps = firstNonNull(latestMetrics?.revisedForecastEps, fyData.revisedForecastEps);
+  const revisedForecastSource = firstNonNull(latestMetrics?.revisedForecastSource, fyData.revisedForecastSource);
+  const forecastEps = firstNonNull(revisedForecastEps, latestMetrics?.forecastEps);
+  const adjustedForecastEps =
+    revisedForecastEps != null ? null : firstNonNull(latestMetrics?.adjustedForecastEps, fyData.adjustedForecastEps);
+
+  return {
+    forecastEps,
+    adjustedForecastEps,
+    revisedForecastEps,
+    revisedForecastSource,
+  };
+}
+
+function resolveForecastAboveRecentFlag(
+  fyData: ApiFundamentalDataPoint,
+  latestMetrics: ApiFundamentalDataPoint | null | undefined
+): boolean | null {
+  return firstNonNull(
+    latestMetrics?.forecastEpsAboveRecentFyActuals,
+    latestMetrics?.forecastEpsAboveAllHistoricalActuals,
+    fyData.forecastEpsAboveRecentFyActuals,
+    fyData.forecastEpsAboveAllHistoricalActuals
+  );
+}
+
+function mergeLatestMetrics(
+  fyData: ApiFundamentalDataPoint,
+  latestMetrics: ApiFundamentalDataPoint | null | undefined,
+  forecastEpsLookbackFyCount: number
+): ApiFundamentalDataPoint {
+  const forecastEpsFields = resolveForecastEpsFields(fyData, latestMetrics);
+
+  return {
+    ...fyData,
+    forecastEps: forecastEpsFields.forecastEps,
+    adjustedForecastEps: forecastEpsFields.adjustedForecastEps,
+    forecastEpsChangeRate: latestMetrics?.forecastEpsChangeRate ?? null,
+    revisedForecastEps: forecastEpsFields.revisedForecastEps,
+    revisedForecastSource: forecastEpsFields.revisedForecastSource,
+    forecastDividendFy: latestMetrics?.forecastDividendFy ?? null,
+    adjustedForecastDividendFy: latestMetrics?.adjustedForecastDividendFy ?? fyData.adjustedForecastDividendFy ?? null,
+    forecastDividendFyChangeRate: latestMetrics?.forecastDividendFyChangeRate ?? null,
+    payoutRatio: latestMetrics?.payoutRatio ?? fyData.payoutRatio ?? null,
+    forecastPayoutRatio: latestMetrics?.forecastPayoutRatio ?? null,
+    forecastPayoutRatioChangeRate: latestMetrics?.forecastPayoutRatioChangeRate ?? null,
+    prevCashFlowOperating: latestMetrics?.prevCashFlowOperating ?? null,
+    prevCashFlowInvesting: latestMetrics?.prevCashFlowInvesting ?? null,
+    prevCashFlowFinancing: latestMetrics?.prevCashFlowFinancing ?? null,
+    prevCashAndEquivalents: latestMetrics?.prevCashAndEquivalents ?? null,
+    cfoToNetProfitRatio: latestMetrics?.cfoToNetProfitRatio ?? fyData.cfoToNetProfitRatio ?? null,
+    tradingValueToMarketCapRatio:
+      latestMetrics?.tradingValueToMarketCapRatio ?? fyData.tradingValueToMarketCapRatio ?? null,
+    forecastEpsAboveRecentFyActuals: resolveForecastAboveRecentFlag(fyData, latestMetrics),
+    forecastEpsLookbackFyCount,
+  };
+}
+
+function applyForecastChangeRates(metrics: ApiFundamentalDataPoint): ApiFundamentalDataPoint {
+  let nextMetrics = metrics;
+
+  const displayActualEps = metrics.adjustedEps ?? metrics.eps ?? null;
+  const displayForecastEps = metrics.revisedForecastEps ?? metrics.adjustedForecastEps ?? metrics.forecastEps ?? null;
+  const epsChangeRate = resolveChangeRate(displayActualEps, displayForecastEps);
+  if (epsChangeRate != null) {
+    nextMetrics = { ...nextMetrics, forecastEpsChangeRate: epsChangeRate };
+  }
+
+  const displayActualDividend = metrics.adjustedDividendFy ?? metrics.dividendFy ?? null;
+  const displayForecastDividend = metrics.adjustedForecastDividendFy ?? metrics.forecastDividendFy ?? null;
+  const dividendChangeRate = resolveChangeRate(displayActualDividend, displayForecastDividend);
+  if (dividendChangeRate != null) {
+    nextMetrics = { ...nextMetrics, forecastDividendFyChangeRate: dividendChangeRate };
+  }
+
+  const payoutChangeRate = resolveChangeRate(metrics.payoutRatio ?? null, metrics.forecastPayoutRatio ?? null);
+  if (payoutChangeRate != null) {
+    nextMetrics = { ...nextMetrics, forecastPayoutRatioChangeRate: payoutChangeRate };
+  }
+
+  return nextMetrics;
+}
+
+function applyForecastFlagFallback(
+  metrics: ApiFundamentalDataPoint,
+  rows: ApiFundamentalDataPoint[]
+): ApiFundamentalDataPoint {
+  if (metrics.forecastEpsAboveRecentFyActuals != null) {
+    return metrics;
+  }
+
+  const displayForecastEps = metrics.revisedForecastEps ?? metrics.adjustedForecastEps ?? metrics.forecastEps ?? null;
+  return {
+    ...metrics,
+    forecastEpsAboveRecentFyActuals: resolveForecastEpsAboveRecentFyActuals(
+      rows,
+      displayForecastEps,
+      metrics.forecastEpsLookbackFyCount ?? 3
+    ),
+  };
+}
+
+function applyLatestDailyValuation(
+  metrics: ApiFundamentalDataPoint,
+  dailyValuation: DailyValuationPoint[] | null | undefined
+): ApiFundamentalDataPoint {
+  const latestDaily = dailyValuation?.[dailyValuation.length - 1];
+  if (!latestDaily) {
+    return metrics;
+  }
+
+  return {
+    ...metrics,
+    per: latestDaily.per ?? null,
+    pbr: latestDaily.pbr ?? null,
+    stockPrice: latestDaily.close ?? null,
+  };
+}
+
+function resolveLatestFyMetrics(data: FundamentalsViewData | undefined): ApiFundamentalDataPoint | undefined {
+  if (!data?.data || data.data.length === 0) {
+    return undefined;
+  }
+
+  const latestFyData = findLatestFiscalYearWithActualData(data.data);
+  if (!latestFyData) {
+    return undefined;
+  }
+
+  const lookbackCount = data.forecastEpsLookbackFyCount ?? 3;
+  const merged = mergeLatestMetrics(latestFyData, data.latestMetrics, lookbackCount);
+  const withRates = applyForecastChangeRates(merged);
+  const withForecastFlag = applyForecastFlagFallback(withRates, data.data);
+  return applyLatestDailyValuation(withForecastFlag, data.dailyValuation);
+}
+
 export function FundamentalsPanel({
   symbol,
   enabled = true,
@@ -82,109 +248,7 @@ export function FundamentalsPanel({
   // Get the latest FY (full year) data with actual financial data for summary card
   // Then update PER/PBR/stockPrice with latest daily valuation for current prices
   // Also merge forecastEps and prevCashFlow* from latestMetrics (which has enhanced data)
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: data merging logic with multiple conditional fields
-  const latestFyMetrics = useMemo(() => {
-    if (!data?.data) return undefined;
-
-    // Find latest FY with actual financial data (not forecast)
-    const fyData = data.data.find((d) => isFiscalYear(d.periodType) && hasActualFinancialData(d));
-
-    if (!fyData) return undefined;
-
-    // Start with FY data and merge enhanced fields from latestMetrics
-    const revisedForecastEps = data.latestMetrics?.revisedForecastEps ?? fyData.revisedForecastEps ?? null;
-    const revisedForecastSource = data.latestMetrics?.revisedForecastSource ?? fyData.revisedForecastSource ?? null;
-    const forecastEps = revisedForecastEps ?? data.latestMetrics?.forecastEps ?? null;
-    const adjustedForecastEps =
-      revisedForecastEps != null ? null : data.latestMetrics?.adjustedForecastEps ?? fyData.adjustedForecastEps ?? null;
-
-    let result = {
-      ...fyData,
-      // Merge forecast and previous period data from latestMetrics (API enhances these)
-      forecastEps,
-      adjustedForecastEps,
-      forecastEpsChangeRate: data.latestMetrics?.forecastEpsChangeRate ?? null,
-      revisedForecastEps,
-      revisedForecastSource,
-      forecastDividendFy: data.latestMetrics?.forecastDividendFy ?? null,
-      adjustedForecastDividendFy:
-        data.latestMetrics?.adjustedForecastDividendFy ?? fyData.adjustedForecastDividendFy ?? null,
-      forecastDividendFyChangeRate: data.latestMetrics?.forecastDividendFyChangeRate ?? null,
-      payoutRatio: data.latestMetrics?.payoutRatio ?? fyData.payoutRatio ?? null,
-      forecastPayoutRatio: data.latestMetrics?.forecastPayoutRatio ?? null,
-      forecastPayoutRatioChangeRate: data.latestMetrics?.forecastPayoutRatioChangeRate ?? null,
-      prevCashFlowOperating: data.latestMetrics?.prevCashFlowOperating ?? null,
-      prevCashFlowInvesting: data.latestMetrics?.prevCashFlowInvesting ?? null,
-      prevCashFlowFinancing: data.latestMetrics?.prevCashFlowFinancing ?? null,
-      prevCashAndEquivalents: data.latestMetrics?.prevCashAndEquivalents ?? null,
-      cfoToNetProfitRatio: data.latestMetrics?.cfoToNetProfitRatio ?? fyData.cfoToNetProfitRatio ?? null,
-      tradingValueToMarketCapRatio:
-        data.latestMetrics?.tradingValueToMarketCapRatio ?? fyData.tradingValueToMarketCapRatio ?? null,
-      forecastEpsAboveRecentFyActuals:
-        data.latestMetrics?.forecastEpsAboveRecentFyActuals ??
-        data.latestMetrics?.forecastEpsAboveAllHistoricalActuals ??
-        fyData.forecastEpsAboveRecentFyActuals ??
-        fyData.forecastEpsAboveAllHistoricalActuals ??
-        null,
-      forecastEpsLookbackFyCount: data.forecastEpsLookbackFyCount ?? 3,
-    };
-
-    const displayActualEps = result.adjustedEps ?? result.eps ?? null;
-    const displayForecastEps = result.revisedForecastEps ?? result.adjustedForecastEps ?? result.forecastEps ?? null;
-    const epsChangeRate = resolveChangeRate(displayActualEps, displayForecastEps);
-    if (epsChangeRate != null) {
-      result = {
-        ...result,
-        forecastEpsChangeRate: epsChangeRate,
-      };
-    }
-
-    const displayActualDividend = result.adjustedDividendFy ?? result.dividendFy ?? null;
-    const displayForecastDividend =
-      result.adjustedForecastDividendFy ?? result.forecastDividendFy ?? null;
-    const dividendChangeRate = resolveChangeRate(displayActualDividend, displayForecastDividend);
-    if (dividendChangeRate != null) {
-      result = {
-        ...result,
-        forecastDividendFyChangeRate: dividendChangeRate,
-      };
-    }
-
-    const payoutChangeRate = resolveChangeRate(result.payoutRatio ?? null, result.forecastPayoutRatio ?? null);
-    if (payoutChangeRate != null) {
-      result = {
-        ...result,
-        forecastPayoutRatioChangeRate: payoutChangeRate,
-      };
-    }
-
-    result = {
-      ...result,
-      forecastEpsAboveRecentFyActuals:
-        result.forecastEpsAboveRecentFyActuals ??
-        resolveForecastEpsAboveRecentFyActuals(
-          data.data,
-          displayForecastEps,
-          result.forecastEpsLookbackFyCount ?? 3
-        ),
-    };
-
-    // Update with latest daily valuation (current stock price PER/PBR)
-    const dailyValuation = data.dailyValuation;
-    if (dailyValuation && dailyValuation.length > 0) {
-      const latestDaily = dailyValuation[dailyValuation.length - 1];
-      if (latestDaily) {
-        result = {
-          ...result,
-          per: latestDaily.per,
-          pbr: latestDaily.pbr,
-          stockPrice: latestDaily.close,
-        };
-      }
-    }
-
-    return result;
-  }, [data]);
+  const latestFyMetrics = useMemo(() => resolveLatestFyMetrics(data), [data]);
 
   if (!symbol) {
     return (

--- a/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.tsx
@@ -131,7 +131,7 @@ export function RiskAdjustedReturnChart({
     if (chartRef.current) {
       setChartVisibleBars(chartRef.current, ratioData.length, settings.visibleBars);
     }
-  }, [condition, data, settings.visibleBars, threshold]);
+  }, [data, settings.visibleBars, threshold]);
 
   useEffect(() => {
     const container = chartContainerRef.current;

--- a/apps/ts/packages/web/src/components/Lab/LabPanel.tsx
+++ b/apps/ts/packages/web/src/components/Lab/LabPanel.tsx
@@ -29,7 +29,61 @@ function tabButtonClass(isActive: boolean): string {
   }`;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: UI component with conditional rendering
+function isRunningStatus(status: string | null | undefined): boolean {
+  return status === 'pending' || status === 'running';
+}
+
+function resolveIsJobActive(params: {
+  generatePending: boolean;
+  evolvePending: boolean;
+  optimizePending: boolean;
+  improvePending: boolean;
+  sseStatus: string | null | undefined;
+  jobStatus: string | null | undefined;
+}): boolean {
+  return (
+    params.generatePending ||
+    params.evolvePending ||
+    params.optimizePending ||
+    params.improvePending ||
+    isRunningStatus(params.sseStatus) ||
+    isRunningStatus(params.jobStatus)
+  );
+}
+
+interface LabOperationFormProps {
+  operation: LabType;
+  strategyName: string | null;
+  disabled: boolean;
+  onGenerateSubmit: (request: unknown) => Promise<void>;
+  onEvolveSubmit: (request: unknown) => Promise<void>;
+  onOptimizeSubmit: (request: unknown) => Promise<void>;
+  onImproveSubmit: (request: unknown) => Promise<void>;
+}
+
+function LabOperationForm({
+  operation,
+  strategyName,
+  disabled,
+  onGenerateSubmit,
+  onEvolveSubmit,
+  onOptimizeSubmit,
+  onImproveSubmit,
+}: LabOperationFormProps) {
+  switch (operation) {
+    case 'generate':
+      return <LabGenerateForm onSubmit={onGenerateSubmit} disabled={disabled} />;
+    case 'evolve':
+      return <LabEvolveForm strategyName={strategyName} onSubmit={onEvolveSubmit} disabled={disabled} />;
+    case 'optimize':
+      return <LabOptimizeForm strategyName={strategyName} onSubmit={onOptimizeSubmit} disabled={disabled} />;
+    case 'improve':
+      return <LabImproveForm strategyName={strategyName} onSubmit={onImproveSubmit} disabled={disabled} />;
+    default:
+      return null;
+  }
+}
+
 export function LabPanel() {
   const [activeTab, setActiveTab] = useState<'run' | 'history'>('run');
   const [operation, setOperation] = useState<LabType>('generate');
@@ -52,15 +106,14 @@ export function LabPanel() {
   const labImprove = useLabImprove();
   const cancelLabJob = useCancelLabJob();
 
-  const isJobActive =
-    labGenerate.isPending ||
-    labEvolve.isPending ||
-    labOptimize.isPending ||
-    labImprove.isPending ||
-    sse.status === 'pending' ||
-    sse.status === 'running' ||
-    jobStatus?.status === 'pending' ||
-    jobStatus?.status === 'running';
+  const isJobActive = resolveIsJobActive({
+    generatePending: labGenerate.isPending,
+    evolvePending: labEvolve.isPending,
+    optimizePending: labOptimize.isPending,
+    improvePending: labImprove.isPending,
+    sseStatus: sse.status,
+    jobStatus: jobStatus?.status,
+  });
 
   const needsStrategy = operation !== 'generate';
 
@@ -86,6 +139,26 @@ export function LabPanel() {
   };
 
   const mutationError = labGenerate.error ?? labEvolve.error ?? labOptimize.error ?? labImprove.error;
+  const shouldShowProgress = !!activeLabJobId && !!currentStatus;
+  const cancelHandler =
+    activeLabJobId && isRunningStatus(currentStatus) ? () => cancelLabJob.mutate(activeLabJobId) : undefined;
+
+  const handleGenerateSubmit = async (request: unknown) => {
+    const result = await labGenerate.mutateAsync(request as Parameters<typeof labGenerate.mutateAsync>[0]);
+    handleJobStart(result.job_id, 'generate');
+  };
+  const handleEvolveSubmit = async (request: unknown) => {
+    const result = await labEvolve.mutateAsync(request as Parameters<typeof labEvolve.mutateAsync>[0]);
+    handleJobStart(result.job_id, 'evolve');
+  };
+  const handleOptimizeSubmit = async (request: unknown) => {
+    const result = await labOptimize.mutateAsync(request as Parameters<typeof labOptimize.mutateAsync>[0]);
+    handleJobStart(result.job_id, 'optimize');
+  };
+  const handleImproveSubmit = async (request: unknown) => {
+    const result = await labImprove.mutateAsync(request as Parameters<typeof labImprove.mutateAsync>[0]);
+    handleJobStart(result.job_id, 'improve');
+  };
 
   return (
     <div className="max-w-2xl space-y-4">
@@ -129,48 +202,15 @@ export function LabPanel() {
             </div>
           )}
 
-          {operation === 'generate' && (
-            <LabGenerateForm
-              onSubmit={async (req) => {
-                const result = await labGenerate.mutateAsync(req);
-                handleJobStart(result.job_id, 'generate');
-              }}
-              disabled={isJobActive}
-            />
-          )}
-
-          {operation === 'evolve' && (
-            <LabEvolveForm
-              strategyName={selectedStrategy}
-              onSubmit={async (req) => {
-                const result = await labEvolve.mutateAsync(req);
-                handleJobStart(result.job_id, 'evolve');
-              }}
-              disabled={isJobActive}
-            />
-          )}
-
-          {operation === 'optimize' && (
-            <LabOptimizeForm
-              strategyName={selectedStrategy}
-              onSubmit={async (req) => {
-                const result = await labOptimize.mutateAsync(req);
-                handleJobStart(result.job_id, 'optimize');
-              }}
-              disabled={isJobActive}
-            />
-          )}
-
-          {operation === 'improve' && (
-            <LabImproveForm
-              strategyName={selectedStrategy}
-              onSubmit={async (req) => {
-                const result = await labImprove.mutateAsync(req);
-                handleJobStart(result.job_id, 'improve');
-              }}
-              disabled={isJobActive}
-            />
-          )}
+          <LabOperationForm
+            operation={operation}
+            strategyName={selectedStrategy}
+            disabled={isJobActive}
+            onGenerateSubmit={handleGenerateSubmit}
+            onEvolveSubmit={handleEvolveSubmit}
+            onOptimizeSubmit={handleOptimizeSubmit}
+            onImproveSubmit={handleImproveSubmit}
+          />
 
           {mutationError && (
             <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{mutationError.message}</div>
@@ -189,7 +229,7 @@ export function LabPanel() {
         />
       )}
 
-      {activeLabJobId && currentStatus && (
+      {shouldShowProgress && (
         <LabJobProgress
           status={currentStatus}
           progress={currentProgress}
@@ -197,11 +237,7 @@ export function LabPanel() {
           error={jobStatus?.error}
           createdAt={jobStatus?.created_at}
           startedAt={jobStatus?.started_at}
-          onCancel={
-            currentStatus === 'pending' || currentStatus === 'running'
-              ? () => cancelLabJob.mutate(activeLabJobId)
-              : undefined
-          }
+          onCancel={cancelHandler}
           isCancelling={cancelLabJob.isPending}
         />
       )}

--- a/apps/ts/packages/web/src/components/Screening/ScreeningSummary.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningSummary.tsx
@@ -21,54 +21,52 @@ export function ScreeningSummary({ summary, markets, recentDays, referenceDate }
   const topStrategy = Object.entries(summary.byStrategy).sort((a, b) => b[1] - a[1])[0] || null;
 
   return (
-    <>
-      <div className="grid grid-cols-4 gap-3 mb-4">
-        <Card className="glass-panel">
-          <CardContent className="p-3">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <BarChart3 className="h-4 w-4" />
-              <span className="text-xs">Screened</span>
-            </div>
-            <p className="text-xl font-bold tabular-nums">{summary.totalStocksScreened.toLocaleString()}</p>
-            <p className="text-xs text-muted-foreground mt-1">{marketInfo}</p>
-          </CardContent>
-        </Card>
+    <div className="grid grid-cols-4 gap-3 mb-4">
+      <Card className="glass-panel">
+        <CardContent className="p-3">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <BarChart3 className="h-4 w-4" />
+            <span className="text-xs">Screened</span>
+          </div>
+          <p className="text-xl font-bold tabular-nums">{summary.totalStocksScreened.toLocaleString()}</p>
+          <p className="text-xs text-muted-foreground mt-1">{marketInfo}</p>
+        </CardContent>
+      </Card>
 
-        <Card className="glass-panel">
-          <CardContent className="p-3">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <TrendingUp className="h-4 w-4" />
-              <span className="text-xs">Matches</span>
-            </div>
-            <p className="text-xl font-bold tabular-nums text-green-600 dark:text-green-400">{summary.matchCount}</p>
-            <p className="text-xs text-muted-foreground mt-1">{hitRate.toFixed(1)}% hit rate</p>
-          </CardContent>
-        </Card>
+      <Card className="glass-panel">
+        <CardContent className="p-3">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <TrendingUp className="h-4 w-4" />
+            <span className="text-xs">Matches</span>
+          </div>
+          <p className="text-xl font-bold tabular-nums text-green-600 dark:text-green-400">{summary.matchCount}</p>
+          <p className="text-xs text-muted-foreground mt-1">{hitRate.toFixed(1)}% hit rate</p>
+        </CardContent>
+      </Card>
 
-        <Card className="glass-panel">
-          <CardContent className="p-3">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <Trophy className="h-4 w-4" />
-              <span className="text-xs">Strategies</span>
-            </div>
-            <p className="text-xl font-bold tabular-nums">{summary.strategiesEvaluated.length}</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              {topStrategy ? `${topStrategy[0]} (${topStrategy[1]})` : 'No strategy hits'}
-            </p>
-          </CardContent>
-        </Card>
+      <Card className="glass-panel">
+        <CardContent className="p-3">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <Trophy className="h-4 w-4" />
+            <span className="text-xs">Strategies</span>
+          </div>
+          <p className="text-xl font-bold tabular-nums">{summary.strategiesEvaluated.length}</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {topStrategy ? `${topStrategy[0]} (${topStrategy[1]})` : 'No strategy hits'}
+          </p>
+        </CardContent>
+      </Card>
 
-        <Card className="glass-panel">
-          <CardContent className="p-3">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <AlertTriangle className="h-4 w-4" />
-              <span className="text-xs">Missing Metrics</span>
-            </div>
-            <p className="text-xl font-bold tabular-nums">{summary.strategiesWithoutBacktestMetrics.length}</p>
-            <p className="text-xs text-muted-foreground mt-1">{summary.warnings.length} warnings</p>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+      <Card className="glass-panel">
+        <CardContent className="p-3">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <AlertTriangle className="h-4 w-4" />
+            <span className="text-xs">Missing Metrics</span>
+          </div>
+          <p className="text-xl font-bold tabular-nums">{summary.strategiesWithoutBacktestMetrics.length}</p>
+          <p className="text-xs text-muted-foreground mt-1">{summary.warnings.length} warnings</p>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/apps/ts/packages/web/src/components/Settings/SyncStatusCard.tsx
+++ b/apps/ts/packages/web/src/components/Settings/SyncStatusCard.tsx
@@ -74,13 +74,170 @@ function toDisplayMethod(method: SyncFetchDetail['method'] | null | undefined): 
   return null;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sync status UI intentionally composes multiple status/detail sections
+function FetchInfoRow({ endpoint, method }: FetchProgressInfo) {
+  if (!method && !endpoint) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      <span className="text-muted-foreground">Fetch</span>
+      {method && <span className={`rounded px-2 py-0.5 font-medium ${getMethodBadgeClass(method)}`}>{method}</span>}
+      {endpoint && <code className="rounded bg-muted px-1.5 py-0.5 text-[11px]">{endpoint}</code>}
+    </div>
+  );
+}
+
+function LatestFetchDetailCard({ detail }: { detail: SyncFetchDetail | null | undefined }) {
+  if (!detail) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-1 rounded-md border bg-muted/20 p-2 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-muted-foreground">Detail</span>
+        <span className="rounded bg-muted px-1.5 py-0.5 uppercase">{detail.eventType}</span>
+        <span>{new Date(detail.timestamp).toLocaleTimeString()}</span>
+      </div>
+      {(detail.reason || detail.reasonDetail) && (
+        <p className="text-muted-foreground">
+          {detail.reason}
+          {detail.reasonDetail ? ` (${detail.reasonDetail})` : ''}
+        </p>
+      )}
+      {(detail.estimatedRestCalls !== undefined || detail.estimatedBulkCalls !== undefined) && (
+        <p className="text-muted-foreground">
+          REST est: {detail.estimatedRestCalls ?? 'n/a'}, BULK est: {detail.estimatedBulkCalls ?? 'n/a'}
+        </p>
+      )}
+      {detail.fallback && (
+        <p className="text-amber-600">bulk fallback{detail.fallbackReason ? `: ${detail.fallbackReason}` : ''}</p>
+      )}
+    </div>
+  );
+}
+
+function RecentFetchEvents({ items }: { items: SyncFetchDetail[] }) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-1 rounded-md border bg-muted/20 p-2 text-xs">
+      <p className="text-muted-foreground">Recent Fetch Events</p>
+      {items.map((item) => {
+        const displayMethod = toDisplayMethod(item.method) ?? 'REST';
+        return (
+          <div
+            key={`${item.timestamp}-${item.stage}-${item.endpoint}-${item.eventType}`}
+            className="flex flex-wrap items-center gap-2"
+          >
+            <span className="rounded bg-muted px-1 py-0.5 uppercase">{item.eventType}</span>
+            <span className={`rounded px-1 py-0.5 ${getMethodBadgeClass(displayMethod)}`}>{displayMethod}</span>
+            <code className="rounded bg-muted px-1 py-0.5">{item.endpoint}</code>
+            <span className="text-muted-foreground">{item.stage}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ActiveProgressSection({
+  isActive,
+  progress,
+  fetchInfo,
+  latestFetchDetail,
+  recentFetchDetails,
+}: {
+  isActive: boolean;
+  progress: SyncJobResponse['progress'];
+  fetchInfo: FetchProgressInfo;
+  latestFetchDetail: SyncFetchDetail | null | undefined;
+  recentFetchDetails: SyncFetchDetail[];
+}) {
+  if (!isActive || !progress) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground">{progress.stage}</span>
+        <span className="font-medium">{progress.percentage.toFixed(1)}%</span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-secondary">
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all duration-300"
+          style={{ width: `${progress.percentage}%` }}
+        />
+      </div>
+      <FetchInfoRow endpoint={fetchInfo.endpoint} method={fetchInfo.method} />
+      <LatestFetchDetailCard detail={latestFetchDetail} />
+      <RecentFetchEvents items={recentFetchDetails} />
+      <p className="text-xs text-muted-foreground">{progress.message}</p>
+    </div>
+  );
+}
+
+function CompletedResultSection({
+  status,
+  result,
+}: {
+  status: SyncJobResponse['status'];
+  result: SyncJobResponse['result'];
+}) {
+  if (status !== 'completed' || !result) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <span className="text-muted-foreground">API Calls:</span>
+          <span className="ml-2 font-medium">{result.totalApiCalls}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Stocks Updated:</span>
+          <span className="ml-2 font-medium">{result.stocksUpdated}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Dates Processed:</span>
+          <span className="ml-2 font-medium">{result.datesProcessed}</span>
+        </div>
+        {result.failedDates.length > 0 && (
+          <div>
+            <span className="text-muted-foreground">Failed Dates:</span>
+            <span className="ml-2 font-medium text-red-500">{result.failedDates.length}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SyncErrorSection({ status, error }: { status: SyncJobResponse['status']; error: string | null | undefined }) {
+  if (status !== 'failed' || !error) {
+    return null;
+  }
+
+  return <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{error}</div>;
+}
+
+function CancelledSection({ status }: { status: SyncJobResponse['status'] }) {
+  if (status !== 'cancelled') {
+    return null;
+  }
+  return <div className="text-sm text-muted-foreground">Sync was cancelled by user.</div>;
+}
+
 export function SyncStatusCard({ job, fetchDetails, isLoading, onCancel, isCancelling }: SyncStatusCardProps) {
   if (!job) return null;
 
   const isActive = job.status === 'pending' || job.status === 'running';
   const progress = job.progress;
-  const result = job.result;
   const parsedFetchInfo = progress ? parseFetchProgressInfo(progress.message) : { endpoint: null, method: null };
   const latestFetchDetail = fetchDetails?.latest;
   const fetchInfo = {
@@ -108,114 +265,16 @@ export function SyncStatusCard({ job, fetchDetails, isLoading, onCancel, isCance
         <CardDescription>Mode: {job.mode}</CardDescription>
       </CardHeader>
       <CardContent>
-        {/* Progress bar */}
-        {isActive && progress && (
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">{progress.stage}</span>
-              <span className="font-medium">{progress.percentage.toFixed(1)}%</span>
-            </div>
-            <div className="h-2 w-full rounded-full bg-secondary">
-              <div
-                className="h-full rounded-full bg-blue-500 transition-all duration-300"
-                style={{ width: `${progress.percentage}%` }}
-              />
-            </div>
-            {(fetchInfo.method || fetchInfo.endpoint) && (
-              <div className="flex flex-wrap items-center gap-2 text-xs">
-                <span className="text-muted-foreground">Fetch</span>
-                {fetchInfo.method && (
-                  <span className={`rounded px-2 py-0.5 font-medium ${getMethodBadgeClass(fetchInfo.method)}`}>
-                    {fetchInfo.method}
-                  </span>
-                )}
-                {fetchInfo.endpoint && (
-                  <code className="rounded bg-muted px-1.5 py-0.5 text-[11px]">{fetchInfo.endpoint}</code>
-                )}
-              </div>
-            )}
-            {latestFetchDetail && (
-              <div className="space-y-1 rounded-md border bg-muted/20 p-2 text-xs">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-muted-foreground">Detail</span>
-                  <span className="rounded bg-muted px-1.5 py-0.5 uppercase">{latestFetchDetail.eventType}</span>
-                  <span>{new Date(latestFetchDetail.timestamp).toLocaleTimeString()}</span>
-                </div>
-                {(latestFetchDetail.reason || latestFetchDetail.reasonDetail) && (
-                  <p className="text-muted-foreground">
-                    {latestFetchDetail.reason}
-                    {latestFetchDetail.reasonDetail ? ` (${latestFetchDetail.reasonDetail})` : ''}
-                  </p>
-                )}
-                {(latestFetchDetail.estimatedRestCalls !== undefined || latestFetchDetail.estimatedBulkCalls !== undefined) && (
-                  <p className="text-muted-foreground">
-                    REST est: {latestFetchDetail.estimatedRestCalls ?? 'n/a'}, BULK est:{' '}
-                    {latestFetchDetail.estimatedBulkCalls ?? 'n/a'}
-                  </p>
-                )}
-                {latestFetchDetail.fallback && (
-                  <p className="text-amber-600">
-                    bulk fallback{latestFetchDetail.fallbackReason ? `: ${latestFetchDetail.fallbackReason}` : ''}
-                  </p>
-                )}
-              </div>
-            )}
-            {recentFetchDetails.length > 0 && (
-              <div className="space-y-1 rounded-md border bg-muted/20 p-2 text-xs">
-                <p className="text-muted-foreground">Recent Fetch Events</p>
-                {recentFetchDetails.map((item) => {
-                  const displayMethod = toDisplayMethod(item.method) ?? 'REST';
-                  return (
-                    <div
-                      key={`${item.timestamp}-${item.stage}-${item.endpoint}-${item.eventType}`}
-                      className="flex flex-wrap items-center gap-2"
-                    >
-                      <span className="rounded bg-muted px-1 py-0.5 uppercase">{item.eventType}</span>
-                      <span className={`rounded px-1 py-0.5 ${getMethodBadgeClass(displayMethod)}`}>{displayMethod}</span>
-                      <code className="rounded bg-muted px-1 py-0.5">{item.endpoint}</code>
-                      <span className="text-muted-foreground">{item.stage}</span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-            <p className="text-xs text-muted-foreground">{progress.message}</p>
-          </div>
-        )}
-
-        {/* Completed result */}
-        {job.status === 'completed' && result && (
-          <div className="space-y-2 text-sm">
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <span className="text-muted-foreground">API Calls:</span>
-                <span className="ml-2 font-medium">{result.totalApiCalls}</span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Stocks Updated:</span>
-                <span className="ml-2 font-medium">{result.stocksUpdated}</span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Dates Processed:</span>
-                <span className="ml-2 font-medium">{result.datesProcessed}</span>
-              </div>
-              {result.failedDates.length > 0 && (
-                <div>
-                  <span className="text-muted-foreground">Failed Dates:</span>
-                  <span className="ml-2 font-medium text-red-500">{result.failedDates.length}</span>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Failed error */}
-        {job.status === 'failed' && job.error && (
-          <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">{job.error}</div>
-        )}
-
-        {/* Cancelled message */}
-        {job.status === 'cancelled' && <div className="text-sm text-muted-foreground">Sync was cancelled by user.</div>}
+        <ActiveProgressSection
+          isActive={isActive}
+          progress={progress}
+          fetchInfo={fetchInfo}
+          latestFetchDetail={latestFetchDetail}
+          recentFetchDetails={recentFetchDetails}
+        />
+        <CompletedResultSection status={job.status} result={job.result} />
+        <SyncErrorSection status={job.status} error={job.error} />
+        <CancelledSection status={job.status} />
       </CardContent>
     </Card>
   );

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -32,6 +32,13 @@ import type {
 import { formatMarketCap } from '@/utils/formatters';
 import { logger } from '@/utils/logger';
 
+type ChartSettings = ReturnType<typeof useChartStore.getState>['settings'];
+
+interface LazySectionState {
+  sectionRef: (node: HTMLDivElement | null) => void;
+  isVisible: boolean;
+}
+
 // Helper component for margin pressure indicators section
 function MarginPressureIndicatorsSection({
   data,
@@ -132,7 +139,471 @@ function shouldRenderChartPanels(
   return !isLoading && !error && !!selectedSymbol && !!chartData;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Page intentionally coordinates multiple chart panels and state gates.
+function resolveFundamentalPanelVisibility(settings: ChartSettings): Record<FundamentalsPanelId, boolean> {
+  return {
+    fundamentals: settings.showFundamentalsPanel,
+    fundamentalsHistory: settings.showFundamentalsHistoryPanel,
+    marginPressure: settings.showMarginPressurePanel,
+    factorRegression: settings.showFactorRegressionPanel,
+  };
+}
+
+function renderOrderedPanelSection({
+  panelId,
+  selectedSymbol,
+  settings,
+  fundamentalsPanelHeight,
+  tradingValuePeriod,
+  fundamentalsPanelSection,
+  fundamentalsHistorySection,
+  marginSection,
+  factorSection,
+  marginPressureData,
+  marginPressureLoading,
+  marginPressureError,
+}: {
+  panelId: FundamentalsPanelId;
+  selectedSymbol: string | null;
+  settings: ChartSettings;
+  fundamentalsPanelHeight: number;
+  tradingValuePeriod: number;
+  fundamentalsPanelSection: LazySectionState;
+  fundamentalsHistorySection: LazySectionState;
+  marginSection: LazySectionState;
+  factorSection: LazySectionState;
+  marginPressureData: MarginPressureIndicatorsResponse | undefined;
+  marginPressureLoading: boolean;
+  marginPressureError: Error | null;
+}) {
+  switch (panelId) {
+    case 'fundamentals':
+      return (
+        <div
+          key={panelId}
+          ref={fundamentalsPanelSection.sectionRef}
+          data-testid="fundamentals-panel-section"
+          style={{ height: `${fundamentalsPanelHeight}px` }}
+        >
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground">Fundamental Analysis</h3>
+              </div>
+              <div className="h-[calc(100%-4rem)] p-4">
+                <ErrorBoundary>
+                  <FundamentalsPanel
+                    symbol={selectedSymbol}
+                    enabled={fundamentalsPanelSection.isVisible}
+                    tradingValuePeriod={tradingValuePeriod}
+                    metricOrder={settings.fundamentalsMetricOrder}
+                    metricVisibility={settings.fundamentalsMetricVisibility}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    case 'fundamentalsHistory':
+      return (
+        <div key={panelId} ref={fundamentalsHistorySection.sectionRef} className="h-[340px]">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground">FY推移</h3>
+              </div>
+              <div className="h-[calc(100%-4rem)] p-4">
+                <ErrorBoundary>
+                  <FundamentalsHistoryPanel
+                    symbol={selectedSymbol}
+                    enabled={fundamentalsHistorySection.isVisible}
+                    metricOrder={settings.fundamentalsHistoryMetricOrder}
+                    metricVisibility={settings.fundamentalsHistoryMetricVisibility}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    case 'marginPressure':
+      return (
+        <div key={panelId} ref={marginSection.sectionRef} className="h-72">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground">
+                  信用圧力指標
+                  {marginPressureData && (
+                    <span className="text-sm font-normal text-muted-foreground ml-2">
+                      ({marginPressureData.averagePeriod}日平均)
+                    </span>
+                  )}
+                </h3>
+              </div>
+              <div className="h-[calc(100%-4rem)] p-4">
+                <MarginPressureIndicatorsSection
+                  data={marginPressureData}
+                  isLoading={marginPressureLoading}
+                  error={marginPressureError}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    case 'factorRegression':
+      return (
+        <div key={panelId} ref={factorSection.sectionRef} className="h-64">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground">Factor Regression Analysis</h3>
+              </div>
+              <div className="h-[calc(100%-4rem)] p-4">
+                <ErrorBoundary>
+                  <FactorRegressionPanel
+                    symbol={selectedSymbol}
+                    enabled={settings.showFactorRegressionPanel && factorSection.isVisible}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    default:
+      return null;
+  }
+}
+
+function LoadingState({ selectedSymbol }: { selectedSymbol: string | null }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-center space-y-4">
+        <div className="relative">
+          <div className="gradient-primary rounded-full p-4 mx-auto w-fit">
+            <Loader2 className="h-8 w-8 text-white animate-spin" />
+          </div>
+          <div className="absolute inset-0 gradient-primary rounded-full animate-ping opacity-20" />
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-lg font-semibold text-foreground">Loading chart data...</p>
+          <p className="text-sm text-muted-foreground">Fetching latest market data for {selectedSymbol}</p>
+
+          <div className="flex justify-center gap-1 mt-4">
+            <div className="w-2 h-4 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '0ms' }} />
+            <div className="w-2 h-6 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '100ms' }} />
+            <div className="w-2 h-3 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '200ms' }} />
+            <div className="w-2 h-5 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '300ms' }} />
+            <div className="w-2 h-4 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '400ms' }} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ error }: { error: unknown }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-center space-y-6 max-w-md">
+        <div className="relative">
+          <div className="bg-destructive/10 rounded-full p-4 mx-auto w-fit">
+            <AlertCircle className="h-8 w-8 text-destructive" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <h3 className="text-xl font-semibold text-foreground">Unable to load chart data</h3>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : 'An unexpected error occurred while fetching market data'}
+          </p>
+        </div>
+
+        <div className="flex gap-3 justify-center">
+          <Button variant="outline" onClick={() => window.location.reload()} className="glass-panel hover:bg-accent/50">
+            Try Again
+          </Button>
+          <Button variant="default" className="gradient-primary hover:opacity-90">
+            Contact Support
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-center space-y-6 max-w-md">
+        <div className="relative">
+          <div className="gradient-secondary rounded-full p-8 mx-auto w-fit">
+            <TrendingUp className="h-12 w-12 text-primary" />
+          </div>
+          <div className="absolute inset-0 gradient-glass rounded-full" />
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="text-2xl font-bold text-foreground">Start Trading Analysis</h3>
+          <p className="text-muted-foreground">
+            Enter a stock symbol in the search box to view real-time charts and technical analysis
+          </p>
+
+          <div className="pt-4">
+            <p className="text-sm text-muted-foreground mb-3">Popular symbols:</p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              {['7203', '6758', '8306', '9984', '4502'].map((symbol) => (
+                <Button
+                  key={symbol}
+                  variant="outline"
+                  size="sm"
+                  className="glass-panel hover:bg-primary/10 hover:border-primary/50 transition-all duration-200"
+                  onClick={() => {
+                    logger.debug('Symbol selected from popular list', { symbol });
+                  }}
+                >
+                  {symbol}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function openCompanyPage(baseUrl: string, selectedSymbol: string | null, suffix = '') {
+  if (!selectedSymbol) return;
+  window.open(`${baseUrl}${selectedSymbol}${suffix}`, '_blank', 'noopener,noreferrer');
+}
+
+function ChartsPanelsContent({
+  settings,
+  selectedSymbol,
+  stockData,
+  latestMarketCap,
+  chartData,
+  signalMarkers,
+  panelVisibilityById,
+  fundamentalsPanelHeight,
+  tradingValuePeriod,
+  fundamentalsPanelSection,
+  fundamentalsHistorySection,
+  marginSection,
+  factorSection,
+  marginPressureData,
+  marginPressureLoading,
+  marginPressureError,
+}: {
+  settings: ChartSettings;
+  selectedSymbol: string | null;
+  stockData: { companyName?: string | null } | undefined;
+  latestMarketCap: number | null;
+  chartData: ReturnType<typeof useMultiTimeframeChart>['chartData'];
+  signalMarkers: ReturnType<typeof useMultiTimeframeChart>['signalMarkers'];
+  panelVisibilityById: Record<FundamentalsPanelId, boolean>;
+  fundamentalsPanelHeight: number;
+  tradingValuePeriod: number;
+  fundamentalsPanelSection: LazySectionState;
+  fundamentalsHistorySection: LazySectionState;
+  marginSection: LazySectionState;
+  factorSection: LazySectionState;
+  marginPressureData: MarginPressureIndicatorsResponse | undefined;
+  marginPressureLoading: boolean;
+  marginPressureError: Error | null;
+}) {
+  return (
+    <div className="h-full flex flex-col gap-4">
+      <div className="px-6 py-4 gradient-primary rounded-xl">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="gradient-secondary rounded-lg p-2">
+              <TrendingUp className="h-6 w-6 text-white" />
+            </div>
+            <div className="flex flex-col">
+              <h2 className="text-2xl font-bold text-white">
+                {selectedSymbol}
+                {stockData?.companyName && <span className="text-white/90 font-medium ml-2">{stockData.companyName}</span>}
+                {latestMarketCap != null && (
+                  <span className="text-white/80 text-sm font-medium ml-3">時価総額 {formatMarketCap(latestMarketCap)}</span>
+                )}
+                {settings.relativeMode && <span className="text-white/70 font-medium"> / TOPIX</span>}
+              </h2>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => openCompanyPage('https://shikiho.toyokeizai.net/stocks/', selectedSymbol)}
+                className="text-white/80 hover:text-white hover:bg-white/10"
+                title="四季報を開く"
+              >
+                <BookOpen className="h-4 w-4 mr-1" />
+                四季報
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => openCompanyPage('https://www.buffett-code.com/company/', selectedSymbol, '/')}
+                className="text-white/80 hover:text-white hover:bg-white/10"
+                title="Buffett Codeを開く"
+              >
+                <Wallet className="h-4 w-4 mr-1" />
+                B.C.
+              </Button>
+            </div>
+            <TimeframeSelector />
+          </div>
+        </div>
+      </div>
+
+      <div className="h-[512px]">
+        <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+          <div className="absolute inset-0 gradient-glass opacity-50" />
+          <div className="relative z-10 h-full">
+            <div className="p-4 border-b border-border/30">
+              <h3 className="text-lg font-semibold text-foreground capitalize">{settings.displayTimeframe} Chart</h3>
+            </div>
+            <div className="h-[448px]">
+              <ErrorBoundary>
+                <StockChart
+                  data={chartData[settings.displayTimeframe]?.candlestickData || []}
+                  atrSupport={chartData[settings.displayTimeframe]?.indicators.atrSupport as IndicatorValue[] | undefined}
+                  nBarSupport={chartData[settings.displayTimeframe]?.indicators.nBarSupport as IndicatorValue[] | undefined}
+                  bollingerBands={chartData[settings.displayTimeframe]?.bollingerBands as BollingerBandsData[] | undefined}
+                  signalMarkers={signalMarkers?.[settings.displayTimeframe]}
+                />
+              </ErrorBoundary>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {settings.showPPOChart && (
+        <div className="h-96">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground capitalize">{settings.displayTimeframe} PPO</h3>
+              </div>
+              <div className="h-[calc(100%-4rem)]">
+                <ErrorBoundary>
+                  <PPOChart
+                    data={(chartData[settings.displayTimeframe]?.indicators.ppo as PPOIndicatorData[]) || []}
+                    title={`${settings.displayTimeframe.charAt(0).toUpperCase() + settings.displayTimeframe.slice(1)} PPO`}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settings.showRiskAdjustedReturnChart && (
+        <div className="h-[200px]">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground capitalize">
+                  {settings.displayTimeframe} Risk Adjusted Return
+                </h3>
+              </div>
+              <div className="h-[calc(100%-4rem)]">
+                <ErrorBoundary>
+                  <RiskAdjustedReturnChart
+                    data={(chartData[settings.displayTimeframe]?.indicators.riskAdjustedReturn as RiskAdjustedReturnData[]) || []}
+                    lookbackPeriod={settings.riskAdjustedReturn.lookbackPeriod}
+                    ratioType={settings.riskAdjustedReturn.ratioType}
+                    threshold={settings.riskAdjustedReturn.threshold}
+                    condition={settings.riskAdjustedReturn.condition}
+                    title={`${settings.displayTimeframe.charAt(0).toUpperCase() + settings.displayTimeframe.slice(1)} Risk Adjusted Return`}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settings.showVolumeComparison && (
+        <div className="h-[200px]">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground capitalize">{settings.displayTimeframe} Volume Comparison</h3>
+              </div>
+              <div className="h-[calc(100%-4rem)]">
+                <ErrorBoundary>
+                  <VolumeComparisonChart
+                    data={(chartData[settings.displayTimeframe]?.volumeComparison as VolumeComparisonData[]) || []}
+                    shortPeriod={settings.volumeComparison.shortPeriod}
+                    longPeriod={settings.volumeComparison.longPeriod}
+                    lowerMultiplier={settings.volumeComparison.lowerMultiplier}
+                    higherMultiplier={settings.volumeComparison.higherMultiplier}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settings.showTradingValueMA && (
+        <div className="h-[200px]">
+          <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
+            <div className="absolute inset-0 gradient-glass opacity-50" />
+            <div className="relative z-10 h-full">
+              <div className="p-4 border-b border-border/30">
+                <h3 className="text-lg font-semibold text-foreground capitalize">{settings.displayTimeframe} Trading Value MA</h3>
+              </div>
+              <div className="h-[calc(100%-4rem)]">
+                <ErrorBoundary>
+                  <TradingValueMAChart
+                    data={(chartData[settings.displayTimeframe]?.tradingValueMA as TradingValueMAData[]) || []}
+                    period={settings.tradingValueMA.period}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settings.fundamentalsPanelOrder
+        .filter((panelId) => panelVisibilityById[panelId])
+        .map((panelId) =>
+          renderOrderedPanelSection({
+            panelId,
+            selectedSymbol,
+            settings,
+            fundamentalsPanelHeight,
+            tradingValuePeriod,
+            fundamentalsPanelSection,
+            fundamentalsHistorySection,
+            marginSection,
+            factorSection,
+            marginPressureData,
+            marginPressureLoading,
+            marginPressureError,
+          })
+        )}
+    </div>
+  );
+}
+
 export function ChartsPage() {
   const marginSection = useLazySectionVisibility();
   const fundamentalsPanelSection = useLazySectionVisibility();
@@ -166,35 +637,6 @@ export function ChartsPage() {
     hasChartData: !!chartData,
   });
 
-  const renderLoadingState = () => (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center space-y-4">
-        {/* Animated loading spinner */}
-        <div className="relative">
-          <div className="gradient-primary rounded-full p-4 mx-auto w-fit">
-            <Loader2 className="h-8 w-8 text-white animate-spin" />
-          </div>
-          <div className="absolute inset-0 gradient-primary rounded-full animate-ping opacity-20" />
-        </div>
-
-        {/* Loading text with skeleton */}
-        <div className="space-y-2">
-          <p className="text-lg font-semibold text-foreground">Loading chart data...</p>
-          <p className="text-sm text-muted-foreground">Fetching latest market data for {selectedSymbol}</p>
-
-          {/* Skeleton bars */}
-          <div className="flex justify-center gap-1 mt-4">
-            <div className="w-2 h-4 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '0ms' }} />
-            <div className="w-2 h-6 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '100ms' }} />
-            <div className="w-2 h-3 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '200ms' }} />
-            <div className="w-2 h-5 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '300ms' }} />
-            <div className="w-2 h-4 bg-primary/30 rounded-full animate-pulse" style={{ animationDelay: '400ms' }} />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
   const latestMarketCap = useMemo(() => {
     if (!settings.showFundamentalsPanel && !settings.showFundamentalsHistoryPanel) return null;
     const daily = fundamentalsData?.dailyValuation;
@@ -210,191 +652,7 @@ export function ChartsPage() {
     [visibleFundamentalMetricCount]
   );
 
-  const renderErrorState = () => (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center space-y-6 max-w-md">
-        {/* Error icon */}
-        <div className="relative">
-          <div className="bg-destructive/10 rounded-full p-4 mx-auto w-fit">
-            <AlertCircle className="h-8 w-8 text-destructive" />
-          </div>
-        </div>
-
-        {/* Error message */}
-        <div className="space-y-2">
-          <h3 className="text-xl font-semibold text-foreground">Unable to load chart data</h3>
-          <p className="text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : 'An unexpected error occurred while fetching market data'}
-          </p>
-        </div>
-
-        {/* Action buttons */}
-        <div className="flex gap-3 justify-center">
-          <Button variant="outline" onClick={() => window.location.reload()} className="glass-panel hover:bg-accent/50">
-            Try Again
-          </Button>
-          <Button variant="default" className="gradient-primary hover:opacity-90">
-            Contact Support
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderEmptyState = () => (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center space-y-6 max-w-md">
-        {/* Empty state illustration */}
-        <div className="relative">
-          <div className="gradient-secondary rounded-full p-8 mx-auto w-fit">
-            <TrendingUp className="h-12 w-12 text-primary" />
-          </div>
-          <div className="absolute inset-0 gradient-glass rounded-full" />
-        </div>
-
-        {/* Empty state message */}
-        <div className="space-y-3">
-          <h3 className="text-2xl font-bold text-foreground">Start Trading Analysis</h3>
-          <p className="text-muted-foreground">
-            Enter a stock symbol in the search box to view real-time charts and technical analysis
-          </p>
-
-          {/* Popular symbols */}
-          <div className="pt-4">
-            <p className="text-sm text-muted-foreground mb-3">Popular symbols:</p>
-            <div className="flex flex-wrap gap-2 justify-center">
-              {['7203', '6758', '8306', '9984', '4502'].map((symbol) => (
-                <Button
-                  key={symbol}
-                  variant="outline"
-                  size="sm"
-                  className="glass-panel hover:bg-primary/10 hover:border-primary/50 transition-all duration-200"
-                  onClick={() => {
-                    logger.debug('Symbol selected from popular list', { symbol });
-                    // TODO: Connect to chart store
-                  }}
-                >
-                  {symbol}
-                </Button>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
-  const panelVisibilityById: Record<FundamentalsPanelId, boolean> = {
-    fundamentals: settings.showFundamentalsPanel,
-    fundamentalsHistory: settings.showFundamentalsHistoryPanel,
-    marginPressure: settings.showMarginPressurePanel,
-    factorRegression: settings.showFactorRegressionPanel,
-  };
-
-  const renderOrderedPanelSection = (panelId: FundamentalsPanelId) => {
-    switch (panelId) {
-      case 'fundamentals':
-        return (
-          <div
-            key={panelId}
-            ref={fundamentalsPanelSection.sectionRef}
-            data-testid="fundamentals-panel-section"
-            style={{ height: `${fundamentalsPanelHeight}px` }}
-          >
-            <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-              <div className="absolute inset-0 gradient-glass opacity-50" />
-              <div className="relative z-10 h-full">
-                <div className="p-4 border-b border-border/30">
-                  <h3 className="text-lg font-semibold text-foreground">Fundamental Analysis</h3>
-                </div>
-                <div className="h-[calc(100%-4rem)] p-4">
-                  <ErrorBoundary>
-                    <FundamentalsPanel
-                      symbol={selectedSymbol}
-                      enabled={fundamentalsPanelSection.isVisible}
-                      tradingValuePeriod={tradingValuePeriod}
-                      metricOrder={settings.fundamentalsMetricOrder}
-                      metricVisibility={settings.fundamentalsMetricVisibility}
-                    />
-                  </ErrorBoundary>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      case 'fundamentalsHistory':
-        return (
-          <div key={panelId} ref={fundamentalsHistorySection.sectionRef} className="h-[340px]">
-            <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-              <div className="absolute inset-0 gradient-glass opacity-50" />
-              <div className="relative z-10 h-full">
-                <div className="p-4 border-b border-border/30">
-                  <h3 className="text-lg font-semibold text-foreground">FY推移</h3>
-                </div>
-                <div className="h-[calc(100%-4rem)] p-4">
-                  <ErrorBoundary>
-                    <FundamentalsHistoryPanel
-                      symbol={selectedSymbol}
-                      enabled={fundamentalsHistorySection.isVisible}
-                      metricOrder={settings.fundamentalsHistoryMetricOrder}
-                      metricVisibility={settings.fundamentalsHistoryMetricVisibility}
-                    />
-                  </ErrorBoundary>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      case 'marginPressure':
-        return (
-          <div key={panelId} ref={marginSection.sectionRef} className="h-72">
-            <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-              <div className="absolute inset-0 gradient-glass opacity-50" />
-              <div className="relative z-10 h-full">
-                <div className="p-4 border-b border-border/30">
-                  <h3 className="text-lg font-semibold text-foreground">
-                    信用圧力指標
-                    {marginPressureData && (
-                      <span className="text-sm font-normal text-muted-foreground ml-2">
-                        ({marginPressureData.averagePeriod}日平均)
-                      </span>
-                    )}
-                  </h3>
-                </div>
-                <div className="h-[calc(100%-4rem)] p-4">
-                  <MarginPressureIndicatorsSection
-                    data={marginPressureData}
-                    isLoading={marginPressureLoading}
-                    error={marginPressureError}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      case 'factorRegression':
-        return (
-          <div key={panelId} ref={factorSection.sectionRef} className="h-64">
-            <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-              <div className="absolute inset-0 gradient-glass opacity-50" />
-              <div className="relative z-10 h-full">
-                <div className="p-4 border-b border-border/30">
-                  <h3 className="text-lg font-semibold text-foreground">Factor Regression Analysis</h3>
-                </div>
-                <div className="h-[calc(100%-4rem)] p-4">
-                  <ErrorBoundary>
-                    <FactorRegressionPanel
-                      symbol={selectedSymbol}
-                      enabled={settings.showFactorRegressionPanel && factorSection.isVisible}
-                    />
-                  </ErrorBoundary>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-    }
-  };
+  const panelVisibilityById = resolveFundamentalPanelVisibility(settings);
 
   return (
     <div className="flex">
@@ -407,218 +665,28 @@ export function ChartsPage() {
 
       {/* Main Chart Area */}
       <div className="flex-1 p-6">
-        {error && renderErrorState()}
-        {isLoading && renderLoadingState()}
-        {showEmptyState && renderEmptyState()}
-
+        {error && <ErrorState error={error} />}
+        {isLoading && <LoadingState selectedSymbol={selectedSymbol} />}
+        {showEmptyState && <EmptyState />}
         {showChartPanels && (
-          <div className="h-full flex flex-col gap-4">
-            {/* 共通タイトルヘッダー */}
-            <div className="px-6 py-4 gradient-primary rounded-xl">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="gradient-secondary rounded-lg p-2">
-                    <TrendingUp className="h-6 w-6 text-white" />
-                  </div>
-                  <div className="flex flex-col">
-                    <h2 className="text-2xl font-bold text-white">
-                      {selectedSymbol}
-                      {stockData?.companyName && (
-                        <span className="text-white/90 font-medium ml-2">{stockData.companyName}</span>
-                      )}
-                      {latestMarketCap != null && (
-                        <span className="text-white/80 text-sm font-medium ml-3">
-                          時価総額 {formatMarketCap(latestMarketCap)}
-                        </span>
-                      )}
-                      {settings.relativeMode && <span className="text-white/70 font-medium"> / TOPIX</span>}
-                    </h2>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  {/* 外部リンクボタン */}
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        window.open(
-                          `https://shikiho.toyokeizai.net/stocks/${selectedSymbol}`,
-                          '_blank',
-                          'noopener,noreferrer'
-                        );
-                      }}
-                      className="text-white/80 hover:text-white hover:bg-white/10"
-                      title="四季報を開く"
-                    >
-                      <BookOpen className="h-4 w-4 mr-1" />
-                      四季報
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        window.open(
-                          `https://www.buffett-code.com/company/${selectedSymbol}/`,
-                          '_blank',
-                          'noopener,noreferrer'
-                        );
-                      }}
-                      className="text-white/80 hover:text-white hover:bg-white/10"
-                      title="Buffett Codeを開く"
-                    >
-                      <Wallet className="h-4 w-4 mr-1" />
-                      B.C.
-                    </Button>
-                  </div>
-                  <TimeframeSelector />
-                </div>
-              </div>
-            </div>
-
-            {/* Main OHLC Chart - Single timeframe based on selection */}
-            <div className="h-[512px]">
-              <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-                <div className="absolute inset-0 gradient-glass opacity-50" />
-                <div className="relative z-10 h-full">
-                  <div className="p-4 border-b border-border/30">
-                    <h3 className="text-lg font-semibold text-foreground capitalize">
-                      {settings.displayTimeframe} Chart
-                    </h3>
-                  </div>
-                  <div className="h-[448px]">
-                    <ErrorBoundary>
-                      <StockChart
-                        data={chartData[settings.displayTimeframe]?.candlestickData || []}
-                        atrSupport={
-                          chartData[settings.displayTimeframe]?.indicators.atrSupport as IndicatorValue[] | undefined
-                        }
-                        nBarSupport={
-                          chartData[settings.displayTimeframe]?.indicators.nBarSupport as IndicatorValue[] | undefined
-                        }
-                        bollingerBands={
-                          chartData[settings.displayTimeframe]?.bollingerBands as BollingerBandsData[] | undefined
-                        }
-                        signalMarkers={signalMarkers?.[settings.displayTimeframe]}
-                      />
-                    </ErrorBoundary>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* PPO Chart - Single timeframe based on selection (conditionally displayed) */}
-            {settings.showPPOChart && (
-              <div className="h-96">
-                <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-                  <div className="absolute inset-0 gradient-glass opacity-50" />
-                  <div className="relative z-10 h-full">
-                    <div className="p-4 border-b border-border/30">
-                      <h3 className="text-lg font-semibold text-foreground capitalize">
-                        {settings.displayTimeframe} PPO
-                      </h3>
-                    </div>
-                    <div className="h-[calc(100%-4rem)]">
-                      <ErrorBoundary>
-                        <PPOChart
-                          data={(chartData[settings.displayTimeframe]?.indicators.ppo as PPOIndicatorData[]) || []}
-                          title={`${settings.displayTimeframe.charAt(0).toUpperCase() + settings.displayTimeframe.slice(1)} PPO`}
-                        />
-                      </ErrorBoundary>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Risk Adjusted Return Chart (conditionally displayed) */}
-            {settings.showRiskAdjustedReturnChart && (
-              <div className="h-[200px]">
-                <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-                  <div className="absolute inset-0 gradient-glass opacity-50" />
-                  <div className="relative z-10 h-full">
-                    <div className="p-4 border-b border-border/30">
-                      <h3 className="text-lg font-semibold text-foreground capitalize">
-                        {settings.displayTimeframe} Risk Adjusted Return
-                      </h3>
-                    </div>
-                    <div className="h-[calc(100%-4rem)]">
-                      <ErrorBoundary>
-                        <RiskAdjustedReturnChart
-                          data={
-                            (chartData[settings.displayTimeframe]?.indicators
-                              .riskAdjustedReturn as RiskAdjustedReturnData[]) || []
-                          }
-                          lookbackPeriod={settings.riskAdjustedReturn.lookbackPeriod}
-                          ratioType={settings.riskAdjustedReturn.ratioType}
-                          threshold={settings.riskAdjustedReturn.threshold}
-                          condition={settings.riskAdjustedReturn.condition}
-                          title={`${settings.displayTimeframe.charAt(0).toUpperCase() + settings.displayTimeframe.slice(1)} Risk Adjusted Return`}
-                        />
-                      </ErrorBoundary>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Volume Comparison Chart (conditionally displayed) */}
-            {settings.showVolumeComparison && (
-              <div className="h-[200px]">
-                <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-                  <div className="absolute inset-0 gradient-glass opacity-50" />
-                  <div className="relative z-10 h-full">
-                    <div className="p-4 border-b border-border/30">
-                      <h3 className="text-lg font-semibold text-foreground capitalize">
-                        {settings.displayTimeframe} Volume Comparison
-                      </h3>
-                    </div>
-                    <div className="h-[calc(100%-4rem)]">
-                      <ErrorBoundary>
-                        <VolumeComparisonChart
-                          data={
-                            (chartData[settings.displayTimeframe]?.volumeComparison as VolumeComparisonData[]) || []
-                          }
-                          shortPeriod={settings.volumeComparison.shortPeriod}
-                          longPeriod={settings.volumeComparison.longPeriod}
-                          lowerMultiplier={settings.volumeComparison.lowerMultiplier}
-                          higherMultiplier={settings.volumeComparison.higherMultiplier}
-                        />
-                      </ErrorBoundary>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Trading Value MA Chart (conditionally displayed) */}
-            {settings.showTradingValueMA && (
-              <div className="h-[200px]">
-                <div className={cn('h-full rounded-xl glass-panel', 'relative overflow-hidden')}>
-                  <div className="absolute inset-0 gradient-glass opacity-50" />
-                  <div className="relative z-10 h-full">
-                    <div className="p-4 border-b border-border/30">
-                      <h3 className="text-lg font-semibold text-foreground capitalize">
-                        {settings.displayTimeframe} Trading Value MA
-                      </h3>
-                    </div>
-                    <div className="h-[calc(100%-4rem)]">
-                      <ErrorBoundary>
-                        <TradingValueMAChart
-                          data={(chartData[settings.displayTimeframe]?.tradingValueMA as TradingValueMAData[]) || []}
-                          period={settings.tradingValueMA.period}
-                        />
-                      </ErrorBoundary>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {settings.fundamentalsPanelOrder
-              .filter((panelId) => panelVisibilityById[panelId])
-              .map((panelId) => renderOrderedPanelSection(panelId))}
-          </div>
+          <ChartsPanelsContent
+            settings={settings}
+            selectedSymbol={selectedSymbol}
+            stockData={stockData}
+            latestMarketCap={latestMarketCap}
+            chartData={chartData}
+            signalMarkers={signalMarkers}
+            panelVisibilityById={panelVisibilityById}
+            fundamentalsPanelHeight={fundamentalsPanelHeight}
+            tradingValuePeriod={tradingValuePeriod}
+            fundamentalsPanelSection={fundamentalsPanelSection}
+            fundamentalsHistorySection={fundamentalsHistorySection}
+            marginSection={marginSection}
+            factorSection={factorSection}
+            marginPressureData={marginPressureData}
+            marginPressureLoading={marginPressureLoading}
+            marginPressureError={marginPressureError}
+          />
         )}
       </div>
     </div>

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -244,7 +244,6 @@ function RefreshResultTable({ result }: { result: MarketRefreshResponse }) {
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: settings page coordinates sync and refresh sections
 export function SettingsPage() {
   const [syncMode, setSyncMode] = useState<SyncMode>('auto');
   const [enforceBulkForStockData, setEnforceBulkForStockData] = useState(false);
@@ -300,7 +299,7 @@ export function SettingsPage() {
     }
     void refetchDbStats();
     void refetchDbValidation();
-  }, [isRunning, jobStatus?.progress?.stage, jobStatus?.progress?.current, refetchDbStats, refetchDbValidation]);
+  }, [isRunning, refetchDbStats, refetchDbValidation]);
 
   const handleStartSync = () => {
     const request: StartSyncRequest = { mode: syncMode, enforceBulkForStockData };


### PR DESCRIPTION
## Summary
- remove remaining biome-ignore suppressions from web/ui and utils test code
- split large UI components into smaller helpers/sections to reduce cognitive complexity
- fix remaining Biome warnings (useless fragment and exhaustive dependency warnings)
- add StrategyEditor test coverage for YAML parse/serialize edge cases

## Validation
- bun run quality:lint
- bun run --filter @trading25/web typecheck
- bun run --filter @trading25/web test
- bun run --filter @trading25/web test:coverage
- bun run --filter @trading25/utils test