### PR TITLE
fix(ts-web): show DuckDB snapshot warning details

### DIFF
--- a/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.test.tsx
@@ -106,6 +106,12 @@ beforeEach(() => {
       status: 'warning',
       stockData: { missingDatesCount: 12 },
       failedDatesCount: 3,
+      stocksNeedingRefreshCount: 100,
+      integrityIssuesCount: 0,
+      recommendations: [
+        'Run stock refresh for 100 stocks with adjustment events',
+        'Backfill fundamentals for 7 Prime stocks',
+      ],
     },
     isLoading: false,
     error: null,
@@ -299,6 +305,76 @@ describe('SettingsPage', () => {
     expect(screen.getAllByText('2026-02-27').length).toBeGreaterThan(0);
     expect(screen.getByText('Missing Stock Dates:')).toBeInTheDocument();
     expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('Stocks Needing Refresh:')).toBeInTheDocument();
+    expect(screen.getByText('Warning Details')).toBeInTheDocument();
+    expect(screen.getByText('Run stock refresh for 100 stocks with adjustment events')).toBeInTheDocument();
+    expect(screen.getByText('Backfill fundamentals for 7 Prime stocks')).toBeInTheDocument();
+  });
+
+  it('shows validation notes when status is healthy and recommendations exist', () => {
+    mockUseDbValidation.mockReturnValue({
+      data: {
+        status: 'healthy',
+        stockData: { missingDatesCount: 0 },
+        failedDatesCount: 0,
+        stocksNeedingRefreshCount: 0,
+        integrityIssuesCount: 0,
+        recommendations: ['Margin signal readiness depends on margin data source and is excluded from this check'],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText('Validation Notes')).toBeInTheDocument();
+    expect(
+      screen.getByText('Margin signal readiness depends on margin data source and is excluded from this check')
+    ).toBeInTheDocument();
+  });
+
+  it('shows error details when validation status is error', () => {
+    mockUseDbValidation.mockReturnValue({
+      data: {
+        status: 'error',
+        stockData: { missingDatesCount: 0 },
+        failedDatesCount: 0,
+        stocksNeedingRefreshCount: 0,
+        integrityIssuesCount: 1,
+        recommendations: ['Run initial sync to populate the database'],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText('Error Details')).toBeInTheDocument();
+    expect(screen.getByText('Run initial sync to populate the database')).toBeInTheDocument();
+  });
+
+  it('hides validation detail panel when no recommendations are returned', () => {
+    mockUseDbValidation.mockReturnValue({
+      data: {
+        status: 'warning',
+        stockData: { missingDatesCount: 1 },
+        failedDatesCount: 0,
+        stocksNeedingRefreshCount: 0,
+        integrityIssuesCount: 0,
+        recommendations: [],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<SettingsPage />);
+
+    expect(screen.queryByText('Warning Details')).not.toBeInTheDocument();
+    expect(screen.queryByText('Validation Notes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error Details')).not.toBeInTheDocument();
   });
 
   it('validates stock refresh input before submit', async () => {

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -101,6 +101,11 @@ interface SnapshotStatusProps {
   dbValidation: MarketValidationResponse | undefined;
 }
 
+interface SnapshotItem {
+  label: string;
+  value: string | number;
+}
+
 function getValidationDetailsTitle(status: MarketValidationResponse['status']): string {
   switch (status) {
     case 'warning':
@@ -117,6 +122,60 @@ function getValidationDetailsClassName(status: MarketValidationResponse['status'
     return 'rounded-md border border-border bg-muted/30 p-3';
   }
   return 'rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3';
+}
+
+function buildSnapshotItems(
+  dbStats: MarketStatsResponse,
+  dbValidation: MarketValidationResponse
+): SnapshotItem[] {
+  return [
+    { label: 'Validation Status', value: dbValidation.status.toUpperCase() },
+    { label: 'Time-Series Source', value: dbStats.timeSeriesSource },
+    { label: 'Initialized', value: dbStats.initialized ? 'Yes' : 'No' },
+    { label: 'Last Sync', value: formatTimestamp(dbStats.lastSync) },
+    { label: 'Stock Data Latest', value: dbStats.stockData.dateRange?.max ?? 'n/a' },
+    { label: 'TOPIX Latest', value: dbStats.topix.dateRange?.max ?? 'n/a' },
+    { label: 'Indices Latest', value: dbStats.indices.dateRange?.max ?? 'n/a' },
+    { label: 'Missing Stock Dates', value: dbValidation.stockData.missingDatesCount },
+    { label: 'Failed Sync Dates', value: dbValidation.failedDatesCount },
+    { label: 'Stocks Needing Refresh', value: dbValidation.stocksNeedingRefreshCount ?? 0 },
+    { label: 'Readiness Issues', value: dbValidation.integrityIssuesCount ?? 0 },
+  ];
+}
+
+function SnapshotDetails({
+  dbStats,
+  dbValidation,
+}: {
+  dbStats: MarketStatsResponse;
+  dbValidation: MarketValidationResponse;
+}) {
+  const recommendations = dbValidation.recommendations ?? [];
+  const snapshotItems = buildSnapshotItems(dbStats, dbValidation);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {snapshotItems.map((item) => (
+          <div key={item.label}>
+            <span className="text-muted-foreground">{item.label}:</span>
+            <span className="ml-2 font-medium">{item.value}</span>
+          </div>
+        ))}
+      </div>
+
+      {recommendations.length > 0 ? (
+        <div className={getValidationDetailsClassName(dbValidation.status)}>
+          <p className="font-medium">{getValidationDetailsTitle(dbValidation.status)}</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+            {recommendations.map((recommendation) => (
+              <li key={recommendation}>{recommendation}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function SnapshotStatus({
@@ -136,57 +195,17 @@ function SnapshotStatus({
     );
   }
 
-  const recommendations = dbValidation?.recommendations ?? [];
-  const stocksNeedingRefreshCount = dbValidation?.stocksNeedingRefreshCount ?? 0;
-  const integrityIssuesCount = dbValidation?.integrityIssuesCount ?? 0;
-  const snapshotItems =
-    dbStats && dbValidation
-      ? [
-          { label: 'Validation Status', value: dbValidation.status.toUpperCase() },
-          { label: 'Time-Series Source', value: dbStats.timeSeriesSource },
-          { label: 'Initialized', value: dbStats.initialized ? 'Yes' : 'No' },
-          { label: 'Last Sync', value: formatTimestamp(dbStats.lastSync) },
-          { label: 'Stock Data Latest', value: dbStats.stockData.dateRange?.max ?? 'n/a' },
-          { label: 'TOPIX Latest', value: dbStats.topix.dateRange?.max ?? 'n/a' },
-          { label: 'Indices Latest', value: dbStats.indices.dateRange?.max ?? 'n/a' },
-          { label: 'Missing Stock Dates', value: dbValidation.stockData.missingDatesCount },
-          { label: 'Failed Sync Dates', value: dbValidation.failedDatesCount },
-          { label: 'Stocks Needing Refresh', value: stocksNeedingRefreshCount },
-          { label: 'Readiness Issues', value: integrityIssuesCount },
-        ]
-      : [];
+  const errorMessage = statsError?.message ?? validationError?.message ?? null;
 
   return (
     <>
-      {(statsError || validationError) && (
+      {errorMessage ? (
         <div className="rounded-md bg-red-500/10 p-3 text-sm text-red-500">
-          {(statsError || validationError)?.message ?? 'Failed to load market DB status'}
+          {errorMessage ?? 'Failed to load market DB status'}
         </div>
-      )}
+      ) : null}
 
-      {dbStats && dbValidation && (
-        <div className="space-y-3">
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {snapshotItems.map((item) => (
-              <div key={item.label}>
-                <span className="text-muted-foreground">{item.label}:</span>
-                <span className="ml-2 font-medium">{item.value}</span>
-              </div>
-            ))}
-          </div>
-
-          {recommendations.length > 0 && (
-            <div className={getValidationDetailsClassName(dbValidation.status)}>
-              <p className="font-medium">{getValidationDetailsTitle(dbValidation.status)}</p>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
-                {recommendations.map((recommendation) => (
-                  <li key={recommendation}>{recommendation}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-      )}
+      {dbStats && dbValidation ? <SnapshotDetails dbStats={dbStats} dbValidation={dbValidation} /> : null}
     </>
   );
 }

--- a/apps/ts/packages/web/src/pages/SettingsPage.tsx
+++ b/apps/ts/packages/web/src/pages/SettingsPage.tsx
@@ -101,6 +101,24 @@ interface SnapshotStatusProps {
   dbValidation: MarketValidationResponse | undefined;
 }
 
+function getValidationDetailsTitle(status: MarketValidationResponse['status']): string {
+  switch (status) {
+    case 'warning':
+      return 'Warning Details';
+    case 'error':
+      return 'Error Details';
+    default:
+      return 'Validation Notes';
+  }
+}
+
+function getValidationDetailsClassName(status: MarketValidationResponse['status']): string {
+  if (status === 'healthy') {
+    return 'rounded-md border border-border bg-muted/30 p-3';
+  }
+  return 'rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3';
+}
+
 function SnapshotStatus({
   isStatsLoading,
   isValidationLoading,
@@ -118,6 +136,26 @@ function SnapshotStatus({
     );
   }
 
+  const recommendations = dbValidation?.recommendations ?? [];
+  const stocksNeedingRefreshCount = dbValidation?.stocksNeedingRefreshCount ?? 0;
+  const integrityIssuesCount = dbValidation?.integrityIssuesCount ?? 0;
+  const snapshotItems =
+    dbStats && dbValidation
+      ? [
+          { label: 'Validation Status', value: dbValidation.status.toUpperCase() },
+          { label: 'Time-Series Source', value: dbStats.timeSeriesSource },
+          { label: 'Initialized', value: dbStats.initialized ? 'Yes' : 'No' },
+          { label: 'Last Sync', value: formatTimestamp(dbStats.lastSync) },
+          { label: 'Stock Data Latest', value: dbStats.stockData.dateRange?.max ?? 'n/a' },
+          { label: 'TOPIX Latest', value: dbStats.topix.dateRange?.max ?? 'n/a' },
+          { label: 'Indices Latest', value: dbStats.indices.dateRange?.max ?? 'n/a' },
+          { label: 'Missing Stock Dates', value: dbValidation.stockData.missingDatesCount },
+          { label: 'Failed Sync Dates', value: dbValidation.failedDatesCount },
+          { label: 'Stocks Needing Refresh', value: stocksNeedingRefreshCount },
+          { label: 'Readiness Issues', value: integrityIssuesCount },
+        ]
+      : [];
+
   return (
     <>
       {(statsError || validationError) && (
@@ -127,43 +165,26 @@ function SnapshotStatus({
       )}
 
       {dbStats && dbValidation && (
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <div>
-            <span className="text-muted-foreground">Validation Status:</span>
-            <span className="ml-2 font-medium uppercase">{dbValidation.status}</span>
+        <div className="space-y-3">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {snapshotItems.map((item) => (
+              <div key={item.label}>
+                <span className="text-muted-foreground">{item.label}:</span>
+                <span className="ml-2 font-medium">{item.value}</span>
+              </div>
+            ))}
           </div>
-          <div>
-            <span className="text-muted-foreground">Time-Series Source:</span>
-            <span className="ml-2 font-medium">{dbStats.timeSeriesSource}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Initialized:</span>
-            <span className="ml-2 font-medium">{dbStats.initialized ? 'Yes' : 'No'}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Last Sync:</span>
-            <span className="ml-2 font-medium">{formatTimestamp(dbStats.lastSync)}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Stock Data Latest:</span>
-            <span className="ml-2 font-medium">{dbStats.stockData.dateRange?.max ?? 'n/a'}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">TOPIX Latest:</span>
-            <span className="ml-2 font-medium">{dbStats.topix.dateRange?.max ?? 'n/a'}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Indices Latest:</span>
-            <span className="ml-2 font-medium">{dbStats.indices.dateRange?.max ?? 'n/a'}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Missing Stock Dates:</span>
-            <span className="ml-2 font-medium">{dbValidation.stockData.missingDatesCount}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Failed Sync Dates:</span>
-            <span className="ml-2 font-medium">{dbValidation.failedDatesCount}</span>
-          </div>
+
+          {recommendations.length > 0 && (
+            <div className={getValidationDetailsClassName(dbValidation.status)}>
+              <p className="font-medium">{getValidationDetailsTitle(dbValidation.status)}</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                {recommendations.map((recommendation) => (
+                  <li key={recommendation}>{recommendation}</li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- expose DuckDB validation warning reasons in the Settings snapshot
- surface refresh/readiness counts alongside validation recommendations
- add tests for warning, healthy, error, and empty recommendation states

## Testing
- bun run --filter @trading25/web test -- src/pages/SettingsPage.test.tsx
- bun run --filter @trading25/web typecheck
- bun x vitest run src/pages/SettingsPage.test.tsx --coverage --coverage.include=src/pages/SettingsPage.tsx --coverage.reporter=text-summary