### PR TITLE
feat(web): compact screening job status and toggle history

### DIFF
--- a/apps/ts/packages/web/src/components/Screening/ScreeningJobHistoryTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningJobHistoryTable.test.tsx
@@ -42,4 +42,23 @@ describe('ScreeningJobHistoryTable', () => {
     render(<ScreeningJobHistoryTable jobs={[job]} isLoading={false} selectedJobId={null} onSelectJob={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Monitor' })).toBeInTheDocument();
   });
+
+  it('toggles job history visibility', async () => {
+    const user = userEvent.setup();
+    const job = createJob({ job_id: 'job-toggle' });
+
+    render(<ScreeningJobHistoryTable jobs={[job]} isLoading={false} selectedJobId={null} onSelectJob={vi.fn()} />);
+
+    const toggle = screen.getByRole('switch', { name: 'Show History' });
+    expect(toggle).toBeChecked();
+    expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(toggle).not.toBeChecked();
+    expect(screen.queryByRole('button', { name: 'View' })).not.toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(toggle).toBeChecked();
+    expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
+  });
 });

--- a/apps/ts/packages/web/src/components/Screening/ScreeningJobHistoryTable.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningJobHistoryTable.tsx
@@ -1,4 +1,7 @@
+import { useId, useState } from 'react';
 import { JobHistoryTable, type JobHistoryColumn } from '@/components/Jobs/JobHistoryTable';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import type { ScreeningJobResponse } from '@/types/screening';
 
 interface ScreeningJobHistoryTableProps {
@@ -28,6 +31,9 @@ function truncateJobId(jobId: string): string {
 }
 
 export function ScreeningJobHistoryTable({ jobs, isLoading, selectedJobId, onSelectJob }: ScreeningJobHistoryTableProps) {
+  const [showHistory, setShowHistory] = useState(true);
+  const switchId = useId();
+
   const columns: JobHistoryColumn<ScreeningJobResponse>[] = [
     {
       key: 'jobId',
@@ -52,17 +58,30 @@ export function ScreeningJobHistoryTable({ jobs, isLoading, selectedJobId, onSel
   ];
 
   return (
-    <JobHistoryTable
-      jobs={jobs}
-      isLoading={isLoading}
-      selectedJobId={selectedJobId}
-      title="Job History"
-      emptyMessage="No screening jobs found"
-      columns={columns}
-      getJobId={(job) => job.job_id}
-      getStatus={(job) => job.status}
-      getActionLabel={(job) => actionLabel(job.status)}
-      onSelectJob={onSelectJob}
-    />
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium">Job History</h4>
+        <div className="flex items-center gap-2">
+          <Label htmlFor={switchId} className="cursor-pointer text-xs text-muted-foreground">
+            Show History
+          </Label>
+          <Switch id={switchId} checked={showHistory} onCheckedChange={setShowHistory} />
+        </div>
+      </div>
+
+      {showHistory ? (
+        <JobHistoryTable
+          jobs={jobs}
+          isLoading={isLoading}
+          selectedJobId={selectedJobId}
+          emptyMessage="No screening jobs found"
+          columns={columns}
+          getJobId={(job) => job.job_id}
+          getStatus={(job) => job.status}
+          getActionLabel={(job) => actionLabel(job.status)}
+          onSelectJob={onSelectJob}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/apps/ts/packages/web/src/components/Screening/ScreeningJobProgress.test.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningJobProgress.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScreeningJobResponse } from '@/types/screening';
+import { ScreeningJobProgress, ScreeningJobStatusInline } from './ScreeningJobProgress';
+
+function createJob(overrides: Partial<ScreeningJobResponse> = {}): ScreeningJobResponse {
+  return {
+    job_id: 'job-1',
+    status: 'pending',
+    created_at: '2026-02-18T12:00:00Z',
+    markets: 'prime',
+    recentDays: 10,
+    sortBy: 'matchedDate',
+    order: 'desc',
+    ...overrides,
+  };
+}
+
+describe('ScreeningJobProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-18T12:01:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when there is no job', () => {
+    const { container } = render(<ScreeningJobProgress job={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders pending progress with elapsed time and cancel action', () => {
+    const onCancel = vi.fn();
+
+    render(<ScreeningJobProgress job={createJob()} onCancel={onCancel} />);
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(screen.getByText('Screening Job: pending')).toBeInTheDocument();
+    expect(screen.getByText('1:00')).toBeInTheDocument();
+    expect(screen.getByText('Running...')).toBeInTheDocument();
+    expect(screen.queryByText('%')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders determinate running progress using started_at and message', () => {
+    const { container } = render(
+      <ScreeningJobProgress
+        job={createJob({
+          status: 'running',
+          started_at: '2026-02-18T12:00:30Z',
+          progress: 0.42,
+          message: 'Fetching results',
+        })}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Screening Job: running')).toBeInTheDocument();
+    expect(screen.getByText('0:31')).toBeInTheDocument();
+    expect(screen.getByText('Fetching results')).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+    expect(container.querySelector('[style*="width: 42%"]')).not.toBeNull();
+  });
+
+  it('disables cancel button while cancellation is pending', () => {
+    render(<ScreeningJobProgress job={createJob()} onCancel={vi.fn()} isCancelling />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('renders failure state with error message', () => {
+    render(<ScreeningJobProgress job={createJob({ status: 'failed', error: 'backend failed' })} />);
+    expect(screen.getByText('Screening Job: failed')).toBeInTheDocument();
+    expect(screen.getByText('backend failed')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('renders cancelled state message', () => {
+    render(<ScreeningJobProgress job={createJob({ status: 'cancelled' })} />);
+    expect(screen.getByText('Screening Job: cancelled')).toBeInTheDocument();
+    expect(screen.getByText('Screening was cancelled.')).toBeInTheDocument();
+  });
+});
+
+describe('ScreeningJobStatusInline', () => {
+  it('renders completed status inline', () => {
+    render(<ScreeningJobStatusInline job={createJob({ status: 'completed' })} />);
+    expect(screen.getByText('Screening Job: completed')).toBeInTheDocument();
+  });
+
+  it('renders unknown status text without crashing', () => {
+    render(
+      <ScreeningJobStatusInline
+        job={createJob({
+          status: 'mystery' as unknown as ScreeningJobResponse['status'],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Screening Job: mystery')).toBeInTheDocument();
+  });
+});

--- a/apps/ts/packages/web/src/components/Screening/ScreeningJobProgress.tsx
+++ b/apps/ts/packages/web/src/components/Screening/ScreeningJobProgress.tsx
@@ -10,6 +10,10 @@ interface ScreeningJobProgressProps {
   isCancelling?: boolean;
 }
 
+interface ScreeningJobStatusInlineProps {
+  job: ScreeningJobResponse;
+}
+
 function StatusIcon({ status }: { status: ScreeningJobResponse['status'] }) {
   switch (status) {
     case 'pending':
@@ -30,6 +34,15 @@ function formatElapsedSeconds(seconds: number): string {
   const minutes = Math.floor(seconds / 60);
   const sec = seconds % 60;
   return `${minutes}:${String(sec).padStart(2, '0')}`;
+}
+
+export function ScreeningJobStatusInline({ job }: ScreeningJobStatusInlineProps) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <StatusIcon status={job.status} />
+      <span className="font-medium">Screening Job: {job.status}</span>
+    </div>
+  );
 }
 
 export function ScreeningJobProgress({ job, onCancel, isCancelling = false }: ScreeningJobProgressProps) {

--- a/apps/ts/packages/web/src/pages/AnalysisPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/AnalysisPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '@/lib/api-client';
 import { createInitialAnalysisState, useAnalysisStore } from '@/stores/analysisStore';
-import type { MarketScreeningResponse } from '@/types/screening';
+import type { MarketScreeningResponse, ScreeningJobResponse } from '@/types/screening';
 import { AnalysisPage } from './AnalysisPage';
 
 const mockNavigate = vi.fn();
@@ -60,6 +60,19 @@ function createCachedScreeningResult(): MarketScreeningResponse {
         ],
       },
     ],
+  };
+}
+
+function createScreeningJob(overrides: Partial<ScreeningJobResponse> = {}): ScreeningJobResponse {
+  return {
+    job_id: 'job-1',
+    status: 'pending',
+    created_at: '2026-02-18T00:00:00Z',
+    markets: 'prime',
+    recentDays: 10,
+    sortBy: 'matchedDate',
+    order: 'desc',
+    ...overrides,
   };
 }
 
@@ -121,6 +134,7 @@ vi.mock('@/components/Screening/ScreeningFilters', () => ({
 
 vi.mock('@/components/Screening/ScreeningJobProgress', () => ({
   ScreeningJobProgress: () => <div>Screening Job Progress</div>,
+  ScreeningJobStatusInline: ({ job }: { job: ScreeningJobResponse }) => <div>Screening Job: {job.status}</div>,
 }));
 
 vi.mock('@/components/Screening/ScreeningSummary', () => ({
@@ -269,5 +283,17 @@ describe('AnalysisPage', () => {
         ]),
       })
     );
+  });
+
+  it('shows completed screening job status inline beside the run action', () => {
+    mockUseScreeningJobStatus.mockReturnValue({
+      data: createScreeningJob({ status: 'completed' }),
+      error: null,
+    });
+
+    render(<AnalysisPage />);
+
+    expect(screen.getByText('Screening Job: completed')).toBeInTheDocument();
+    expect(screen.queryByText('Screening Job Progress')).not.toBeInTheDocument();
   });
 });

--- a/apps/ts/packages/web/src/pages/AnalysisPage.tsx
+++ b/apps/ts/packages/web/src/pages/AnalysisPage.tsx
@@ -9,7 +9,7 @@ import {
 import { RankingFilters, RankingSummary, RankingTable } from '@/components/Ranking';
 import { ScreeningFilters } from '@/components/Screening/ScreeningFilters';
 import { ScreeningJobHistoryTable } from '@/components/Screening/ScreeningJobHistoryTable';
-import { ScreeningJobProgress } from '@/components/Screening/ScreeningJobProgress';
+import { ScreeningJobProgress, ScreeningJobStatusInline } from '@/components/Screening/ScreeningJobProgress';
 import { ScreeningSummary } from '@/components/Screening/ScreeningSummary';
 import { ScreeningTable } from '@/components/Screening/ScreeningTable';
 import { Button } from '@/components/ui/button';
@@ -135,19 +135,26 @@ function AnalysisMainContent({
   fundamentalError,
 }: AnalysisMainContentProps) {
   if (activeSubTab === 'screening') {
+    const completedScreeningJob = screeningJob?.status === 'completed' ? screeningJob : null;
+
     return (
       <>
-        <div className="mb-3 flex justify-end">
+        <div className="mb-3 flex flex-wrap items-center gap-3">
+          <div className="min-w-0 flex-1">
+            {completedScreeningJob ? <ScreeningJobStatusInline job={completedScreeningJob} /> : null}
+          </div>
           <Button onClick={() => void handleRunScreening()} disabled={screeningIsRunning}>
             Run Screening
           </Button>
         </div>
 
-        <ScreeningJobProgress
-          job={screeningJob}
-          onCancel={screeningIsRunning ? handleCancelScreening : undefined}
-          isCancelling={cancelScreeningPending}
-        />
+        {completedScreeningJob ? null : (
+          <ScreeningJobProgress
+            job={screeningJob}
+            onCancel={screeningIsRunning ? handleCancelScreening : undefined}
+            isCancelling={cancelScreeningPending}
+          />
+        )}
 
         <ScreeningJobHistoryTable
           jobs={screeningJobHistory}


### PR DESCRIPTION
## Summary
- move completed screening job status next to the Run Screening action instead of using a full-width row
- add a Show History toggle for the screening job history table
- add focused tests for screening job progress, history toggling, and completed-job inline rendering

## Testing
- bun run --cwd apps/ts/packages/web test src/components/Screening/ScreeningJobProgress.test.tsx src/components/Screening/ScreeningJobHistoryTable.test.tsx src/pages/AnalysisPage.test.tsx
- bun run --cwd apps/ts/packages/web typecheck
- bun run --cwd apps/ts/packages/web vitest run --coverage --coverage.include='src/pages/AnalysisPage.tsx' --coverage.include='src/components/Screening/ScreeningJobProgress.tsx' --coverage.include='src/components/Screening/ScreeningJobHistoryTable.tsx' src/components/Screening/ScreeningJobProgress.test.tsx src/components/Screening/ScreeningJobHistoryTable.test.tsx src/pages/AnalysisPage.test.tsx