### PR TITLE
feat(bt): align evolve with optuna guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ uv run pyright src/              # 型チェック
 - Lab `evolve/optimize` の API/Web は `target_scope`（`entry_filter_only` / `exit_trigger_only` / `both`）を受け付ける（`entry_filter_only` は互換フラグとして維持）
 - Lab `evolve/optimize` の frontend `allowed categories` は `all` / `fundamental only` を提供
 - Lab frontend は `Run` / `History` タブを持ち、`/api/lab/jobs` で実行履歴を一覧し、選択したジョブの進捗・結果を再表示できる
+- Lab `evolve` は依存パラメータ制約付き mutation（`long>short` / `slow>fast` / `max>min`）を適用し、baseline（ベース戦略）より悪化した候補は guardrail で棄却して base 採用へフォールバックする
+- Lab `evolve` は世代間で OHLCV/benchmark prefetch を再利用し、forecast revision が必要になった場合のみ再prefetch する
 - Lab `optimize`（Optuna）は開始時に OHLCV/benchmark を1回プリフェッチして trial 間で再利用し、`pruning=true` 時は第1段階バックテストの暫定スコアで早期枝刈りを行う
 - Lab `optimize`（Optuna）は依存パラメータ制約付きサンプリング（`long>short` / `slow>fast` / `max>min`）を適用し、`n_trials>=40` では `stage1(広域)+stage2(局所)` の2段階探索を行う
 - Lab `optimize` は `GET /api/lab/optimize/recommendation` を提供し、戦略の探索次元数から `minimum/recommended/high_quality` trial 推奨値を返す。web の Optimize form は `target_scope` / `allowed_categories` 選択に追従して推奨値を再取得し、最低推奨未満を警告表示する

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ uv run bt lab optimize experimental/base_strategy_01 --trials 50 --structure-mod
   - `entry_filter_only` は後方互換フラグとして維持（`target_scope=entry_filter_only` と同義）
   - `allowed_categories` は `all` または `fundamental` 運用を推奨
 - `/api/lab/optimize` は依存パラメータ制約（`long>short` / `slow>fast` / `max>min`）付きで探索し、`trials>=40` では `stage1(広域)+stage2(局所)` の2段階探索を行う
+- `/api/lab/evolve` も依存パラメータ制約（`long>short` / `slow>fast` / `max>min`）を適用し、baseline（ベース戦略）より悪化した候補は guardrail で棄却して base 採用へフォールバックする
+- `evolve` は世代間で OHLCV/benchmark の prefetch を再利用し、forecast revision が必要になった場合のみ再prefetch する
 - `/api/lab/optimize/recommendation` で探索次元数に応じた `minimum/recommended/high_quality` trial 推奨値を取得可能
 - `evolve` / `optimize` は `--structure-mode` で探索方式を切り替え可能
   - `params_only`: 既存シグナルのパラメータのみ探索

--- a/apps/bt/src/domains/lab_agent/evaluator/batch_executor.py
+++ b/apps/bt/src/domains/lab_agent/evaluator/batch_executor.py
@@ -78,7 +78,7 @@ def _is_forecast_signal_enabled(side_params: dict[str, Any]) -> bool:
     return False
 
 
-def _should_include_forecast_revision(
+def should_include_forecast_revision(
     candidates: list[StrategyCandidate] | None,
 ) -> bool:
     if not candidates:
@@ -90,9 +90,14 @@ def _should_include_forecast_revision(
     )
 
 
+# Backward-compatible alias.
+_should_include_forecast_revision = should_include_forecast_revision
+
+
 def prepare_batch_data(
     shared_config_dict: dict[str, Any],
     candidates: list[StrategyCandidate] | None = None,
+    force_include_forecast_revision: bool = False,
 ) -> BatchPreparedData:
     """
     バッチ評価用データを事前取得
@@ -107,7 +112,9 @@ def prepare_batch_data(
     Returns:
         BatchPreparedData: 事前取得データ（銘柄リスト、OHLCVデータ、ベンチマークデータ）
     """
-    include_forecast_revision = _should_include_forecast_revision(candidates)
+    include_forecast_revision = force_include_forecast_revision or should_include_forecast_revision(
+        candidates
+    )
     stock_codes = fetch_stock_codes(shared_config_dict)
     ohlcv_data = fetch_ohlcv_data(
         shared_config_dict,
@@ -120,6 +127,7 @@ def prepare_batch_data(
         stock_codes=stock_codes,
         ohlcv_data=ohlcv_data,
         benchmark_data=benchmark_data,
+        include_forecast_revision=include_forecast_revision,
     )
 
 

--- a/apps/bt/src/domains/lab_agent/evaluator/data_preparation.py
+++ b/apps/bt/src/domains/lab_agent/evaluator/data_preparation.py
@@ -27,6 +27,7 @@ class BatchPreparedData:
     stock_codes: list[str] | None
     ohlcv_data: dict[str, dict[str, Any]] | None
     benchmark_data: dict[str, Any] | None
+    include_forecast_revision: bool = False
 
 
 def convert_dataframes_to_dict(

--- a/apps/bt/src/domains/lab_agent/evaluator/evaluator.py
+++ b/apps/bt/src/domains/lab_agent/evaluator/evaluator.py
@@ -17,9 +17,10 @@ from .batch_executor import (
     execute_batch_evaluation,
     get_max_workers,
     prepare_batch_data,
+    should_include_forecast_revision,
 )
 from .candidate_processor import evaluate_single_candidate
-from .data_preparation import load_default_shared_config
+from .data_preparation import BatchPreparedData, load_default_shared_config
 from .score_normalizer import normalize_scores
 
 
@@ -58,17 +59,31 @@ class StrategyEvaluator:
         self.n_jobs = n_jobs
         self.timeout_seconds = timeout_seconds
 
-    def evaluate_single(self, candidate: StrategyCandidate) -> EvaluationResult:
+    def evaluate_single(
+        self,
+        candidate: StrategyCandidate,
+        prepared_data: BatchPreparedData | None = None,
+    ) -> EvaluationResult:
         """
         単一候補を評価
 
         Args:
             candidate: 戦略候補
+            prepared_data: 事前取得データ（省略時は都度ロード）
 
         Returns:
             評価結果
         """
         with data_access_mode_context("direct"):
+            if prepared_data is not None:
+                return evaluate_single_candidate(
+                    candidate,
+                    self.shared_config_dict,
+                    self.scoring_weights,
+                    prepared_data.stock_codes,
+                    prepared_data.ohlcv_data,
+                    prepared_data.benchmark_data,
+                )
             return evaluate_single_candidate(
                 candidate, self.shared_config_dict, self.scoring_weights
             )
@@ -78,6 +93,7 @@ class StrategyEvaluator:
         candidates: list[StrategyCandidate],
         top_k: int | None = None,
         enable_cache: bool = True,
+        prepared_data: BatchPreparedData | None = None,
     ) -> list[EvaluationResult]:
         """
         複数候補をバッチ評価
@@ -105,7 +121,11 @@ class StrategyEvaluator:
                 logger.debug("DataCache enabled for batch evaluation")
 
             try:
-                results = self._evaluate_batch_internal(candidates, top_k)
+                results = self._evaluate_batch_internal(
+                    candidates,
+                    top_k,
+                    prepared_data=prepared_data,
+                )
             finally:
                 # キャッシュ無効化・クリア
                 if enable_cache:
@@ -116,18 +136,39 @@ class StrategyEvaluator:
 
             return results
 
+    def prepare_batch_data(
+        self,
+        candidates: list[StrategyCandidate] | None = None,
+        *,
+        force_include_forecast_revision: bool = False,
+    ) -> BatchPreparedData:
+        """共有設定に基づいてバッチ評価用データを事前取得する。"""
+        return prepare_batch_data(
+            self.shared_config_dict,
+            candidates,
+            force_include_forecast_revision=force_include_forecast_revision,
+        )
+
+    def requires_forecast_revision(
+        self,
+        candidates: list[StrategyCandidate] | None,
+    ) -> bool:
+        """候補群が forecast revision データを必要とするか判定する。"""
+        return should_include_forecast_revision(candidates)
+
     def _evaluate_batch_internal(
         self,
         candidates: list[StrategyCandidate],
         top_k: int | None = None,
+        prepared_data: BatchPreparedData | None = None,
     ) -> list[EvaluationResult]:
         """バッチ評価の内部実装"""
         max_workers = get_max_workers(self.n_jobs)
-        prepared_data = prepare_batch_data(self.shared_config_dict, candidates)
+        effective_prepared_data = prepared_data or self.prepare_batch_data(candidates)
         results = execute_batch_evaluation(
             candidates,
             max_workers,
-            prepared_data,
+            effective_prepared_data,
             self.shared_config_dict,
             self.scoring_weights,
             self.timeout_seconds,

--- a/apps/bt/src/domains/lab_agent/optuna_optimizer.py
+++ b/apps/bt/src/domains/lab_agent/optuna_optimizer.py
@@ -42,6 +42,7 @@ from src.domains.strategy.runtime.loader import ConfigLoader
 from src.domains.optimization.scoring import calculate_weighted_score_from_metrics
 
 from .models import LabTargetScope, OptunaConfig, SignalCategory, StrategyCandidate
+from .param_constraints import apply_param_dependency_constraints
 from .signal_filters import is_signal_allowed
 from .signal_augmentation import apply_random_add_structure
 from .signal_search_space import CATEGORICAL_PARAMS, PARAM_RANGES, ParamType
@@ -1026,36 +1027,13 @@ class OptunaOptimizer:
         sibling_params: dict[str, Any],
     ) -> tuple[float, float]:
         """相互依存パラメータの制約を sampling range に反映する。"""
-        lower_bound = min_val
-        upper_bound = max_val
-
-        if key == "long_period" and "short_period" in sibling_params:
-            lower_bound = max(lower_bound, float(sibling_params["short_period"]) + 1.0)
-        elif key == "short_period" and "long_period" in sibling_params:
-            upper_bound = min(upper_bound, float(sibling_params["long_period"]) - 1.0)
-        elif key == "slow_period" and "fast_period" in sibling_params:
-            lower_bound = max(lower_bound, float(sibling_params["fast_period"]) + 1.0)
-        elif key == "fast_period" and "slow_period" in sibling_params:
-            upper_bound = min(upper_bound, float(sibling_params["slow_period"]) - 1.0)
-        elif key == "max_threshold" and "min_threshold" in sibling_params:
-            lower_bound = max(lower_bound, float(sibling_params["min_threshold"]) + 1e-6)
-        elif key == "min_threshold" and "max_threshold" in sibling_params:
-            upper_bound = min(upper_bound, float(sibling_params["max_threshold"]) - 1e-6)
-        elif key == "max_beta" and "min_beta" in sibling_params:
-            lower_bound = max(lower_bound, float(sibling_params["min_beta"]) + 1e-6)
-        elif key == "min_beta" and "max_beta" in sibling_params:
-            upper_bound = min(upper_bound, float(sibling_params["max_beta"]) - 1e-6)
-
-        if param_type == "int":
-            lower_bound = float(int(np.ceil(lower_bound)))
-            upper_bound = float(int(np.floor(upper_bound)))
-            if lower_bound > upper_bound:
-                lower_bound = upper_bound
-            return lower_bound, upper_bound
-
-        if lower_bound >= upper_bound:
-            upper_bound = float(np.nextafter(lower_bound, float("inf")))
-        return lower_bound, upper_bound
+        return apply_param_dependency_constraints(
+            key=key,
+            min_val=min_val,
+            max_val=max_val,
+            param_type=param_type,
+            sibling_params=sibling_params,
+        )
 
     def _is_signal_optimization_allowed(self, signal_name: str, usage_type: str) -> bool:
         """制約に基づいて最適化対象に含めるか判定する。"""

--- a/apps/bt/src/domains/lab_agent/param_constraints.py
+++ b/apps/bt/src/domains/lab_agent/param_constraints.py
@@ -1,0 +1,51 @@
+"""Shared parameter dependency constraints for Lab optimize/evolve."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .signal_search_space import ParamType
+
+
+def apply_param_dependency_constraints(
+    *,
+    key: str,
+    min_val: float,
+    max_val: float,
+    param_type: ParamType,
+    sibling_params: dict[str, Any],
+) -> tuple[float, float]:
+    """Apply sibling-parameter ordering constraints to a numeric range."""
+    lower_bound = min_val
+    upper_bound = max_val
+
+    if key == "long_period" and "short_period" in sibling_params:
+        lower_bound = max(lower_bound, float(sibling_params["short_period"]) + 1.0)
+    elif key == "short_period" and "long_period" in sibling_params:
+        upper_bound = min(upper_bound, float(sibling_params["long_period"]) - 1.0)
+    elif key == "slow_period" and "fast_period" in sibling_params:
+        lower_bound = max(lower_bound, float(sibling_params["fast_period"]) + 1.0)
+    elif key == "fast_period" and "slow_period" in sibling_params:
+        upper_bound = min(upper_bound, float(sibling_params["slow_period"]) - 1.0)
+    elif key == "max_threshold" and "min_threshold" in sibling_params:
+        lower_bound = max(lower_bound, float(sibling_params["min_threshold"]) + 1e-6)
+    elif key == "min_threshold" and "max_threshold" in sibling_params:
+        upper_bound = min(upper_bound, float(sibling_params["max_threshold"]) - 1e-6)
+    elif key == "max_beta" and "min_beta" in sibling_params:
+        lower_bound = max(lower_bound, float(sibling_params["min_beta"]) + 1e-6)
+    elif key == "min_beta" and "max_beta" in sibling_params:
+        upper_bound = min(upper_bound, float(sibling_params["max_beta"]) - 1e-6)
+
+    if param_type == "int":
+        lower_bound = float(int(np.ceil(lower_bound)))
+        upper_bound = float(int(np.floor(upper_bound)))
+        if lower_bound > upper_bound:
+            lower_bound = upper_bound
+        return lower_bound, upper_bound
+
+    if lower_bound >= upper_bound:
+        upper_bound = float(np.nextafter(lower_bound, float("inf")))
+
+    return lower_bound, upper_bound

--- a/apps/bt/src/domains/lab_agent/parameter_evolver.py
+++ b/apps/bt/src/domains/lab_agent/parameter_evolver.py
@@ -5,14 +5,18 @@
 """
 
 import copy
+import math
 import random
 from typing import Any
 
 from loguru import logger
 
+from src.domains.optimization.scoring import calculate_weighted_score_from_metrics
 from src.domains.strategy.runtime.loader import ConfigLoader
 
+from .evaluator.data_preparation import BatchPreparedData
 from .models import EvolutionConfig, EvaluationResult, SignalCategory, StrategyCandidate
+from .param_constraints import apply_param_dependency_constraints
 from .signal_filters import is_signal_allowed
 from .signal_augmentation import apply_random_add_structure
 from .signal_search_space import CATEGORICAL_PARAMS, PARAM_RANGES, ParamType
@@ -28,6 +32,7 @@ class ParameterEvolver:
 
     # Backward-compatible alias (used by older internal callers).
     PARAM_RANGES = PARAM_RANGES
+    MIN_ACCEPTABLE_RETURN_RATIO = 0.95
 
     def __init__(
         self,
@@ -45,7 +50,6 @@ class ParameterEvolver:
         """
         self.config = config or EvolutionConfig()
         self.shared_config_dict = shared_config_dict
-        self.scoring_weights = scoring_weights
         self.allowed_category_set: set[SignalCategory] = set(self.config.allowed_categories)
 
         # 乱数シード設定
@@ -58,11 +62,14 @@ class ParameterEvolver:
             n_jobs=self.config.n_jobs,
             timeout_seconds=self.config.timeout_seconds,
         )
+        self.scoring_weights = self.evaluator.scoring_weights
 
         # 進化履歴
         self.history: list[dict[str, Any]] = []
         self._base_entry_signals: set[str] = set()
         self._base_exit_signals: set[str] = set()
+        self._baseline_score: float | None = None
+        self._baseline_total_return: float | None = None
 
     def evolve(
         self,
@@ -95,6 +102,8 @@ class ParameterEvolver:
 
         # 初期集団生成
         population = self._initialize_population(base_candidate)
+        prepared_data = self.evaluator.prepare_batch_data(population)
+        self._evaluate_baseline_candidate(base_candidate, prepared_data)
 
         # 最良個体追跡
         best_result: EvaluationResult | None = None
@@ -103,8 +112,17 @@ class ParameterEvolver:
         for generation in range(self.config.generations):
             logger.info(f"Generation {generation + 1}/{self.config.generations}")
 
+            if self._needs_prefetch_upgrade(population, prepared_data):
+                logger.info(
+                    "Evolution prefetch upgraded to include forecast revision data"
+                )
+                prepared_data = self.evaluator.prepare_batch_data(population)
+
             # 評価
-            results = self.evaluator.evaluate_batch(population)
+            results = self.evaluator.evaluate_batch(
+                population,
+                prepared_data=prepared_data,
+            )
             all_results.extend(results)
 
             # 成功した結果のみ抽出
@@ -143,12 +161,14 @@ class ParameterEvolver:
         if best_result is None:
             raise RuntimeError("Evolution failed: no successful evaluations")
 
+        best_candidate = self._resolve_best_candidate(best_result, base_candidate)
+
         logger.info(
             f"Evolution complete: best_score={best_result.score:.4f}, "
             f"sharpe={best_result.sharpe_ratio:.4f}"
         )
 
-        return best_result.candidate, all_results
+        return best_candidate, all_results
 
     def _is_usage_targeted(self, usage_type: str) -> bool:
         """target_scope に基づき対象サイドか判定する。"""
@@ -171,6 +191,108 @@ class ParameterEvolver:
             else 0
         )
         return add_entry, add_exit
+
+    def _needs_prefetch_upgrade(
+        self,
+        population: list[StrategyCandidate],
+        prepared_data: BatchPreparedData,
+    ) -> bool:
+        """未取得だった forecast revision データが必要になった時のみ再prefetchする。"""
+        if prepared_data.include_forecast_revision:
+            return False
+        return self.evaluator.requires_forecast_revision(population)
+
+    @staticmethod
+    def _safe_metric(value: Any) -> float:
+        try:
+            scalar = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        return scalar if math.isfinite(scalar) else 0.0
+
+    def _calculate_weighted_score(
+        self,
+        sharpe: float,
+        calmar: float,
+        total_return: float,
+    ) -> float:
+        return calculate_weighted_score_from_metrics(
+            {
+                "sharpe_ratio": sharpe,
+                "calmar_ratio": calmar,
+                "total_return": total_return,
+            },
+            self.scoring_weights,
+        )
+
+    def _weighted_score_from_result(self, result: EvaluationResult) -> float:
+        """評価結果を guardrail 比較用の重み付きスコアへ変換する。"""
+        return self._calculate_weighted_score(
+            self._safe_metric(result.sharpe_ratio),
+            self._safe_metric(result.calmar_ratio),
+            self._safe_metric(result.total_return),
+        )
+
+    def _evaluate_baseline_candidate(
+        self,
+        base_candidate: StrategyCandidate,
+        prepared_data: BatchPreparedData,
+    ) -> None:
+        """ベース戦略の基準値を計算して非退行ガードに使う。"""
+        self._baseline_score = None
+        self._baseline_total_return = None
+
+        baseline_result = self.evaluator.evaluate_single(
+            base_candidate,
+            prepared_data=prepared_data,
+        )
+        if not baseline_result.success:
+            logger.warning(
+                "Failed to evaluate baseline strategy for evolve guardrail: "
+                f"strategy={base_candidate.strategy_id}, "
+                f"error={baseline_result.error_message}"
+            )
+            return
+
+        total_return = self._safe_metric(baseline_result.total_return)
+        self._baseline_total_return = total_return
+        self._baseline_score = self._weighted_score_from_result(baseline_result)
+
+        logger.info(
+            "Evolution baseline evaluated: "
+            f"score={self._baseline_score:.4f}, total_return={total_return:.4f}"
+        )
+
+    def _resolve_best_candidate(
+        self,
+        best_result: EvaluationResult,
+        base_candidate: StrategyCandidate,
+    ) -> StrategyCandidate:
+        """非退行ガードを適用し、最終的な採用候補を返す。"""
+        best_score = self._weighted_score_from_result(best_result)
+        if self._baseline_score is not None and best_score < self._baseline_score:
+            logger.warning(
+                "Evolution best score is below baseline; falling back to base strategy "
+                f"(best={best_score:.4f}, baseline={self._baseline_score:.4f})"
+            )
+            return base_candidate
+
+        best_return = self._safe_metric(best_result.total_return)
+        if (
+            self._baseline_total_return is not None
+            and self._baseline_total_return > 0.0
+            and best_return
+            < self._baseline_total_return * self.MIN_ACCEPTABLE_RETURN_RATIO
+        ):
+            logger.warning(
+                "Evolution best return is below acceptable baseline ratio; "
+                "falling back to base strategy "
+                f"(best={best_return:.4f}, baseline={self._baseline_total_return:.4f}, "
+                f"ratio={self.MIN_ACCEPTABLE_RETURN_RATIO:.2f})"
+            )
+            return base_candidate
+
+        return best_result.candidate
 
     def _load_base_strategy(
         self, base_strategy: str | StrategyCandidate
@@ -505,11 +627,20 @@ class ParameterEvolver:
                 continue
 
             min_val, max_val, param_type = ranges[param_name]
+            min_val, max_val = apply_param_dependency_constraints(
+                key=key,
+                min_val=min_val,
+                max_val=max_val,
+                param_type=param_type,
+                sibling_params=params,
+            )
             if param_type == "int":
                 # ガウシアン摂動（整数）
-                delta = int((max_val - min_val) * 0.2 * random.gauss(0, 1))
+                min_int = int(min_val)
+                max_int = int(max_val)
+                delta = int((max_int - min_int) * 0.2 * random.gauss(0, 1))
                 new_value = int(value) + delta
-                params[key] = max(int(min_val), min(int(max_val), new_value))
+                params[key] = max(min_int, min(max_int, new_value))
             else:
                 # ガウシアン摂動（浮動小数点）
                 delta = (max_val - min_val) * 0.2 * random.gauss(0, 1)

--- a/apps/bt/tests/unit/agent/evaluator/test_evaluator.py
+++ b/apps/bt/tests/unit/agent/evaluator/test_evaluator.py
@@ -1,8 +1,10 @@
 """agent/evaluator/evaluator.py のテスト"""
 
 from contextlib import contextmanager
+from typing import Any
 
 from src.domains.lab_agent.evaluator import evaluator as evaluator_module
+from src.domains.lab_agent.evaluator.data_preparation import BatchPreparedData
 from src.domains.lab_agent.evaluator.evaluator import StrategyEvaluator
 from src.domains.lab_agent.models import EvaluationResult, StrategyCandidate
 
@@ -55,7 +57,7 @@ def test_evaluate_batch_forces_direct_mode(monkeypatch) -> None:
     monkeypatch.setattr(
         StrategyEvaluator,
         "_evaluate_batch_internal",
-        lambda self, candidates, top_k=None: [],
+        lambda self, candidates, top_k=None, prepared_data=None: [],
     )
 
     evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
@@ -108,7 +110,7 @@ def test_evaluate_batch_enables_and_disables_cache(monkeypatch) -> None:
     monkeypatch.setattr(
         StrategyEvaluator,
         "_evaluate_batch_internal",
-        lambda self, candidates, top_k=None: [],
+        lambda self, candidates, top_k=None, prepared_data=None: [],
     )
 
     evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]})
@@ -121,11 +123,16 @@ def test_evaluate_batch_enables_and_disables_cache(monkeypatch) -> None:
 def test_evaluate_batch_internal_uses_prepare_and_execute(monkeypatch) -> None:
     prepared = object()
     expected = [EvaluationResult(candidate=_candidate(), score=0.5)]
-    observed: dict[str, object] = {}
+    observed: dict[str, Any] = {}
 
-    def _fake_prepare_batch_data(shared_config_dict, candidates):
+    def _fake_prepare_batch_data(
+        shared_config_dict,
+        candidates,
+        force_include_forecast_revision=False,
+    ):
         observed["shared_config_dict"] = shared_config_dict
         observed["candidates"] = candidates
+        observed["force_include_forecast_revision"] = force_include_forecast_revision
         return prepared
 
     def _fake_execute_batch_evaluation(
@@ -170,6 +177,43 @@ def test_evaluate_batch_internal_uses_prepare_and_execute(monkeypatch) -> None:
     assert result == expected
     assert observed["shared_config_dict"]["stock_codes"] == ["7203"]
     assert observed["candidates"] == input_candidates
+    assert observed["force_include_forecast_revision"] is False
+
+
+def test_evaluate_batch_internal_uses_provided_prepared_data(monkeypatch) -> None:
+    expected = [EvaluationResult(candidate=_candidate(), score=0.5)]
+    provided = BatchPreparedData(
+        stock_codes=["7203"],
+        ohlcv_data={},
+        benchmark_data={},
+    )
+
+    monkeypatch.setattr(evaluator_module, "get_max_workers", lambda n_jobs: 2)
+    monkeypatch.setattr(
+        StrategyEvaluator,
+        "prepare_batch_data",
+        lambda self, candidates: (_ for _ in ()).throw(
+            AssertionError("prepare_batch_data should not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        evaluator_module,
+        "execute_batch_evaluation",
+        lambda *args, **kwargs: expected,
+    )
+    monkeypatch.setattr(
+        StrategyEvaluator,
+        "_finalize_batch_results",
+        lambda self, results, top_k: results,
+    )
+
+    evaluator = StrategyEvaluator(shared_config_dict={"stock_codes": ["7203"]}, n_jobs=2)
+    result = evaluator._evaluate_batch_internal(
+        [_candidate()],
+        top_k=1,
+        prepared_data=provided,
+    )
+    assert result == expected
 
 
 def test_finalize_batch_results_sorts_and_applies_topk(monkeypatch) -> None:

--- a/apps/bt/tests/unit/agent/test_batch_executor.py
+++ b/apps/bt/tests/unit/agent/test_batch_executor.py
@@ -166,6 +166,25 @@ class TestPrepareBatchData:
 
         assert mock_ohlcv.call_args.kwargs["include_forecast_revision"] is True
 
+    def test_force_include_forecast_revision(self):
+        with (
+            patch("src.domains.lab_agent.evaluator.batch_executor.fetch_stock_codes") as mock_codes,
+            patch("src.domains.lab_agent.evaluator.batch_executor.fetch_ohlcv_data") as mock_ohlcv,
+            patch("src.domains.lab_agent.evaluator.batch_executor.fetch_benchmark_data") as mock_bench,
+        ):
+            mock_codes.return_value = ["1234"]
+            mock_ohlcv.return_value = {"1234": {"data": "test"}}
+            mock_bench.return_value = {"index": [], "columns": [], "data": []}
+
+            result = prepare_batch_data(
+                {"dataset": "test"},
+                [],
+                force_include_forecast_revision=True,
+            )
+
+        assert result.include_forecast_revision is True
+        assert mock_ohlcv.call_args.kwargs["include_forecast_revision"] is True
+
 
 class TestForecastRevisionHelpers:
     def test_is_forecast_signal_enabled_handles_invalid_and_disabled_payloads(self):

--- a/apps/bt/tests/unit/agent/test_param_constraints.py
+++ b/apps/bt/tests/unit/agent/test_param_constraints.py
@@ -1,0 +1,119 @@
+"""param_constraints.py のテスト"""
+
+import math
+
+from src.domains.lab_agent.param_constraints import apply_param_dependency_constraints
+
+
+def test_long_period_depends_on_short_period() -> None:
+    lower, upper = apply_param_dependency_constraints(
+        key="long_period",
+        min_val=50.0,
+        max_val=300.0,
+        param_type="int",
+        sibling_params={"short_period": 120},
+    )
+    assert lower == 121.0
+    assert upper == 300.0
+
+
+def test_short_period_depends_on_long_period() -> None:
+    lower, upper = apply_param_dependency_constraints(
+        key="short_period",
+        min_val=10.0,
+        max_val=100.0,
+        param_type="int",
+        sibling_params={"long_period": 40},
+    )
+    assert lower == 10.0
+    assert upper == 39.0
+
+
+def test_slow_fast_constraints() -> None:
+    slow_lower, slow_upper = apply_param_dependency_constraints(
+        key="slow_period",
+        min_val=10.0,
+        max_val=100.0,
+        param_type="int",
+        sibling_params={"fast_period": 25},
+    )
+    fast_lower, fast_upper = apply_param_dependency_constraints(
+        key="fast_period",
+        min_val=5.0,
+        max_val=80.0,
+        param_type="int",
+        sibling_params={"slow_period": 20},
+    )
+
+    assert slow_lower == 26.0
+    assert slow_upper == 100.0
+    assert fast_lower == 5.0
+    assert fast_upper == 19.0
+
+
+def test_threshold_constraints() -> None:
+    max_lower, max_upper = apply_param_dependency_constraints(
+        key="max_threshold",
+        min_val=0.1,
+        max_val=2.0,
+        param_type="float",
+        sibling_params={"min_threshold": 0.8},
+    )
+    min_lower, min_upper = apply_param_dependency_constraints(
+        key="min_threshold",
+        min_val=0.1,
+        max_val=2.0,
+        param_type="float",
+        sibling_params={"max_threshold": 1.2},
+    )
+
+    assert max_lower > 0.8
+    assert max_upper == 2.0
+    assert min_lower == 0.1
+    assert min_upper < 1.2
+
+
+def test_beta_constraints() -> None:
+    max_lower, max_upper = apply_param_dependency_constraints(
+        key="max_beta",
+        min_val=0.1,
+        max_val=3.0,
+        param_type="float",
+        sibling_params={"min_beta": 1.1},
+    )
+    min_lower, min_upper = apply_param_dependency_constraints(
+        key="min_beta",
+        min_val=0.1,
+        max_val=3.0,
+        param_type="float",
+        sibling_params={"max_beta": 1.4},
+    )
+
+    assert max_lower > 1.1
+    assert max_upper == 3.0
+    assert min_lower == 0.1
+    assert min_upper < 1.4
+
+
+def test_int_range_collapses_when_constraints_invert_bounds() -> None:
+    lower, upper = apply_param_dependency_constraints(
+        key="short_period",
+        min_val=10.0,
+        max_val=100.0,
+        param_type="int",
+        sibling_params={"long_period": 10},
+    )
+    assert lower == upper
+
+
+def test_float_range_uses_nextafter_when_constraints_invert_bounds() -> None:
+    lower, upper = apply_param_dependency_constraints(
+        key="min_threshold",
+        min_val=0.1,
+        max_val=2.0,
+        param_type="float",
+        sibling_params={"max_threshold": 0.1},
+    )
+
+    assert lower < upper
+    assert math.isclose(lower, 0.1)

--- a/apps/bt/tests/unit/agent/test_parameter_evolver.py
+++ b/apps/bt/tests/unit/agent/test_parameter_evolver.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 
+from src.domains.lab_agent.evaluator.data_preparation import BatchPreparedData
 from src.domains.lab_agent.models import (
     EvaluationResult,
     EvolutionConfig,
@@ -28,13 +29,19 @@ def _make_candidate(sid="test", entry_params=None, exit_params=None):
     )
 
 
-def _make_result(candidate, score=0.5):
+def _make_result(
+    candidate,
+    score=0.5,
+    sharpe_ratio=1.0,
+    calmar_ratio=0.5,
+    total_return=0.1,
+):
     return EvaluationResult(
         candidate=candidate,
         score=score,
-        sharpe_ratio=1.0,
-        calmar_ratio=0.5,
-        total_return=0.1,
+        sharpe_ratio=sharpe_ratio,
+        calmar_ratio=calmar_ratio,
+        total_return=total_return,
         max_drawdown=-0.1,
         win_rate=0.5,
         trade_count=100,
@@ -232,6 +239,20 @@ class TestMutateSignalParams:
             assert 10 <= result["short_period"] <= 100
             assert 50 <= result["long_period"] <= 300
 
+    def test_enforces_dependent_period_constraints(self):
+        evolver = _make_evolver()
+        params = {"enabled": True, "short_period": 99, "long_period": 100}
+        with (
+            patch("src.domains.lab_agent.parameter_evolver.random.random", return_value=0.0),
+            patch("src.domains.lab_agent.parameter_evolver.random.gauss", return_value=10.0),
+        ):
+            result = evolver._mutate_signal_params(
+                "volume",
+                params,
+                mutation_strength=1.0,
+            )
+        assert result["long_period"] > result["short_period"]
+
 
 class TestCrossover:
     def test_crossover_returns_candidate(self):
@@ -395,6 +416,17 @@ class TestEvolveFlow:
             patch.object(evolver, "_initialize_population", return_value=population_g1),
             patch.object(
                 evolver.evaluator,
+                "prepare_batch_data",
+                return_value=BatchPreparedData(
+                    stock_codes=["7203"],
+                    ohlcv_data={},
+                    benchmark_data={},
+                ),
+            ),
+            patch.object(evolver.evaluator, "evaluate_single", return_value=_make_result(base, score=0.9)),
+            patch.object(evolver.evaluator, "requires_forecast_revision", return_value=False),
+            patch.object(
+                evolver.evaluator,
                 "evaluate_batch",
                 side_effect=[results_g1, results_g2],
             ),
@@ -426,6 +458,17 @@ class TestEvolveFlow:
             patch.object(evolver, "_initialize_population", return_value=population_g1),
             patch.object(
                 evolver.evaluator,
+                "prepare_batch_data",
+                return_value=BatchPreparedData(
+                    stock_codes=["7203"],
+                    ohlcv_data={},
+                    benchmark_data={},
+                ),
+            ),
+            patch.object(evolver.evaluator, "evaluate_single", return_value=_make_result(base, score=0.9)),
+            patch.object(evolver.evaluator, "requires_forecast_revision", return_value=False),
+            patch.object(
+                evolver.evaluator,
                 "evaluate_batch",
                 side_effect=[results_g1, results_g2],
             ),
@@ -447,9 +490,190 @@ class TestEvolveFlow:
             patch.object(evolver, "_initialize_population", return_value=[base]),
             patch.object(
                 evolver.evaluator,
+                "prepare_batch_data",
+                return_value=BatchPreparedData(
+                    stock_codes=["7203"],
+                    ohlcv_data={},
+                    benchmark_data={},
+                ),
+            ),
+            patch.object(evolver.evaluator, "evaluate_single", return_value=_make_result(base, score=0.9)),
+            patch.object(evolver.evaluator, "requires_forecast_revision", return_value=False),
+            patch.object(
+                evolver.evaluator,
                 "evaluate_batch",
                 side_effect=[[failed], [failed]],
             ),
         ):
             with pytest.raises(RuntimeError, match="no successful evaluations"):
                 evolver.evolve("demo_strategy")
+
+    def test_evolve_reuses_prefetched_data_between_generations(self):
+        evolver = _make_evolver(pop_size=10, generations=2)
+        base = _make_candidate("base")
+        population_g1 = [_make_candidate("g1_a"), _make_candidate("g1_b")]
+        population_g2 = [_make_candidate("g2_a"), _make_candidate("g2_b")]
+        results_g1 = [_make_result(population_g1[0], score=0.6), _make_result(population_g1[1], score=0.5)]
+        results_g2 = [_make_result(population_g2[0], score=0.7), _make_result(population_g2[1], score=0.4)]
+        prepared = BatchPreparedData(
+            stock_codes=["7203"],
+            ohlcv_data={},
+            benchmark_data={},
+            include_forecast_revision=False,
+        )
+
+        with (
+            patch.object(evolver, "_load_base_strategy", return_value=base),
+            patch.object(evolver, "_initialize_population", return_value=population_g1),
+            patch.object(evolver.evaluator, "prepare_batch_data", return_value=prepared) as mock_prepare,
+            patch.object(evolver.evaluator, "evaluate_single", return_value=_make_result(base, score=0.9)),
+            patch.object(evolver.evaluator, "requires_forecast_revision", return_value=False),
+            patch.object(
+                evolver.evaluator,
+                "evaluate_batch",
+                side_effect=[results_g1, results_g2],
+            ) as mock_eval_batch,
+            patch.object(evolver, "_evolve_population", return_value=population_g2),
+        ):
+            evolver.evolve("demo_strategy")
+
+        assert mock_prepare.call_count == 1
+        for call in mock_eval_batch.call_args_list:
+            assert call.kwargs["prepared_data"] is prepared
+
+    def test_evolve_refreshes_prefetch_when_forecast_revision_becomes_required(self):
+        evolver = _make_evolver(pop_size=10, generations=2)
+        base = _make_candidate("base")
+        population_g1 = [_make_candidate("g1_a"), _make_candidate("g1_b")]
+        population_g2 = [_make_candidate("g2_a"), _make_candidate("g2_b")]
+        results_g1 = [_make_result(population_g1[0], score=0.6), _make_result(population_g1[1], score=0.5)]
+        results_g2 = [_make_result(population_g2[0], score=0.7), _make_result(population_g2[1], score=0.4)]
+        prepared_v1 = BatchPreparedData(
+            stock_codes=["7203"],
+            ohlcv_data={},
+            benchmark_data={},
+            include_forecast_revision=False,
+        )
+        prepared_v2 = BatchPreparedData(
+            stock_codes=["7203"],
+            ohlcv_data={},
+            benchmark_data={},
+            include_forecast_revision=True,
+        )
+
+        with (
+            patch.object(evolver, "_load_base_strategy", return_value=base),
+            patch.object(evolver, "_initialize_population", return_value=population_g1),
+            patch.object(
+                evolver.evaluator,
+                "prepare_batch_data",
+                side_effect=[prepared_v1, prepared_v2],
+            ) as mock_prepare,
+            patch.object(evolver.evaluator, "evaluate_single", return_value=_make_result(base, score=0.9)),
+            patch.object(
+                evolver.evaluator,
+                "requires_forecast_revision",
+                side_effect=[False, True],
+            ),
+            patch.object(
+                evolver.evaluator,
+                "evaluate_batch",
+                side_effect=[results_g1, results_g2],
+            ) as mock_eval_batch,
+            patch.object(evolver, "_evolve_population", return_value=population_g2),
+        ):
+            evolver.evolve("demo_strategy")
+
+        assert mock_prepare.call_count == 2
+        assert mock_eval_batch.call_args_list[0].kwargs["prepared_data"] is prepared_v1
+        assert mock_eval_batch.call_args_list[1].kwargs["prepared_data"] is prepared_v2
+
+    def test_evolve_falls_back_to_base_when_best_score_is_worse_than_baseline(self):
+        evolver = _make_evolver(pop_size=10, generations=1)
+        base = _make_candidate("base")
+        population = [_make_candidate("g1_a"), _make_candidate("g1_b")]
+        worse_best = _make_result(
+            population[0],
+            score=0.9,
+            sharpe_ratio=0.1,
+            calmar_ratio=0.1,
+            total_return=0.05,
+        )
+        other = _make_result(
+            population[1],
+            score=0.2,
+            sharpe_ratio=0.0,
+            calmar_ratio=0.0,
+            total_return=0.01,
+        )
+        baseline = _make_result(
+            base,
+            score=1.0,
+            sharpe_ratio=1.5,
+            calmar_ratio=1.2,
+            total_return=0.2,
+        )
+        prepared = BatchPreparedData(
+            stock_codes=["7203"],
+            ohlcv_data={},
+            benchmark_data={},
+        )
+
+        with (
+            patch.object(evolver, "_load_base_strategy", return_value=base),
+            patch.object(evolver, "_initialize_population", return_value=population),
+            patch.object(evolver.evaluator, "prepare_batch_data", return_value=prepared),
+            patch.object(evolver.evaluator, "evaluate_single", return_value=baseline),
+            patch.object(evolver.evaluator, "requires_forecast_revision", return_value=False),
+            patch.object(evolver.evaluator, "evaluate_batch", return_value=[worse_best, other]),
+        ):
+            best_candidate, _ = evolver.evolve("demo_strategy")
+
+        assert best_candidate.strategy_id == "base"
+
+    def test_evolve_falls_back_to_base_when_best_return_is_too_low(self):
+        evolver = _make_evolver(pop_size=10, generations=1)
+        base = _make_candidate("base")
+        population = [_make_candidate("g1_a"), _make_candidate("g1_b")]
+        score_better_but_return_worse = _make_result(
+            population[0],
+            score=0.9,
+            sharpe_ratio=2.0,
+            calmar_ratio=2.0,
+            total_return=0.10,
+        )
+        other = _make_result(
+            population[1],
+            score=0.2,
+            sharpe_ratio=0.5,
+            calmar_ratio=0.4,
+            total_return=0.08,
+        )
+        baseline = _make_result(
+            base,
+            score=1.0,
+            sharpe_ratio=1.0,
+            calmar_ratio=0.8,
+            total_return=0.2,
+        )
+        prepared = BatchPreparedData(
+            stock_codes=["7203"],
+            ohlcv_data={},
+            benchmark_data={},
+        )
+
+        with (
+            patch.object(evolver, "_load_base_strategy", return_value=base),
+            patch.object(evolver, "_initialize_population", return_value=population),
+            patch.object(evolver.evaluator, "prepare_batch_data", return_value=prepared),
+            patch.object(evolver.evaluator, "evaluate_single", return_value=baseline),
+            patch.object(evolver.evaluator, "requires_forecast_revision", return_value=False),
+            patch.object(
+                evolver.evaluator,
+                "evaluate_batch",
+                return_value=[score_better_but_return_worse, other],
+            ),
+        ):
+            best_candidate, _ = evolver.evolve("demo_strategy")
+
+        assert best_candidate.strategy_id == "base"


### PR DESCRIPTION
## Summary
- share parameter dependency constraints between optuna and evolve via a new param_constraints module
- add baseline guardrails to ParameterEvolver so regressions fall back to the base strategy
- reuse prefetched OHLCV/benchmark data across evolve generations and refresh only when forecast revision becomes necessary
- update README/AGENTS lab notes for evolve parity with optimize

## Testing
- uv run --project /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt pytest /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt/tests/unit/agent/evaluator/test_evaluator.py /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt/tests/unit/agent/evaluator/test_data_preparation.py /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt/tests/unit/agent/test_batch_executor.py /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt/tests/unit/agent/test_optuna_optimizer.py /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt/tests/unit/agent/test_parameter_evolver.py /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt/tests/unit/agent/test_param_constraints.py
- coverage run --branch + coverage report (target modules all >= 80% line/branch)
- uv run --project /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt ruff check <changed files>
- uv run --project /Users/shinjiroaso/.codex/worktrees/2ad4/trading25/apps/bt pyright <changed files>