### PR TITLE
feat(bt): add TOPIX gap playground analysis

### DIFF
--- a/apps/bt/notebooks/playground/topix_gap_intraday_distribution_playground.py
+++ b/apps/bt/notebooks/playground/topix_gap_intraday_distribution_playground.py
@@ -1,0 +1,381 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "pandas>=2.0.0",
+#     "matplotlib>=3.0.0",
+# ]
+# ///
+
+"""
+TOPIX Gap / Intraday Distribution Playground (Marimo)
+
+UI playground for DuckDB-backed analytics.
+Computation logic must stay in src/domains, this notebook provides UI only.
+"""
+
+from __future__ import annotations
+
+import marimo
+
+app = marimo.App(width="full", app_title="TOPIX Gap / Intraday Distribution Playground")
+
+
+@app.cell
+def imports():
+    import marimo as mo
+    import sys
+    from pathlib import Path
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    return mo, sys, Path, plt, pd
+
+
+@app.cell
+def bootstrap_project_root(sys, Path):
+    project_root = Path.cwd()
+    if project_root.name == "playground":
+        project_root = project_root.parent.parent
+    elif project_root.name == "notebooks":
+        project_root = project_root.parent
+
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    from src.shared.config.settings import get_settings
+    from src.domains.analytics.topix_gap_intraday_distribution import (
+        STOCK_GROUP_ORDER,
+        get_topix_available_date_range,
+        run_topix_gap_intraday_distribution,
+    )
+
+    settings = get_settings()
+    default_db_path = settings.market_db_path
+    return (
+        STOCK_GROUP_ORDER,
+        default_db_path,
+        get_topix_available_date_range,
+        run_topix_gap_intraday_distribution,
+    )
+
+
+@app.cell
+def initial_range(default_db_path, get_topix_available_date_range):
+    try:
+        available_start_date, available_end_date = get_topix_available_date_range(default_db_path)
+    except Exception:
+        available_start_date, available_end_date = None, None
+    return available_start_date, available_end_date
+
+
+@app.cell
+def controls(mo, STOCK_GROUP_ORDER, default_db_path, initial_range):
+    available_start_date, available_end_date = initial_range
+    db_path = mo.ui.text(value=default_db_path, label="DuckDB Path")
+    start_date = mo.ui.text(
+        value=available_start_date or "",
+        label="Start Date (YYYY-MM-DD)",
+    )
+    end_date = mo.ui.text(
+        value=available_end_date or "",
+        label="End Date (YYYY-MM-DD)",
+    )
+    selected_groups = mo.ui.text(
+        value=", ".join(STOCK_GROUP_ORDER),
+        label="Groups (comma separated)",
+    )
+    gap_threshold_1 = mo.ui.number(
+        value=1.0,
+        start=0.1,
+        stop=10.0,
+        step=0.1,
+        label="Gap Threshold 1 (%)",
+    )
+    gap_threshold_2 = mo.ui.number(
+        value=2.0,
+        start=0.2,
+        stop=20.0,
+        step=0.1,
+        label="Gap Threshold 2 (%)",
+    )
+    sample_size = mo.ui.number(
+        value=1500,
+        start=0,
+        step=100,
+        label="Sample Size Per Group/Bucket",
+    )
+    clip_lower = mo.ui.number(
+        value=1.0,
+        start=0.0,
+        stop=49.0,
+        step=0.5,
+        label="Clip Lower Percentile",
+    )
+    clip_upper = mo.ui.number(
+        value=99.0,
+        start=51.0,
+        stop=100.0,
+        step=0.5,
+        label="Clip Upper Percentile",
+    )
+
+    mo.vstack(
+        [
+            db_path,
+            mo.hstack([start_date, end_date]),
+            selected_groups,
+            mo.hstack([gap_threshold_1, gap_threshold_2]),
+            mo.hstack([sample_size, clip_lower, clip_upper]),
+        ]
+    )
+    return (
+        clip_lower,
+        clip_upper,
+        db_path,
+        end_date,
+        gap_threshold_1,
+        gap_threshold_2,
+        sample_size,
+        selected_groups,
+        start_date,
+    )
+
+
+@app.cell
+def parsed_inputs(
+    STOCK_GROUP_ORDER,
+    clip_lower,
+    clip_upper,
+    db_path,
+    end_date,
+    gap_threshold_1,
+    gap_threshold_2,
+    sample_size,
+    selected_groups,
+    start_date,
+):
+    requested_groups = [
+        value.strip()
+        for value in selected_groups.value.split(",")
+        if value.strip()
+    ]
+    if not requested_groups:
+        requested_groups = list(STOCK_GROUP_ORDER)
+
+    selected_start = start_date.value.strip() or None
+    selected_end = end_date.value.strip() or None
+    selected_db_path = db_path.value.strip()
+    selected_sample_size = int(sample_size.value)
+    selected_clip = (float(clip_lower.value), float(clip_upper.value))
+    thresholds = (
+        float(gap_threshold_1.value) / 100.0,
+        float(gap_threshold_2.value) / 100.0,
+    )
+    return (
+        requested_groups,
+        selected_clip,
+        selected_db_path,
+        selected_end,
+        selected_sample_size,
+        selected_start,
+        thresholds,
+    )
+
+
+@app.cell
+def analysis_result(
+    mo,
+    parsed_inputs,
+    run_topix_gap_intraday_distribution,
+):
+    (
+        requested_groups,
+        selected_clip,
+        selected_db_path,
+        selected_end,
+        selected_sample_size,
+        selected_start,
+        thresholds,
+    ) = parsed_inputs
+    try:
+        result = run_topix_gap_intraday_distribution(
+            selected_db_path,
+            start_date=selected_start,
+            end_date=selected_end,
+            gap_threshold_1=thresholds[0],
+            gap_threshold_2=thresholds[1],
+            selected_groups=requested_groups,
+            sample_size=selected_sample_size,
+            clip_percentiles=selected_clip,
+        )
+        error_message = None
+    except Exception as exc:
+        result = None
+        error_message = str(exc)
+    return error_message, result
+
+
+@app.cell
+def render_error(mo, error_message):
+    if not error_message:
+        return
+    mo.md(f"## Input Error\n\n`{error_message}`")
+
+
+@app.cell
+def render_summary(mo, error_message, parsed_inputs, result):
+    if error_message or result is None:
+        return
+
+    requested_groups, selected_clip, _, _, selected_sample_size, _, thresholds = parsed_inputs
+    mo.md(
+        f"""
+## TOPIX Gap / Intraday Distribution Playground
+
+- Source mode: **{result.source_mode}**
+- Source detail: **{result.source_detail}**
+- Available range: **{result.available_start_date} → {result.available_end_date}**
+- Analysis range: **{result.analysis_start_date} → {result.analysis_end_date}**
+- Selected groups: **{", ".join(requested_groups)}**
+- Thresholds: **{thresholds[0] * 100:.1f}% / {thresholds[1] * 100:.1f}%**
+- Sample size per group/bucket: **{selected_sample_size}**
+- Plot clip: **{selected_clip[0]:.1f}% → {selected_clip[1]:.1f}%**
+- Excluded TOPIX days without previous close: **{result.excluded_topix_days_without_prev_close}**
+"""
+    )
+
+
+@app.cell
+def render_day_counts_chart(plt, error_message, result):
+    if error_message or result is None:
+        return
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    day_counts = result.day_counts_df
+    ax.bar(day_counts["gap_bucket_label"], day_counts["day_count"], color=["#8fb996", "#f4a259", "#bc4b51"])
+    ax.set_title("TOPIX Gap Day Counts")
+    ax.set_ylabel("Days")
+    ax.grid(axis="y", alpha=0.2)
+    plt.xticks(rotation=15, ha="right")
+    fig.tight_layout()
+    fig
+
+
+@app.cell
+def render_direction_chart(plt, error_message, result):
+    if error_message or result is None:
+        return
+
+    summary_df = result.summary_df.copy()
+    summary_df["label"] = summary_df["stock_group"] + "\n" + summary_df["gap_bucket_label"]
+
+    fig, ax = plt.subplots(figsize=(14, 7))
+    x = range(len(summary_df))
+    up = summary_df["up_ratio"]
+    down = summary_df["down_ratio"]
+    flat = summary_df["flat_ratio"]
+
+    ax.bar(x, up, label="Up", color="#2a9d8f")
+    ax.bar(x, down, bottom=up, label="Down", color="#e76f51")
+    ax.bar(x, flat, bottom=up + down, label="Flat", color="#7a7a7a")
+    ax.set_ylim(0.0, 1.0)
+    ax.set_ylabel("Ratio")
+    ax.set_title("Up / Down / Flat Ratios by Group and Gap Bucket")
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(summary_df["label"], rotation=35, ha="right")
+    ax.legend()
+    ax.grid(axis="y", alpha=0.2)
+    fig.tight_layout()
+    fig
+
+
+@app.cell
+def render_distribution_chart(plt, error_message, result):
+    if error_message or result is None:
+        return
+
+    plot_df = result.clipped_samples_df
+    bucket_order = list(result.day_counts_df["gap_bucket_key"])
+    bucket_labels = {
+        row["gap_bucket_key"]: row["gap_bucket_label"]
+        for _, row in result.day_counts_df.iterrows()
+    }
+
+    fig, axes = plt.subplots(len(bucket_order), 1, figsize=(12, 4 * len(bucket_order)), sharex=False)
+    if len(bucket_order) == 1:
+        axes = [axes]
+
+    for ax, bucket_key in zip(axes, bucket_order, strict=True):
+        bucket_df = plot_df[plot_df["gap_bucket_key"] == bucket_key]
+        group_order = [
+            group
+            for group in result.selected_groups
+            if not bucket_df[bucket_df["stock_group"] == group].empty
+        ]
+        boxplot_data = [
+            bucket_df.loc[bucket_df["stock_group"] == group, "intraday_diff"].tolist()
+            for group in group_order
+        ]
+
+        if any(boxplot_data):
+            ax.boxplot(boxplot_data, labels=group_order, patch_artist=True)
+        else:
+            ax.text(0.5, 0.5, "No sampled rows in this bucket", ha="center", va="center")
+            ax.set_xticks([])
+
+        ax.set_title(bucket_labels[bucket_key])
+        ax.set_ylabel("close - open")
+        ax.grid(axis="y", alpha=0.2)
+
+    fig.suptitle("Sampled Distribution of close - open (Clipped for Plotting)", y=1.02)
+    fig.tight_layout()
+    fig
+
+
+@app.cell
+def render_tables(mo, error_message, result):
+    if error_message or result is None:
+        return
+
+    summary_columns = [
+        "stock_group",
+        "gap_bucket_label",
+        "sample_count",
+        "up_count",
+        "down_count",
+        "flat_count",
+        "up_ratio",
+        "down_ratio",
+        "flat_ratio",
+        "mean_intraday_diff",
+        "median_intraday_diff",
+        "p05_intraday_diff",
+        "p25_intraday_diff",
+        "p50_intraday_diff",
+        "p75_intraday_diff",
+        "p95_intraday_diff",
+    ]
+    sample_columns = [
+        "stock_group",
+        "gap_bucket_label",
+        "date",
+        "code",
+        "intraday_diff",
+        "direction",
+        "sample_rank",
+    ]
+    mo.vstack(
+        [
+            mo.md("### Bucket Day Counts"),
+            mo.Html(result.day_counts_df.to_html(index=False)),
+            mo.md("### Exact Summary"),
+            mo.Html(result.summary_df[summary_columns].to_html(index=False, float_format=lambda x: f"{x:.4f}")),
+            mo.md("### Sampled Rows (first 100)"),
+            mo.Html(result.samples_df[sample_columns].head(100).to_html(index=False, float_format=lambda x: f"{x:.4f}")),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    app.run()

--- a/apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py
+++ b/apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py
@@ -1,0 +1,755 @@
+"""
+TOPIX gap / stock intraday distribution analysis.
+
+The market.duckdb file is the source of truth for both metadata and time-series
+tables. This module performs read-only analytics and returns pandas DataFrames
+for notebook visualization.
+"""
+
+from __future__ import annotations
+
+import importlib
+import shutil
+import tempfile
+from collections.abc import Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import pandas as pd
+
+GapBucketKey = Literal[
+    "gap_lt_threshold_1",
+    "gap_threshold_1_to_2",
+    "gap_ge_threshold_2",
+]
+StockGroup = Literal[
+    "PRIME",
+    "STANDARD",
+    "GROWTH",
+    "TOPIX500",
+    "PRIME ex TOPIX500",
+]
+SourceMode = Literal["live", "snapshot"]
+
+GAP_BUCKET_ORDER: tuple[GapBucketKey, ...] = (
+    "gap_lt_threshold_1",
+    "gap_threshold_1_to_2",
+    "gap_ge_threshold_2",
+)
+STOCK_GROUP_ORDER: tuple[StockGroup, ...] = (
+    "PRIME",
+    "STANDARD",
+    "GROWTH",
+    "TOPIX500",
+    "PRIME ex TOPIX500",
+)
+TOPIX500_SCALE_CATEGORIES: tuple[str, ...] = (
+    "TOPIX Core30",
+    "TOPIX Large70",
+    "TOPIX Mid400",
+)
+
+_LOCK_ERROR_PATTERNS: tuple[str, ...] = (
+    "conflicting lock is held",
+    "could not set lock",
+)
+
+
+@dataclass(frozen=True)
+class TopixGapIntradayDistributionResult:
+    db_path: str
+    source_mode: SourceMode
+    source_detail: str
+    available_start_date: str | None
+    available_end_date: str | None
+    analysis_start_date: str | None
+    analysis_end_date: str | None
+    gap_threshold_1: float
+    gap_threshold_2: float
+    selected_groups: tuple[StockGroup, ...]
+    excluded_topix_days_without_prev_close: int
+    day_counts_df: pd.DataFrame
+    summary_df: pd.DataFrame
+    samples_df: pd.DataFrame
+    clipped_samples_df: pd.DataFrame
+    clip_bounds_df: pd.DataFrame
+
+
+@dataclass(frozen=True)
+class _ConnectionContext:
+    connection: Any
+    source_mode: SourceMode
+    source_detail: str
+
+
+def _connect_duckdb(db_path: str, *, read_only: bool = True) -> Any:
+    duckdb = importlib.import_module("duckdb")
+    return duckdb.connect(db_path, read_only=read_only)
+
+
+def _is_lock_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(pattern in message for pattern in _LOCK_ERROR_PATTERNS)
+
+
+@contextmanager
+def _open_analysis_connection(db_path: str):
+    conn: Any | None = None
+    tmpdir: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        try:
+            conn = _connect_duckdb(db_path, read_only=True)
+            yield _ConnectionContext(
+                connection=conn,
+                source_mode="live",
+                source_detail=f"live DuckDB: {db_path}",
+            )
+            return
+        except Exception as exc:
+            if not _is_lock_error(exc):
+                raise
+
+        tmpdir = tempfile.TemporaryDirectory(
+            prefix="topix-gap-intraday-",
+            dir="/tmp",
+        )
+        snapshot_dir = Path(tmpdir.name)
+        db_path_obj = Path(db_path)
+        snapshot_path = snapshot_dir / db_path_obj.name
+        shutil.copy2(db_path_obj, snapshot_path)
+
+        wal_path = Path(f"{db_path}.wal")
+        if wal_path.exists():
+            shutil.copy2(wal_path, Path(f"{snapshot_path}.wal"))
+
+        conn = _connect_duckdb(str(snapshot_path), read_only=True)
+        yield _ConnectionContext(
+            connection=conn,
+            source_mode="snapshot",
+            source_detail=f"temporary snapshot copied from {db_path}",
+        )
+    finally:
+        if conn is not None:
+            conn.close()
+        if tmpdir is not None:
+            tmpdir.cleanup()
+
+
+def _date_where_clause(column_name: str, start_date: str | None, end_date: str | None) -> tuple[str, list[str]]:
+    conditions: list[str] = []
+    params: list[str] = []
+    if start_date:
+        conditions.append(f"{column_name} >= ?")
+        params.append(start_date)
+    if end_date:
+        conditions.append(f"{column_name} <= ?")
+        params.append(end_date)
+    if not conditions:
+        return "", []
+    return " WHERE " + " AND ".join(conditions), params
+
+
+def _format_threshold(value: float) -> str:
+    percent = value * 100.0
+    if percent.is_integer():
+        return f"{int(percent)}%"
+    formatted = f"{percent:.2f}".rstrip("0").rstrip(".")
+    return f"{formatted}%"
+
+
+def _normalize_code_sql(column_name: str) -> str:
+    return (
+        "CASE "
+        f"WHEN length({column_name}) IN (5, 6) AND right({column_name}, 1) = '0' "
+        f"THEN left({column_name}, length({column_name}) - 1) "
+        f"ELSE {column_name} "
+        "END"
+    )
+
+
+def _fetch_date_range(
+    conn: Any,
+    *,
+    table_name: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> tuple[str | None, str | None]:
+    where_sql, params = _date_where_clause("date", start_date, end_date)
+    row = conn.execute(
+        f"SELECT MIN(date) AS min_date, MAX(date) AS max_date FROM {table_name}{where_sql}",
+        params,
+    ).fetchone()
+    min_date = str(row[0]) if row and row[0] else None
+    max_date = str(row[1]) if row and row[1] else None
+    return min_date, max_date
+
+
+def format_gap_bucket_label(
+    bucket_key: GapBucketKey,
+    *,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+) -> str:
+    threshold_1 = _format_threshold(gap_threshold_1)
+    threshold_2 = _format_threshold(gap_threshold_2)
+    if bucket_key == "gap_lt_threshold_1":
+        return f"|gap| < {threshold_1}"
+    if bucket_key == "gap_threshold_1_to_2":
+        return f"{threshold_1} <= |gap| < {threshold_2}"
+    return f"|gap| >= {threshold_2}"
+
+
+def _grouped_stock_days_cte(
+    *,
+    start_date: str | None,
+    end_date: str | None,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+    selected_groups: Sequence[StockGroup],
+) -> tuple[str, list[Any]]:
+    gap_where_sql, gap_params = _date_where_clause("date", start_date, end_date)
+    normalized_code_sql = _normalize_code_sql("code")
+    stock_conditions: list[str] = ["open IS NOT NULL", "close IS NOT NULL"]
+    stock_params: list[str] = []
+    if start_date:
+        stock_conditions.insert(0, "date >= ?")
+        stock_params.append(start_date)
+    if end_date:
+        stock_conditions.insert(1 if start_date else 0, "date <= ?")
+        stock_params.append(end_date)
+    stock_where_sql = " WHERE " + " AND ".join(stock_conditions)
+
+    group_selects = {
+        "PRIME": """
+            SELECT date, normalized_code, intraday_diff, direction, gap_bucket_key, gap_return, 'PRIME' AS stock_group
+            FROM stock_days_joined
+            WHERE is_prime
+        """,
+        "STANDARD": """
+            SELECT date, normalized_code, intraday_diff, direction, gap_bucket_key, gap_return, 'STANDARD' AS stock_group
+            FROM stock_days_joined
+            WHERE is_standard
+        """,
+        "GROWTH": """
+            SELECT date, normalized_code, intraday_diff, direction, gap_bucket_key, gap_return, 'GROWTH' AS stock_group
+            FROM stock_days_joined
+            WHERE is_growth
+        """,
+        "TOPIX500": """
+            SELECT date, normalized_code, intraday_diff, direction, gap_bucket_key, gap_return, 'TOPIX500' AS stock_group
+            FROM stock_days_joined
+            WHERE is_topix500
+        """,
+        "PRIME ex TOPIX500": """
+            SELECT date, normalized_code, intraday_diff, direction, gap_bucket_key, gap_return, 'PRIME ex TOPIX500' AS stock_group
+            FROM stock_days_joined
+            WHERE is_prime_ex_topix500
+        """,
+    }
+    union_sql = "\nUNION ALL\n".join(group_selects[group] for group in selected_groups)
+
+    sql = f"""
+        WITH topix_with_gap AS (
+            SELECT
+                date,
+                open,
+                close,
+                prev_close,
+                CASE
+                    WHEN prev_close IS NULL OR prev_close = 0 THEN NULL
+                    WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_ge_threshold_2'
+                    WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_threshold_1_to_2'
+                    ELSE 'gap_lt_threshold_1'
+                END AS gap_bucket_key,
+                CASE
+                    WHEN prev_close IS NULL OR prev_close = 0 THEN NULL
+                    ELSE (open - prev_close) / prev_close
+                END AS gap_return
+                FROM (
+                    SELECT
+                        date,
+                        open,
+                        close,
+                        LAG(close) OVER (ORDER BY date) AS prev_close
+                    FROM topix_data
+                ) ordered_topix
+                {gap_where_sql}
+        ),
+        stocks_snapshot_raw AS (
+            SELECT
+                {normalized_code_sql} AS normalized_code,
+                lower(trim(market_code)) AS market_code_norm,
+                coalesce(scale_category, '') AS scale_category,
+                ROW_NUMBER() OVER (
+                    PARTITION BY {normalized_code_sql}
+                    ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END, code
+                ) AS row_priority
+            FROM stocks
+        ),
+        stocks_snapshot AS (
+            SELECT
+                normalized_code,
+                market_code_norm IN ('prime', '0111') AS is_prime,
+                market_code_norm IN ('standard', '0112') AS is_standard,
+                market_code_norm IN ('growth', '0113') AS is_growth,
+                scale_category IN ('TOPIX Core30', 'TOPIX Large70', 'TOPIX Mid400') AS is_topix500,
+                market_code_norm IN ('prime', '0111')
+                    AND scale_category NOT IN ('TOPIX Core30', 'TOPIX Large70', 'TOPIX Mid400') AS is_prime_ex_topix500
+            FROM stocks_snapshot_raw
+            WHERE row_priority = 1
+        ),
+        stock_data_raw AS (
+            SELECT
+                date,
+                {normalized_code_sql} AS normalized_code,
+                open,
+                close,
+                ROW_NUMBER() OVER (
+                    PARTITION BY {normalized_code_sql}, date
+                    ORDER BY CASE WHEN length(code) = 4 THEN 0 ELSE 1 END, code
+                ) AS row_priority
+            FROM stock_data
+            {stock_where_sql}
+        ),
+        stock_data_dedup AS (
+            SELECT
+                date,
+                normalized_code,
+                close - open AS intraday_diff,
+                CASE
+                    WHEN close - open > 0 THEN 'up'
+                    WHEN close - open < 0 THEN 'down'
+                    ELSE 'flat'
+                END AS direction
+            FROM stock_data_raw
+            WHERE row_priority = 1
+        ),
+        stock_days_joined AS (
+            SELECT
+                s.date,
+                s.normalized_code,
+                s.intraday_diff,
+                s.direction,
+                t.gap_bucket_key,
+                t.gap_return,
+                m.is_prime,
+                m.is_standard,
+                m.is_growth,
+                m.is_topix500,
+                m.is_prime_ex_topix500
+            FROM stock_data_dedup s
+            JOIN topix_with_gap t USING (date)
+            JOIN stocks_snapshot m USING (normalized_code)
+            WHERE t.gap_bucket_key IS NOT NULL
+        ),
+        grouped_stock_days AS (
+            {union_sql}
+        )
+    """
+    return sql, [gap_threshold_2, gap_threshold_1, *gap_params, *stock_params]
+
+
+def _query_day_counts(
+    conn: Any,
+    *,
+    start_date: str | None,
+    end_date: str | None,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+) -> tuple[pd.DataFrame, int]:
+    gap_where_sql, gap_params = _date_where_clause("date", start_date, end_date)
+    excluded_conditions: list[str] = ["prev_close IS NULL OR prev_close = 0"]
+    excluded_params: list[str] = []
+    if start_date:
+        excluded_conditions.insert(0, "date >= ?")
+        excluded_params.append(start_date)
+    if end_date:
+        excluded_conditions.insert(1 if start_date else 0, "date <= ?")
+        excluded_params.append(end_date)
+    excluded_where_sql = " WHERE " + " AND ".join(excluded_conditions)
+    sql = f"""
+        WITH topix_with_gap AS (
+            SELECT
+                CASE
+                    WHEN prev_close IS NULL OR prev_close = 0 THEN NULL
+                    WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_ge_threshold_2'
+                    WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_threshold_1_to_2'
+                    ELSE 'gap_lt_threshold_1'
+                END AS gap_bucket_key
+            FROM (
+                SELECT
+                    date,
+                    open,
+                    close,
+                    LAG(close) OVER (ORDER BY date) AS prev_close
+                FROM topix_data
+            ) ordered_topix
+            {gap_where_sql}
+        )
+        SELECT gap_bucket_key, COUNT(*) AS day_count
+        FROM topix_with_gap
+        WHERE gap_bucket_key IS NOT NULL
+        GROUP BY gap_bucket_key
+    """
+    params = [gap_threshold_2, gap_threshold_1, *gap_params]
+    df = cast(pd.DataFrame, conn.execute(sql, params).fetchdf())
+
+    excluded_row = conn.execute(
+        f"""
+        SELECT COUNT(*) AS excluded_count
+        FROM (
+            SELECT
+                LAG(close) OVER (ORDER BY date) AS prev_close,
+                date
+            FROM topix_data
+        ) ordered_topix
+        {excluded_where_sql}
+        """,
+        excluded_params,
+    ).fetchone()
+    excluded_count = int(excluded_row[0] or 0) if excluded_row else 0
+    return df, excluded_count
+
+
+def _query_summary(
+    conn: Any,
+    *,
+    start_date: str | None,
+    end_date: str | None,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+    selected_groups: Sequence[StockGroup],
+) -> pd.DataFrame:
+    cte_sql, params = _grouped_stock_days_cte(
+        start_date=start_date,
+        end_date=end_date,
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+        selected_groups=selected_groups,
+    )
+    sql = f"""
+        {cte_sql}
+        SELECT
+            stock_group,
+            gap_bucket_key,
+            COUNT(*) AS sample_count,
+            COUNT(*) FILTER (WHERE direction = 'up') AS up_count,
+            COUNT(*) FILTER (WHERE direction = 'down') AS down_count,
+            COUNT(*) FILTER (WHERE direction = 'flat') AS flat_count,
+            AVG(CASE WHEN direction = 'up' THEN 1.0 ELSE 0.0 END) AS up_ratio,
+            AVG(CASE WHEN direction = 'down' THEN 1.0 ELSE 0.0 END) AS down_ratio,
+            AVG(CASE WHEN direction = 'flat' THEN 1.0 ELSE 0.0 END) AS flat_ratio,
+            AVG(intraday_diff) AS mean_intraday_diff,
+            median(intraday_diff) AS median_intraday_diff,
+            quantile_cont(intraday_diff, 0.05) AS p05_intraday_diff,
+            quantile_cont(intraday_diff, 0.25) AS p25_intraday_diff,
+            quantile_cont(intraday_diff, 0.50) AS p50_intraday_diff,
+            quantile_cont(intraday_diff, 0.75) AS p75_intraday_diff,
+            quantile_cont(intraday_diff, 0.95) AS p95_intraday_diff
+        FROM grouped_stock_days
+        GROUP BY stock_group, gap_bucket_key
+    """
+    return cast(pd.DataFrame, conn.execute(sql, params).fetchdf())
+
+
+def _query_samples(
+    conn: Any,
+    *,
+    start_date: str | None,
+    end_date: str | None,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+    selected_groups: Sequence[StockGroup],
+    sample_size: int,
+) -> pd.DataFrame:
+    if sample_size <= 0:
+        return pd.DataFrame(
+            columns=[
+                "stock_group",
+                "gap_bucket_key",
+                "date",
+                "code",
+                "intraday_diff",
+                "direction",
+                "sample_rank",
+            ]
+        )
+
+    cte_sql, params = _grouped_stock_days_cte(
+        start_date=start_date,
+        end_date=end_date,
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+        selected_groups=selected_groups,
+    )
+    sql = f"""
+        {cte_sql}
+        SELECT
+            stock_group,
+            gap_bucket_key,
+            date,
+            normalized_code AS code,
+            intraday_diff,
+            direction,
+            sample_rank
+        FROM (
+            SELECT
+                stock_group,
+                gap_bucket_key,
+                date,
+                normalized_code,
+                intraday_diff,
+                direction,
+                ROW_NUMBER() OVER (
+                    PARTITION BY stock_group, gap_bucket_key
+                    ORDER BY md5(
+                        stock_group || '|' || normalized_code || '|' || date || '|' || CAST(intraday_diff AS VARCHAR)
+                    )
+                ) AS sample_rank
+            FROM grouped_stock_days
+        ) ranked_samples
+        WHERE sample_rank <= ?
+        ORDER BY stock_group, gap_bucket_key, sample_rank
+    """
+    return cast(pd.DataFrame, conn.execute(sql, [*params, sample_size]).fetchdf())
+
+
+def _complete_day_counts(
+    day_counts_df: pd.DataFrame,
+    *,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+) -> pd.DataFrame:
+    expected = pd.DataFrame({"gap_bucket_key": list(GAP_BUCKET_ORDER)})
+    merged = expected.merge(day_counts_df, how="left", on="gap_bucket_key")
+    merged["day_count"] = merged["day_count"].fillna(0).astype(int)
+    merged["gap_bucket_label"] = merged["gap_bucket_key"].map(
+        lambda value: format_gap_bucket_label(
+            cast(GapBucketKey, value),
+            gap_threshold_1=gap_threshold_1,
+            gap_threshold_2=gap_threshold_2,
+        )
+    )
+    return merged
+
+
+def _complete_summary_grid(
+    summary_df: pd.DataFrame,
+    *,
+    selected_groups: Sequence[StockGroup],
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+) -> pd.DataFrame:
+    expected = pd.MultiIndex.from_product(
+        [list(selected_groups), list(GAP_BUCKET_ORDER)],
+        names=["stock_group", "gap_bucket_key"],
+    ).to_frame(index=False)
+    merged = expected.merge(
+        summary_df,
+        how="left",
+        on=["stock_group", "gap_bucket_key"],
+    )
+
+    count_columns = ["sample_count", "up_count", "down_count", "flat_count"]
+    ratio_columns = ["up_ratio", "down_ratio", "flat_ratio"]
+    for column in count_columns:
+        merged[column] = merged[column].fillna(0).astype(int)
+    for column in ratio_columns:
+        merged[column] = merged[column].fillna(0.0).astype(float)
+
+    merged["gap_bucket_label"] = merged["gap_bucket_key"].map(
+        lambda value: format_gap_bucket_label(
+            cast(GapBucketKey, value),
+            gap_threshold_1=gap_threshold_1,
+            gap_threshold_2=gap_threshold_2,
+        )
+    )
+    return merged
+
+
+def _apply_sample_clipping(
+    samples_df: pd.DataFrame,
+    *,
+    clip_percentiles: tuple[float, float],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if samples_df.empty:
+        empty_bounds = pd.DataFrame(
+            columns=["stock_group", "gap_bucket_key", "clip_lower", "clip_upper"]
+        )
+        return samples_df.copy(), empty_bounds
+
+    lower_pct, upper_pct = clip_percentiles
+    bounds_df = (
+        samples_df.groupby(["stock_group", "gap_bucket_key"], as_index=False)
+        .agg(
+            clip_lower=("intraday_diff", lambda values: values.quantile(lower_pct / 100.0)),
+            clip_upper=("intraday_diff", lambda values: values.quantile(upper_pct / 100.0)),
+        )
+    )
+    clipped = samples_df.merge(
+        bounds_df,
+        how="left",
+        on=["stock_group", "gap_bucket_key"],
+    )
+    clipped = clipped[
+        clipped["intraday_diff"].between(
+            clipped["clip_lower"],
+            clipped["clip_upper"],
+            inclusive="both",
+        )
+    ].copy()
+    return clipped, bounds_df
+
+
+def _validate_selected_groups(selected_groups: Sequence[str] | None) -> tuple[StockGroup, ...]:
+    if selected_groups is None:
+        return STOCK_GROUP_ORDER
+    validated: list[StockGroup] = []
+    seen: set[str] = set()
+    allowed = set(STOCK_GROUP_ORDER)
+    for group in selected_groups:
+        if group not in allowed:
+            raise ValueError(f"Unsupported stock group: {group}")
+        if group in seen:
+            continue
+        validated.append(cast(StockGroup, group))
+        seen.add(group)
+    if not validated:
+        raise ValueError("selected_groups must contain at least one supported group")
+    return tuple(validated)
+
+
+def _validate_inputs(
+    *,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+    sample_size: int,
+    clip_percentiles: tuple[float, float],
+) -> None:
+    if gap_threshold_1 <= 0:
+        raise ValueError("gap_threshold_1 must be positive")
+    if gap_threshold_2 <= gap_threshold_1:
+        raise ValueError("gap_threshold_2 must be greater than gap_threshold_1")
+    if sample_size < 0:
+        raise ValueError("sample_size must be non-negative")
+    lower, upper = clip_percentiles
+    if lower < 0 or upper > 100 or lower >= upper:
+        raise ValueError("clip_percentiles must satisfy 0 <= lower < upper <= 100")
+
+
+def get_topix_available_date_range(db_path: str) -> tuple[str | None, str | None]:
+    """Return the available TOPIX date range from market.duckdb."""
+    with _open_analysis_connection(db_path) as ctx:
+        return _fetch_date_range(ctx.connection, table_name="topix_data")
+
+
+def run_topix_gap_intraday_distribution(
+    db_path: str,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    gap_threshold_1: float = 0.01,
+    gap_threshold_2: float = 0.02,
+    selected_groups: Sequence[str] | None = None,
+    sample_size: int = 2000,
+    clip_percentiles: tuple[float, float] = (1.0, 99.0),
+) -> TopixGapIntradayDistributionResult:
+    """Run the TOPIX gap / intraday distribution analysis from market.duckdb."""
+    _validate_inputs(
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+        sample_size=sample_size,
+        clip_percentiles=clip_percentiles,
+    )
+    validated_groups = _validate_selected_groups(selected_groups)
+
+    with _open_analysis_connection(db_path) as ctx:
+        conn = ctx.connection
+        available_start, available_end = _fetch_date_range(conn, table_name="topix_data")
+        analysis_start, analysis_end = _fetch_date_range(
+            conn,
+            table_name="topix_data",
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        day_counts_df, excluded_count = _query_day_counts(
+            conn,
+            start_date=start_date,
+            end_date=end_date,
+            gap_threshold_1=gap_threshold_1,
+            gap_threshold_2=gap_threshold_2,
+        )
+        summary_df = _query_summary(
+            conn,
+            start_date=start_date,
+            end_date=end_date,
+            gap_threshold_1=gap_threshold_1,
+            gap_threshold_2=gap_threshold_2,
+            selected_groups=validated_groups,
+        )
+        samples_df = _query_samples(
+            conn,
+            start_date=start_date,
+            end_date=end_date,
+            gap_threshold_1=gap_threshold_1,
+            gap_threshold_2=gap_threshold_2,
+            selected_groups=validated_groups,
+            sample_size=sample_size,
+        )
+
+    day_counts_df = _complete_day_counts(
+        day_counts_df,
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+    )
+    summary_df = _complete_summary_grid(
+        summary_df,
+        selected_groups=validated_groups,
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+    )
+    samples_df = samples_df.copy()
+    if samples_df.empty:
+        samples_df["gap_bucket_label"] = pd.Series(dtype="object")
+    else:
+        samples_df["gap_bucket_label"] = samples_df["gap_bucket_key"].map(
+            lambda value: format_gap_bucket_label(
+                cast(GapBucketKey, value),
+                gap_threshold_1=gap_threshold_1,
+                gap_threshold_2=gap_threshold_2,
+            )
+        )
+    clipped_samples_df, clip_bounds_df = _apply_sample_clipping(
+        samples_df,
+        clip_percentiles=clip_percentiles,
+    )
+    if not clip_bounds_df.empty:
+        clip_bounds_df["gap_bucket_label"] = clip_bounds_df["gap_bucket_key"].map(
+            lambda value: format_gap_bucket_label(
+                cast(GapBucketKey, value),
+                gap_threshold_1=gap_threshold_1,
+                gap_threshold_2=gap_threshold_2,
+            )
+        )
+
+    return TopixGapIntradayDistributionResult(
+        db_path=db_path,
+        source_mode=ctx.source_mode,
+        source_detail=ctx.source_detail,
+        available_start_date=available_start,
+        available_end_date=available_end,
+        analysis_start_date=analysis_start,
+        analysis_end_date=analysis_end,
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+        selected_groups=validated_groups,
+        excluded_topix_days_without_prev_close=excluded_count,
+        day_counts_df=day_counts_df,
+        summary_df=summary_df,
+        samples_df=samples_df,
+        clipped_samples_df=clipped_samples_df,
+        clip_bounds_df=clip_bounds_df,
+    )

--- a/apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py
+++ b/apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py
@@ -258,13 +258,13 @@ def _grouped_stock_days_cte(
                 close,
                 prev_close,
                 CASE
-                    WHEN prev_close IS NULL OR prev_close = 0 THEN NULL
+                    WHEN open IS NULL OR prev_close IS NULL OR prev_close = 0 THEN NULL
                     WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_ge_threshold_2'
                     WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_threshold_1_to_2'
                     ELSE 'gap_lt_threshold_1'
                 END AS gap_bucket_key,
                 CASE
-                    WHEN prev_close IS NULL OR prev_close = 0 THEN NULL
+                    WHEN open IS NULL OR prev_close IS NULL OR prev_close = 0 THEN NULL
                     ELSE (open - prev_close) / prev_close
                 END AS gap_return
                 FROM (
@@ -360,7 +360,9 @@ def _query_day_counts(
     gap_threshold_2: float,
 ) -> tuple[pd.DataFrame, int]:
     gap_where_sql, gap_params = _date_where_clause("date", start_date, end_date)
-    excluded_conditions: list[str] = ["prev_close IS NULL OR prev_close = 0"]
+    excluded_conditions: list[str] = [
+        "open IS NULL OR prev_close IS NULL OR prev_close = 0"
+    ]
     excluded_params: list[str] = []
     if start_date:
         excluded_conditions.insert(0, "date >= ?")
@@ -373,7 +375,7 @@ def _query_day_counts(
         WITH topix_with_gap AS (
             SELECT
                 CASE
-                    WHEN prev_close IS NULL OR prev_close = 0 THEN NULL
+                    WHEN open IS NULL OR prev_close IS NULL OR prev_close = 0 THEN NULL
                     WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_ge_threshold_2'
                     WHEN abs((open - prev_close) / prev_close) >= ? THEN 'gap_threshold_1_to_2'
                     ELSE 'gap_lt_threshold_1'
@@ -401,6 +403,7 @@ def _query_day_counts(
         SELECT COUNT(*) AS excluded_count
         FROM (
             SELECT
+                open,
                 LAG(close) OVER (ORDER BY date) AS prev_close,
                 date
             FROM topix_data
@@ -452,6 +455,35 @@ def _query_summary(
         GROUP BY stock_group, gap_bucket_key
     """
     return cast(pd.DataFrame, conn.execute(sql, params).fetchdf())
+
+
+def _query_analysis_date_range(
+    conn: Any,
+    *,
+    start_date: str | None,
+    end_date: str | None,
+    gap_threshold_1: float,
+    gap_threshold_2: float,
+    selected_groups: Sequence[StockGroup],
+) -> tuple[str | None, str | None]:
+    cte_sql, params = _grouped_stock_days_cte(
+        start_date=start_date,
+        end_date=end_date,
+        gap_threshold_1=gap_threshold_1,
+        gap_threshold_2=gap_threshold_2,
+        selected_groups=selected_groups,
+    )
+    row = conn.execute(
+        f"""
+        {cte_sql}
+        SELECT MIN(date) AS min_date, MAX(date) AS max_date
+        FROM grouped_stock_days
+        """,
+        params,
+    ).fetchone()
+    min_date = str(row[0]) if row and row[0] else None
+    max_date = str(row[1]) if row and row[1] else None
+    return min_date, max_date
 
 
 def _query_samples(
@@ -668,11 +700,13 @@ def run_topix_gap_intraday_distribution(
     with _open_analysis_connection(db_path) as ctx:
         conn = ctx.connection
         available_start, available_end = _fetch_date_range(conn, table_name="topix_data")
-        analysis_start, analysis_end = _fetch_date_range(
+        analysis_start, analysis_end = _query_analysis_date_range(
             conn,
-            table_name="topix_data",
             start_date=start_date,
             end_date=end_date,
+            gap_threshold_1=gap_threshold_1,
+            gap_threshold_2=gap_threshold_2,
+            selected_groups=validated_groups,
         )
 
         day_counts_df, excluded_count = _query_day_counts(

--- a/apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py
+++ b/apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py
@@ -135,7 +135,7 @@ def test_gap_boundaries_and_missing_prev_close_are_handled(analytics_db_path: st
     assert result.excluded_topix_days_without_prev_close == 1
     assert result.available_start_date == "2024-01-01"
     assert result.available_end_date == "2024-01-04"
-    assert result.analysis_start_date == "2024-01-01"
+    assert result.analysis_start_date == "2024-01-02"
     assert result.analysis_end_date == "2024-01-04"
 
 
@@ -195,6 +195,45 @@ def test_selected_date_range_filters_results(analytics_db_path: str) -> None:
     assert result.analysis_start_date == "2024-01-03"
     assert result.analysis_end_date == "2024-01-04"
     assert tuple(result.summary_df["stock_group"].unique()) == ("PRIME", "TOPIX500")
+
+
+def test_null_topix_open_is_excluded_from_gap_buckets(analytics_db_path: str) -> None:
+    conn = duckdb.connect(analytics_db_path)
+    conn.execute("UPDATE topix_data SET open = NULL WHERE date = ?", ["2024-01-02"])
+    conn.close()
+
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME"],
+        sample_size=10,
+    )
+
+    day_counts = dict(
+        zip(result.day_counts_df["gap_bucket_key"], result.day_counts_df["day_count"], strict=True)
+    )
+    assert day_counts == {
+        "gap_lt_threshold_1": 1,
+        "gap_threshold_1_to_2": 0,
+        "gap_ge_threshold_2": 1,
+    }
+    assert result.excluded_topix_days_without_prev_close == 2
+    assert result.analysis_start_date == "2024-01-03"
+    assert result.analysis_end_date == "2024-01-04"
+
+
+def test_analysis_range_is_empty_when_no_rows_are_analyzable(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        start_date="2024-01-01",
+        end_date="2024-01-01",
+        selected_groups=["PRIME"],
+        sample_size=10,
+    )
+
+    assert result.analysis_start_date is None
+    assert result.analysis_end_date is None
+    assert result.samples_df.empty
+    assert result.summary_df["sample_count"].sum() == 0
 
 
 def test_sampling_is_deterministic(analytics_db_path: str) -> None:

--- a/apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py
+++ b/apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from src.domains.analytics import topix_gap_intraday_distribution as analysis_module
+from src.domains.analytics.topix_gap_intraday_distribution import (
+    format_gap_bucket_label,
+    get_topix_available_date_range,
+    run_topix_gap_intraday_distribution,
+)
+
+
+def _build_market_db(db_path: Path) -> str:
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE stocks (
+            code TEXT PRIMARY KEY,
+            company_name TEXT NOT NULL,
+            company_name_english TEXT,
+            market_code TEXT NOT NULL,
+            market_name TEXT NOT NULL,
+            sector_17_code TEXT NOT NULL,
+            sector_17_name TEXT NOT NULL,
+            sector_33_code TEXT NOT NULL,
+            sector_33_name TEXT NOT NULL,
+            scale_category TEXT,
+            listed_date TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE stock_data (
+            code TEXT NOT NULL,
+            date TEXT NOT NULL,
+            open DOUBLE,
+            high DOUBLE,
+            low DOUBLE,
+            close DOUBLE,
+            volume BIGINT,
+            adjustment_factor DOUBLE,
+            created_at TEXT,
+            PRIMARY KEY (code, date)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE topix_data (
+            date TEXT PRIMARY KEY,
+            open DOUBLE,
+            high DOUBLE,
+            low DOUBLE,
+            close DOUBLE,
+            created_at TEXT
+        )
+        """
+    )
+
+    stocks = [
+        ("72030", "Topix500 Prime", "TOPIX500 PRIME", "0111", "プライム", "1", "A", "1", "A", "TOPIX Large70", "2000-01-01", None, None),
+        ("11110", "Prime Ex", "PRIME EX", "0111", "プライム", "1", "A", "1", "A", "-", "2000-01-01", None, None),
+        ("22220", "Standard", "STANDARD", "0112", "スタンダード", "1", "A", "1", "A", "-", "2000-01-01", None, None),
+        ("33330", "Growth", "GROWTH", "0113", "グロース", "1", "A", "1", "A", "-", "2000-01-01", None, None),
+    ]
+    conn.executemany(
+        "INSERT INTO stocks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        stocks,
+    )
+
+    topix_rows = [
+        ("2024-01-01", 100.0, 101.0, 99.0, 100.0, None),
+        ("2024-01-02", 101.0, 101.5, 99.5, 100.0, None),
+        ("2024-01-03", 98.0, 99.0, 97.0, 97.0, None),
+        ("2024-01-04", 97.5, 98.5, 97.0, 98.0, None),
+    ]
+    conn.executemany("INSERT INTO topix_data VALUES (?, ?, ?, ?, ?, ?)", topix_rows)
+
+    stock_rows = [
+        ("7203", "2024-01-02", 10.0, 12.5, 9.5, 12.0, 1000, 1.0, None),
+        ("72030", "2024-01-02", 10.0, 10.5, 4.5, 5.0, 1000, 1.0, None),
+        ("11110", "2024-01-02", 20.0, 20.5, 17.5, 18.0, 1000, 1.0, None),
+        ("22220", "2024-01-02", 30.0, 30.0, 30.0, 30.0, 1000, 1.0, None),
+        ("33330", "2024-01-02", 40.0, 41.0, 34.0, 35.0, 1000, 1.0, None),
+        ("7203", "2024-01-03", 12.0, 16.5, 11.5, 16.0, 1000, 1.0, None),
+        ("11110", "2024-01-03", 18.0, 19.5, 17.5, 19.0, 1000, 1.0, None),
+        ("22220", "2024-01-03", 30.0, 30.5, 28.5, 29.0, 1000, 1.0, None),
+        ("33330", "2024-01-03", 35.0, 35.5, 34.5, 35.0, 1000, 1.0, None),
+        ("7203", "2024-01-04", 16.0, 16.5, 14.5, 15.0, 1000, 1.0, None),
+        ("11110", "2024-01-04", 19.0, 22.5, 18.5, 22.0, 1000, 1.0, None),
+        ("22220", "2024-01-04", 29.0, 29.5, 26.5, 27.0, 1000, 1.0, None),
+        ("33330", "2024-01-04", 35.0, 36.5, 34.5, 36.0, 1000, 1.0, None),
+    ]
+    conn.executemany("INSERT INTO stock_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", stock_rows)
+    conn.close()
+    return str(db_path)
+
+
+@pytest.fixture
+def analytics_db_path(tmp_path: Path) -> str:
+    return _build_market_db(tmp_path / "market.duckdb")
+
+
+def _summary_row(result, stock_group: str, bucket_key: str) -> pd.Series:
+    row = result.summary_df[
+        (result.summary_df["stock_group"] == stock_group)
+        & (result.summary_df["gap_bucket_key"] == bucket_key)
+    ]
+    assert len(row) == 1
+    return row.iloc[0]
+
+
+def test_gap_boundaries_and_missing_prev_close_are_handled(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        sample_size=10,
+    )
+
+    day_counts = dict(
+        zip(result.day_counts_df["gap_bucket_key"], result.day_counts_df["day_count"], strict=True)
+    )
+    assert day_counts == {
+        "gap_lt_threshold_1": 1,
+        "gap_threshold_1_to_2": 1,
+        "gap_ge_threshold_2": 1,
+    }
+    assert result.excluded_topix_days_without_prev_close == 1
+    assert result.available_start_date == "2024-01-01"
+    assert result.available_end_date == "2024-01-04"
+    assert result.analysis_start_date == "2024-01-01"
+    assert result.analysis_end_date == "2024-01-04"
+
+
+def test_group_classification_and_4digit_preference(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        sample_size=10,
+    )
+
+    prime_mid = _summary_row(result, "PRIME", "gap_threshold_1_to_2")
+    standard_mid = _summary_row(result, "STANDARD", "gap_threshold_1_to_2")
+    growth_mid = _summary_row(result, "GROWTH", "gap_threshold_1_to_2")
+    topix500_mid = _summary_row(result, "TOPIX500", "gap_threshold_1_to_2")
+    prime_ex_mid = _summary_row(result, "PRIME ex TOPIX500", "gap_threshold_1_to_2")
+
+    assert prime_mid["sample_count"] == 2
+    assert prime_mid["up_count"] == 1
+    assert prime_mid["down_count"] == 1
+    assert prime_mid["flat_count"] == 0
+    assert prime_mid["mean_intraday_diff"] == pytest.approx(0.0)
+    assert prime_mid["median_intraday_diff"] == pytest.approx(0.0)
+    assert prime_mid["p50_intraday_diff"] == pytest.approx(0.0)
+
+    assert standard_mid["sample_count"] == 1
+    assert standard_mid["flat_count"] == 1
+    assert standard_mid["flat_ratio"] == pytest.approx(1.0)
+
+    assert growth_mid["sample_count"] == 1
+    assert growth_mid["down_ratio"] == pytest.approx(1.0)
+
+    assert topix500_mid["sample_count"] == 1
+    assert topix500_mid["up_count"] == 1
+    assert topix500_mid["mean_intraday_diff"] == pytest.approx(2.0)
+
+    assert prime_ex_mid["sample_count"] == 1
+    assert prime_ex_mid["down_count"] == 1
+    assert prime_ex_mid["mean_intraday_diff"] == pytest.approx(-2.0)
+
+
+def test_selected_date_range_filters_results(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        start_date="2024-01-03",
+        end_date="2024-01-04",
+        selected_groups=["PRIME", "TOPIX500"],
+        sample_size=10,
+    )
+
+    day_counts = dict(
+        zip(result.day_counts_df["gap_bucket_key"], result.day_counts_df["day_count"], strict=True)
+    )
+    assert day_counts == {
+        "gap_lt_threshold_1": 1,
+        "gap_threshold_1_to_2": 0,
+        "gap_ge_threshold_2": 1,
+    }
+    assert result.analysis_start_date == "2024-01-03"
+    assert result.analysis_end_date == "2024-01-04"
+    assert tuple(result.summary_df["stock_group"].unique()) == ("PRIME", "TOPIX500")
+
+
+def test_sampling_is_deterministic(analytics_db_path: str) -> None:
+    first = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME"],
+        sample_size=1,
+    )
+    second = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME"],
+        sample_size=1,
+    )
+
+    pdt.assert_frame_equal(first.samples_df.reset_index(drop=True), second.samples_df.reset_index(drop=True))
+
+
+def test_clip_bounds_and_clipped_samples_are_returned(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME"],
+        sample_size=10,
+        clip_percentiles=(25.0, 75.0),
+    )
+
+    assert not result.clip_bounds_df.empty
+    assert len(result.clipped_samples_df) <= len(result.samples_df)
+    assert {"clip_lower", "clip_upper"} <= set(result.clip_bounds_df.columns)
+
+
+def test_get_topix_available_date_range_reads_metadata(analytics_db_path: str) -> None:
+    assert get_topix_available_date_range(analytics_db_path) == ("2024-01-01", "2024-01-04")
+
+
+def test_lock_contention_falls_back_to_snapshot(analytics_db_path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    original_connect = analysis_module._connect_duckdb
+    attempts = {"count": 0}
+    wal_path = Path(f"{analytics_db_path}.wal")
+    wal_path.write_text("wal", encoding="utf-8")
+
+    def flaky_connect(db_path: str, *, read_only: bool = True):
+        assert read_only is True
+        if db_path == analytics_db_path and attempts["count"] == 0:
+            attempts["count"] += 1
+            raise duckdb.IOException(
+                'IO Error: Could not set lock on file "market.duckdb": Conflicting lock is held'
+            )
+        if db_path != analytics_db_path:
+            assert Path(f"{db_path}.wal").exists()
+        return original_connect(db_path, read_only=read_only)
+
+    monkeypatch.setattr(analysis_module, "_connect_duckdb", flaky_connect)
+
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME"],
+        sample_size=2,
+    )
+
+    assert result.source_mode == "snapshot"
+    assert "temporary snapshot copied from" in result.source_detail
+
+
+def test_non_lock_connection_error_is_propagated(
+    analytics_db_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failing_connect(db_path: str, *, read_only: bool = True):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(analysis_module, "_connect_duckdb", failing_connect)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        get_topix_available_date_range(analytics_db_path)
+
+
+def test_sample_size_zero_returns_empty_samples(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME"],
+        sample_size=0,
+    )
+
+    assert result.samples_df.empty
+    assert result.clipped_samples_df.empty
+    assert result.clip_bounds_df.empty
+    assert "gap_bucket_label" in result.samples_df.columns
+
+
+def test_selected_groups_are_deduplicated(analytics_db_path: str) -> None:
+    result = run_topix_gap_intraday_distribution(
+        analytics_db_path,
+        selected_groups=["PRIME", "PRIME", "TOPIX500"],
+        sample_size=1,
+    )
+
+    assert result.selected_groups == ("PRIME", "TOPIX500")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"selected_groups": []}, "selected_groups must contain at least one supported group"),
+        ({"selected_groups": ["INVALID"]}, "Unsupported stock group"),
+        ({"gap_threshold_1": 0.0}, "gap_threshold_1 must be positive"),
+        (
+            {"gap_threshold_1": 0.02, "gap_threshold_2": 0.02},
+            "gap_threshold_2 must be greater than gap_threshold_1",
+        ),
+        ({"sample_size": -1}, "sample_size must be non-negative"),
+        (
+            {"clip_percentiles": (99.0, 99.0)},
+            "clip_percentiles must satisfy 0 <= lower < upper <= 100",
+        ),
+    ],
+)
+def test_invalid_inputs_raise(
+    analytics_db_path: str,
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        run_topix_gap_intraday_distribution(analytics_db_path, **kwargs)
+
+
+def test_gap_bucket_labels_support_fractional_thresholds() -> None:
+    assert (
+        format_gap_bucket_label(
+            "gap_threshold_1_to_2",
+            gap_threshold_1=0.015,
+            gap_threshold_2=0.0275,
+        )
+        == "1.5% <= |gap| < 2.75%"
+    )


### PR DESCRIPTION
## Summary
- add a DuckDB-backed analytics domain for TOPIX gap vs stock intraday distribution analysis
- add a marimo playground notebook for interactive visualization of bucket counts, up/down/flat ratios, and sampled distributions
- add unit tests for lock fallback, code dedupe, input validation, deterministic sampling, and label formatting

## Testing
- uv run --project apps/bt pytest -q apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py
- uv run --project apps/bt ruff check apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py apps/bt/notebooks/playground/topix_gap_intraday_distribution_playground.py
- uv run --project apps/bt pyright apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py
- coverage run --branch -m pytest apps/bt/tests/unit/domains/analytics/test_topix_gap_intraday_distribution.py
- coverage report -m apps/bt/src/domains/analytics/topix_gap_intraday_distribution.py