### PR TITLE
fix(bt): resolve CI blockers in typing cleanup

### DIFF
--- a/apps/bt/src/domains/analytics/signal_screening.py
+++ b/apps/bt/src/domains/analytics/signal_screening.py
@@ -10,6 +10,8 @@
 - 並列処理: ThreadPoolExecutorで銘柄レベル並列化
 """
 
+from __future__ import annotations
+
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 from typing import Any, cast

--- a/apps/bt/src/domains/lab_agent/optuna_optimizer.py
+++ b/apps/bt/src/domains/lab_agent/optuna_optimizer.py
@@ -21,24 +21,6 @@ if TYPE_CHECKING:
     from optuna.pruners import BasePruner
     from optuna.samplers import BaseSampler
 
-# Runtime fallback placeholders (when optuna is not installed).
-TPESampler: Any | None = None
-RandomSampler: Any | None = None
-CmaEsSampler: Any | None = None
-NopPruner: Any | None = None
-MedianPruner: Any | None = None
-
-# ランタイムではtry-exceptでインポート
-try:
-    import optuna as optuna_runtime
-    from optuna.pruners import MedianPruner, NopPruner
-    from optuna.samplers import CmaEsSampler, RandomSampler, TPESampler
-
-    OPTUNA_AVAILABLE = True
-except ImportError:
-    OPTUNA_AVAILABLE = False
-    optuna_runtime: Any | None = None
-
 from src.infrastructure.data_access.mode import data_access_mode_context
 from src.infrastructure.data_access.loaders.data_preparation import prepare_multi_data
 from src.infrastructure.data_access.loaders.index_loaders import load_topix_data
@@ -52,6 +34,22 @@ from .models import LabTargetScope, OptunaConfig, SignalCategory, StrategyCandid
 from .signal_filters import is_signal_allowed
 from .signal_augmentation import apply_random_add_structure
 from .signal_search_space import CATEGORICAL_PARAMS, PARAM_RANGES, ParamType
+
+# ランタイムではtry-exceptでインポート
+try:
+    import optuna as optuna_runtime
+    from optuna.pruners import MedianPruner, NopPruner
+    from optuna.samplers import CmaEsSampler, RandomSampler, TPESampler
+
+    OPTUNA_AVAILABLE = True
+except ImportError:
+    OPTUNA_AVAILABLE = False
+    optuna_runtime: Any | None = None
+    TPESampler: Any | None = None
+    RandomSampler: Any | None = None
+    CmaEsSampler: Any | None = None
+    NopPruner: Any | None = None
+    MedianPruner: Any | None = None
 
 
 class OptunaOptimizer:

--- a/apps/bt/src/infrastructure/db/market/time_series_store.py
+++ b/apps/bt/src/infrastructure/db/market/time_series_store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-import importlib
 from pathlib import Path
 from threading import RLock
 from typing import Any, Protocol, cast
@@ -115,7 +114,7 @@ class DuckDbParquetTimeSeriesStore:
         self._parquet_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            duckdb = importlib.import_module("duckdb")
+            duckdb = __import__("duckdb")
         except ModuleNotFoundError as exc:
             raise RuntimeError(
                 "DuckDB backend requested but `duckdb` package is not installed. "


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to `signal_screening.py` to avoid runtime evaluation of `pd.Series[Any]`/`pd.Index[Any]`
- reorder imports in `optuna_optimizer.py` to satisfy Ruff E402
- keep optuna runtime fallback variables defined in ImportError path

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/domains/lab_agent/optuna_optimizer.py apps/bt/src/domains/analytics/signal_screening.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/data/test_market_analysis.py apps/bt/tests/unit/agent/test_optuna_optimizer.py`

## Context
This PR fixes the blockers found while reviewing #194 so required checks can pass.
