### PR TITLE
feat: add VWEMA indicator and support as mean-reversion baseline (backend + frontend + tests)

### DIFF
--- a/apps/bt/src/domains/strategy/indicators/__init__.py
+++ b/apps/bt/src/domains/strategy/indicators/__init__.py
@@ -6,6 +6,7 @@ from src.domains.strategy.indicators.calculations import (
     compute_risk_adjusted_return,
     compute_trading_value_ma,
     compute_volume_mas,
+    compute_volume_weighted_ema,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "compute_risk_adjusted_return",
     "compute_trading_value_ma",
     "compute_volume_mas",
+    "compute_volume_weighted_ema",
 ]

--- a/apps/bt/src/domains/strategy/indicators/calculations.py
+++ b/apps/bt/src/domains/strategy/indicators/calculations.py
@@ -61,6 +61,21 @@ def compute_trading_value_ma(
     return ma
 
 
+def compute_volume_weighted_ema(
+    close: pd.Series[float],
+    volume: pd.Series[float],
+    period: int,
+) -> pd.Series[float]:
+    """出来高加重EMA (VWEMA)。
+
+    定義: EMA(close * volume, period) / EMA(volume, period)
+    """
+    weighted_price = close * volume
+    weighted_price_ema: pd.Series[float] = vbt.MA.run(weighted_price, period, ewm=True).ma
+    volume_ema: pd.Series[float] = vbt.MA.run(volume, period, ewm=True).ma
+    return weighted_price_ema / volume_ema.replace(0, np.nan)
+
+
 def compute_nbar_support(
     low: pd.Series[float],
     period: int,

--- a/apps/bt/src/domains/strategy/indicators/indicator_registry.py
+++ b/apps/bt/src/domains/strategy/indicators/indicator_registry.py
@@ -14,6 +14,7 @@ from src.domains.strategy.indicators import (
     compute_risk_adjusted_return,
     compute_trading_value_ma,
     compute_volume_mas,
+    compute_volume_weighted_ema,
 )
 
 
@@ -100,6 +101,16 @@ def _compute_ema(
     key = _make_key("ema", period=period)
     return key, _series_to_records(ma, nan_handling)
 
+
+
+
+def _compute_vwema(
+    ohlcv: pd.DataFrame, params: dict[str, Any], nan_handling: str
+) -> tuple[str, list[dict[str, Any]]]:
+    period = params["period"]
+    vwema = compute_volume_weighted_ema(ohlcv["Close"], ohlcv["Volume"], period)
+    key = _make_key("vwema", period=period)
+    return key, _series_to_records(vwema, nan_handling)
 
 def _compute_rsi(
     ohlcv: pd.DataFrame, params: dict[str, Any], nan_handling: str
@@ -256,6 +267,7 @@ def _compute_risk_adjusted_return(
 INDICATOR_REGISTRY: dict[str, ComputeFn] = {
     "sma": _compute_sma,
     "ema": _compute_ema,
+    "vwema": _compute_vwema,
     "rsi": _compute_rsi,
     "macd": _compute_macd,
     "ppo": _compute_ppo,

--- a/apps/bt/src/domains/strategy/signals/mean_reversion.py
+++ b/apps/bt/src/domains/strategy/signals/mean_reversion.py
@@ -8,6 +8,20 @@ import pandas as pd
 import vectorbt as vbt
 from loguru import logger
 
+from src.domains.strategy.indicators import compute_volume_weighted_ema
+
+
+
+
+def _compute_baseline(ohlc_data: pd.DataFrame, baseline_type: str, baseline_period: int) -> pd.Series:
+    close = ohlc_data["Close"]
+    if baseline_type == "sma":
+        return vbt.MA.run(close, baseline_period).ma
+    if baseline_type == "ema":
+        return vbt.MA.run(close, baseline_period, ewm=True).ma
+    if baseline_type == "vwema":
+        return compute_volume_weighted_ema(close, ohlc_data["Volume"], baseline_period)
+    raise ValueError(f"未対応のベースラインタイプ: {baseline_type} (sma/ema/vwemaのみ)")
 
 def deviation_signal(
     price: pd.Series,
@@ -122,7 +136,7 @@ def mean_reversion_entry_signal(
 
     Args:
         ohlc_data: OHLCVデータ（Close含む）
-        baseline_type: ベースラインタイプ（"sma" or "ema"）
+        baseline_type: ベースラインタイプ（"sma" or "ema" or "vwema"）
         baseline_period: ベースライン期間
         deviation_threshold: 乖離率閾値（例: 0.2 = 20%乖離）
         deviation_direction: 乖離方向（"below" or "above"）
@@ -141,14 +155,7 @@ def mean_reversion_entry_signal(
     )
 
     close = ohlc_data["Close"]
-
-    # ベースライン計算（VectorBT使用）
-    if baseline_type == "sma":
-        baseline = vbt.MA.run(close, baseline_period).ma
-    elif baseline_type == "ema":
-        baseline = vbt.MA.run(close, baseline_period, ewm=True).ma
-    else:
-        raise ValueError(f"未対応のベースラインタイプ: {baseline_type} (sma/emaのみ)")
+    baseline = _compute_baseline(ohlc_data, baseline_type, baseline_period)
 
     # 乖離シグナル生成
     return deviation_signal(close, baseline, deviation_threshold, deviation_direction)
@@ -169,7 +176,7 @@ def mean_reversion_exit_signal(
 
     Args:
         ohlc_data: OHLCVデータ（High、Low、Close含む）
-        baseline_type: ベースラインタイプ（"sma" or "ema"）
+        baseline_type: ベースラインタイプ（"sma" or "ema" or "vwema"）
         baseline_period: ベースライン期間
         recovery_direction: 回復方向（"above" or "below"）
         recovery_price: 回復価格（"high"、"low"、"close"）
@@ -188,14 +195,7 @@ def mean_reversion_exit_signal(
     )
 
     close = ohlc_data["Close"]
-
-    # ベースライン計算（VectorBT使用）
-    if baseline_type == "sma":
-        baseline = vbt.MA.run(close, baseline_period).ma
-    elif baseline_type == "ema":
-        baseline = vbt.MA.run(close, baseline_period, ewm=True).ma
-    else:
-        raise ValueError(f"未対応のベースラインタイプ: {baseline_type} (sma/emaのみ)")
+    baseline = _compute_baseline(ohlc_data, baseline_type, baseline_period)
 
     # 回復価格選択
     if recovery_price == "high":
@@ -235,7 +235,7 @@ def mean_reversion_combined_signal(
 
     Args:
         ohlc_data: OHLCVデータ（High、Low、Close含む）
-        baseline_type: ベースラインタイプ（"sma" or "ema"）
+        baseline_type: ベースラインタイプ（"sma" or "ema" or "vwema"）
         baseline_period: ベースライン期間
         deviation_threshold: 乖離率閾値（0.0で無効化、例: 0.2 = 20%乖離）
         deviation_direction: 乖離方向（"below" or "above"）
@@ -266,13 +266,7 @@ def mean_reversion_combined_signal(
     if close.empty:
         return pd.Series([], dtype=bool)
 
-    # ベースライン計算（VectorBT使用）
-    if baseline_type == "sma":
-        baseline = vbt.MA.run(close, baseline_period).ma
-    elif baseline_type == "ema":
-        baseline = vbt.MA.run(close, baseline_period, ewm=True).ma
-    else:
-        raise ValueError(f"未対応のベースラインタイプ: {baseline_type} (sma/emaのみ)")
+    baseline = _compute_baseline(ohlc_data, baseline_type, baseline_period)
 
     # 乖離シグナル（deviation_threshold=0.0で無効化）
     if deviation_threshold > 0.0:

--- a/apps/bt/src/entrypoints/http/schemas/indicators.py
+++ b/apps/bt/src/entrypoints/http/schemas/indicators.py
@@ -25,6 +25,12 @@ class EMAParams(BaseModel):
     period: int = Field(ge=1, le=500, description="移動平均期間")
 
 
+class VWEMAParams(BaseModel):
+    """VWEMAパラメータ"""
+
+    period: int = Field(ge=1, le=500, description="出来高加重EMA期間")
+
+
 class RSIParams(BaseModel):
     """RSIパラメータ"""
 
@@ -104,6 +110,7 @@ class RiskAdjustedReturnParams(BaseModel):
 INDICATOR_PARAMS_MAP: dict[str, type[BaseModel]] = {
     "sma": SMAParams,
     "ema": EMAParams,
+    "vwema": VWEMAParams,
     "rsi": RSIParams,
     "macd": MACDParams,
     "ppo": PPOParams,
@@ -119,6 +126,7 @@ INDICATOR_PARAMS_MAP: dict[str, type[BaseModel]] = {
 INDICATOR_TYPES = Literal[
     "sma",
     "ema",
+    "vwema",
     "rsi",
     "macd",
     "ppo",

--- a/apps/bt/src/shared/models/signals/breakout.py
+++ b/apps/bt/src/shared/models/signals/breakout.py
@@ -80,7 +80,7 @@ class BreakoutSignalParams(BaseSignalParams):
 
 class MeanReversionSignalParams(BaseSignalParams):
     """平均回帰シグナルパラメータ（汎用・シンプル設計）"""
-    baseline_type: str = Field(default="sma", description="基準線タイプ（sma/ema）")
+    baseline_type: str = Field(default="sma", description="基準線タイプ（sma/ema/vwema）")
     baseline_period: int = Field(default=25, gt=0, le=500, description="基準線期間")
     deviation_threshold: float = Field(
         default=0.2,

--- a/apps/bt/src/shared/models/validators.py
+++ b/apps/bt/src/shared/models/validators.py
@@ -92,7 +92,7 @@ DIRECTION_CHOICES = {
 
 INDICATOR_CHOICES = {
     "ma_type": ["sma", "ema"],
-    "baseline_type": ["sma", "ema"],
+    "baseline_type": ["sma", "ema", "vwema"],
     "price_column": ["high", "low", "close"],
     "ratio_type": ["sharpe", "sortino"],
     "crossover_type": ["sma", "rsi", "macd", "ema"],

--- a/apps/bt/tests/unit/server/test_indicator_schemas.py
+++ b/apps/bt/tests/unit/server/test_indicator_schemas.py
@@ -44,6 +44,12 @@ class TestParamsModels:
         p = EMAParams(period=12)
         assert p.period == 12
 
+    def test_vwema_params_valid(self):
+        from src.entrypoints.http.schemas.indicators import VWEMAParams
+
+        p = VWEMAParams(period=20)
+        assert p.period == 20
+
     def test_rsi_params_default(self):
         p = RSIParams()
         assert p.period == 14
@@ -138,14 +144,14 @@ class TestIndicatorSpec:
         with pytest.raises(ValidationError):
             IndicatorSpec(type="unknown", params={})
 
-    def test_all_12_types(self):
+    def test_all_13_types(self):
         types = [
-            "sma", "ema", "rsi", "macd", "ppo", "bollinger",
+            "sma", "ema", "vwema", "rsi", "macd", "ppo", "bollinger",
             "atr", "atr_support", "nbar_support", "volume_comparison",
             "trading_value_ma", "risk_adjusted_return",
         ]
         for t in types:
-            spec = IndicatorSpec(type=t, params={} if t not in ("sma", "ema") else {"period": 20})
+            spec = IndicatorSpec(type=t, params={} if t not in ("sma", "ema", "vwema") else {"period": 20})
             assert spec.type == t
 
 

--- a/apps/bt/tests/unit/strategies/signals/test_mean_reversion.py
+++ b/apps/bt/tests/unit/strategies/signals/test_mean_reversion.py
@@ -225,6 +225,21 @@ class TestMeanReversionEntrySignal:
         assert signal.dtype == bool
         assert len(signal) == len(self.ohlc_data)
 
+    def test_vwema_baseline(self):
+        """VWEMA基準線でのテスト"""
+        signal = mean_reversion_combined_signal(
+            self.ohlc_data,
+            baseline_type="vwema",
+            baseline_period=25,
+            deviation_threshold=0.2,
+            deviation_direction="below",
+            recovery_price="close",
+            recovery_direction="above",
+        )
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
+
     def test_invalid_baseline_type(self):
         """未対応のベースラインタイプでエラー"""
         with pytest.raises(ValueError, match="未対応のベースラインタイプ"):
@@ -320,6 +335,21 @@ class TestMeanReversionExitSignal:
         assert isinstance(signal, pd.Series)
         assert signal.dtype == bool
         assert len(signal) == len(self.ohlc_data)
+
+    def test_vwema_baseline(self):
+        """VWEMA基準線でのテスト"""
+        signal = mean_reversion_combined_signal(
+            self.ohlc_data,
+            baseline_type="vwema",
+            baseline_period=25,
+            deviation_threshold=0.2,
+            deviation_direction="below",
+            recovery_price="close",
+            recovery_direction="above",
+        )
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
 
     def test_invalid_baseline_type(self):
         """未対応のベースラインタイプでエラー"""
@@ -424,6 +454,21 @@ class TestMeanReversionCombinedSignal:
         assert isinstance(signal, pd.Series)
         assert signal.dtype == bool
         assert signal.any()
+
+    def test_vwema_baseline(self):
+        """VWEMA基準線でのテスト"""
+        signal = mean_reversion_combined_signal(
+            self.ohlc_data,
+            baseline_type="vwema",
+            baseline_period=25,
+            deviation_threshold=0.2,
+            deviation_direction="below",
+            recovery_price="close",
+            recovery_direction="above",
+        )
+
+        assert isinstance(signal, pd.Series)
+        assert signal.dtype == bool
 
     def test_invalid_baseline_type(self):
         """不正なベースラインタイプでエラー"""

--- a/apps/bt/tests/unit/utils/test_indicators.py
+++ b/apps/bt/tests/unit/utils/test_indicators.py
@@ -10,6 +10,7 @@ from src.domains.strategy.indicators.calculations import (
     compute_nbar_support,
     compute_trading_value_ma,
     compute_volume_mas,
+    compute_volume_weighted_ema,
 )
 
 
@@ -161,3 +162,29 @@ class TestComputeNBarSupport:
         empty = pd.Series(dtype=float)
         result = compute_nbar_support(empty, 10)
         assert len(result) == 0
+
+
+class TestComputeVolumeWeightedEMA:
+    """compute_volume_weighted_ema() テスト"""
+
+    def setup_method(self):
+        self.dates = pd.date_range("2024-01-01", periods=50)
+        self.close = pd.Series(np.linspace(100, 120, 50), index=self.dates)
+        self.volume = pd.Series(np.linspace(1000, 5000, 50), index=self.dates)
+
+    def test_returns_series(self):
+        result = compute_volume_weighted_ema(self.close, self.volume, 10)
+        assert isinstance(result, pd.Series)
+        assert len(result) == 50
+
+    def test_constant_price_returns_constant(self):
+        close = pd.Series(np.ones(50) * 100, index=self.dates)
+        result = compute_volume_weighted_ema(close, self.volume, 10)
+        valid = ~pd.isna(result)
+        assert np.allclose(result[valid], 100.0, rtol=1e-6)
+
+    def test_zero_volume_safe(self):
+        volume = self.volume.copy()
+        volume.iloc[0] = 0
+        result = compute_volume_weighted_ema(self.close, volume, 10)
+        assert len(result) == 50

--- a/apps/ts/packages/contracts/openapi/bt-openapi.json
+++ b/apps/ts/packages/contracts/openapi/bt-openapi.json
@@ -4099,6 +4099,7 @@
             "enum": [
               "sma",
               "ema",
+              "vwema",
               "rsi",
               "macd",
               "ppo",

--- a/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
@@ -4603,7 +4603,7 @@ export interface components {
              * @description インジケータータイプ
              * @enum {string}
              */
-            type: "sma" | "ema" | "rsi" | "macd" | "ppo" | "bollinger" | "atr" | "atr_support" | "nbar_support" | "volume_comparison" | "trading_value_ma" | "risk_adjusted_return";
+            type: "sma" | "ema" | "vwema" | "rsi" | "macd" | "ppo" | "bollinger" | "atr" | "atr_support" | "nbar_support" | "volume_comparison" | "trading_value_ma" | "risk_adjusted_return";
         };
         /**
          * IndicesListResponse

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -608,6 +608,20 @@ export function ChartControls() {
               />
             </IndicatorToggle>
 
+
+            <IndicatorToggle
+              label="VWEMA"
+              enabled={settings.indicators.vwema.enabled}
+              onToggle={(enabled) => updateIndicatorSettings('vwema', { enabled })}
+            >
+              <NumberInput
+                label="Period"
+                value={settings.indicators.vwema.period}
+                onChange={(period) => updateIndicatorSettings('vwema', { period })}
+                defaultValue={20}
+              />
+            </IndicatorToggle>
+
             <IndicatorToggle
               label="Bollinger Bands"
               enabled={settings.indicators.bollinger.enabled}

--- a/apps/ts/packages/web/src/components/Chart/StockChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/StockChart.tsx
@@ -48,6 +48,7 @@ interface StockChartProps {
   atrSupport?: IndicatorValue[];
   nBarSupport?: IndicatorValue[];
   bollingerBands?: BollingerBandsData[];
+  vwema?: IndicatorValue[];
   signalMarkers?: SignalMarkerData[];
 }
 
@@ -158,7 +159,7 @@ function buildCrosshairOHLC(
   };
 }
 
-export function StockChart({ data = [], atrSupport, nBarSupport, bollingerBands, signalMarkers = [] }: StockChartProps) {
+export function StockChart({ data = [], atrSupport, nBarSupport, bollingerBands, vwema, signalMarkers = [] }: StockChartProps) {
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const candlestickSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
@@ -167,6 +168,7 @@ export function StockChart({ data = [], atrSupport, nBarSupport, bollingerBands,
   const atrSupportSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const nBarSupportSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const bollingerUpperSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const vwemaSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   // Signal markers ref (v5 API)
   const signalMarkersRef = useRef<ISeriesMarkersPluginApi<Time> | null>(null);
 
@@ -237,6 +239,7 @@ export function StockChart({ data = [], atrSupport, nBarSupport, bollingerBands,
       atrSupportSeriesRef.current = null;
       nBarSupportSeriesRef.current = null;
       bollingerUpperSeriesRef.current = null;
+      vwemaSeriesRef.current = null;
       signalMarkersRef.current = null;
     };
   }, []); // Remove showVolume dependency
@@ -307,6 +310,24 @@ export function StockChart({ data = [], atrSupport, nBarSupport, bollingerBands,
       }
     }
   }, [settings.indicators.nBarSupport.enabled, nBarSupport]);
+
+  // Handle VWEMA indicator
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    if (settings.indicators.vwema.enabled && vwema && vwema.length > 0) {
+      if (!vwemaSeriesRef.current) {
+        vwemaSeriesRef.current = chartRef.current.addSeries(LineSeries, {
+          color: CHART_COLORS.VWEMA,
+          lineWidth: CHART_LINE_WIDTHS.STANDARD,
+        });
+      }
+      vwemaSeriesRef.current.setData(vwema.map((item) => ({ time: item.time, value: item.value })));
+    } else if (vwemaSeriesRef.current) {
+      chartRef.current.removeSeries(vwemaSeriesRef.current);
+      vwemaSeriesRef.current = null;
+    }
+  }, [settings.indicators.vwema.enabled, vwema]);
 
   // Handle Bollinger Bands indicator (Upper line only)
   useEffect(() => {

--- a/apps/ts/packages/web/src/hooks/useBtIndicators.ts
+++ b/apps/ts/packages/web/src/hooks/useBtIndicators.ts
@@ -64,6 +64,9 @@ export function buildIndicatorSpecs(settings: ChartSettings): BtIndicatorSpec[] 
   if (indicators.ema.enabled) {
     specs.push({ type: 'ema', params: { period: indicators.ema.period } });
   }
+  if (indicators.vwema.enabled) {
+    specs.push({ type: 'vwema', params: { period: indicators.vwema.period } });
+  }
   if (indicators.macd.enabled) {
     specs.push({
       type: 'macd',
@@ -217,6 +220,7 @@ const INDICATOR_KEY_TRANSFORMS: Array<{
 }> = [
   { prefix: 'sma_', transform: (r) => ({ target: 'indicator', name: 'sma', data: transformSingleValueRecords(r) }) },
   { prefix: 'ema_', transform: (r) => ({ target: 'indicator', name: 'ema', data: transformSingleValueRecords(r) }) },
+  { prefix: 'vwema_', transform: (r) => ({ target: 'indicator', name: 'vwema', data: transformSingleValueRecords(r) }) },
   { prefix: 'macd_', transform: (r) => ({ target: 'indicator', name: 'macd', data: transformMACDRecords(r) }) },
   { prefix: 'ppo_', transform: (r) => ({ target: 'indicator', name: 'ppo', data: transformPPORecords(r) }) },
   { prefix: 'bollinger_', transform: (r) => ({ target: 'bollinger', data: transformBollingerRecords(r) }) },

--- a/apps/ts/packages/web/src/lib/constants.ts
+++ b/apps/ts/packages/web/src/lib/constants.ts
@@ -13,6 +13,8 @@ export const CHART_COLORS = {
   N_BAR_SUPPORT: '#F23645',
   /** ATR Support line color (red) */
   ATR_SUPPORT: '#ef5350',
+  /** Volume Weighted EMA line color */
+  VWEMA: '#8B5CF6',
   /** Grid line color */
   GRID: '#e1e1e1',
   /** Text color */

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -481,6 +481,7 @@ function ChartsPanelsContent({
                   atrSupport={chartData[settings.displayTimeframe]?.indicators.atrSupport as IndicatorValue[] | undefined}
                   nBarSupport={chartData[settings.displayTimeframe]?.indicators.nBarSupport as IndicatorValue[] | undefined}
                   bollingerBands={chartData[settings.displayTimeframe]?.bollingerBands as BollingerBandsData[] | undefined}
+                  vwema={chartData[settings.displayTimeframe]?.indicators.vwema as IndicatorValue[] | undefined}
                   signalMarkers={signalMarkers?.[settings.displayTimeframe]}
                 />
               </ErrorBoundary>

--- a/apps/ts/packages/web/src/stores/chartStore.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.ts
@@ -46,6 +46,7 @@ export interface ChartSettings {
   indicators: {
     sma: { enabled: boolean; period: number };
     ema: { enabled: boolean; period: number };
+    vwema: { enabled: boolean; period: number };
     macd: { enabled: boolean; fast: number; slow: number; signal: number };
     ppo: { enabled: boolean; fast: number; slow: number; signal: number };
     atrSupport: { enabled: boolean; period: number; multiplier: number };
@@ -146,6 +147,7 @@ export const defaultSettings: ChartSettings = {
   indicators: {
     sma: { enabled: false, period: 20 },
     ema: { enabled: false, period: 12 },
+    vwema: { enabled: false, period: 20 },
     macd: { enabled: false, fast: 12, slow: 26, signal: 9 },
     ppo: { enabled: true, fast: 12, slow: 26, signal: 9 },
     atrSupport: { enabled: false, period: 20, multiplier: 3.0 },
@@ -305,6 +307,7 @@ function normalizeSettings(settings: unknown): ChartSettings {
   const partialSignalOverlay = toPartialRecord<ChartSettings['signalOverlay']>(partial.signalOverlay);
   const partialSma = toPartialRecord<ChartSettings['indicators']['sma']>(partialIndicators.sma);
   const partialEma = toPartialRecord<ChartSettings['indicators']['ema']>(partialIndicators.ema);
+  const partialVwema = toPartialRecord<ChartSettings['indicators']['vwema']>(partialIndicators.vwema);
   const partialMacd = toPartialRecord<ChartSettings['indicators']['macd']>(partialIndicators.macd);
   const partialPpo = toPartialRecord<ChartSettings['indicators']['ppo']>(partialIndicators.ppo);
   const partialAtrSupport = toPartialRecord<ChartSettings['indicators']['atrSupport']>(partialIndicators.atrSupport);
@@ -325,6 +328,10 @@ function normalizeSettings(settings: unknown): ChartSettings {
       ema: {
         enabled: normalizeBoolean(partialEma.enabled, defaultSettings.indicators.ema.enabled),
         period: normalizePositiveInt(partialEma.period, defaultSettings.indicators.ema.period),
+      },
+      vwema: {
+        enabled: normalizeBoolean(partialVwema.enabled, defaultSettings.indicators.vwema.enabled),
+        period: normalizePositiveInt(partialVwema.period, defaultSettings.indicators.vwema.period),
       },
       macd: {
         enabled: normalizeBoolean(partialMacd.enabled, defaultSettings.indicators.macd.enabled),


### PR DESCRIPTION
### Motivation
- Provide a volume-weighted EMA (VWEMA) indicator so charts can show volume-adjusted trend and strategies can use it as a baseline for mean-reversion signals.
- Integrate VWEMA across indicator API, backtest signal system, and frontend chart UI so VWEMA can be requested, rendered, and used in backtests.

### Description
- Backend: implemented `compute_volume_weighted_ema(close, volume, period)` as `EMA(close * volume, period) / EMA(volume, period)` and exported it from `src.domains.strategy.indicators`; added `_compute_vwema` and registered `vwema` in `INDICATOR_REGISTRY`. (files: `calculations.py`, `indicator_registry.py`, `__init__.py`).
- Signals/schema: introduced a shared `_compute_baseline()` helper and extended mean-reversion signals to accept `baseline_type='vwema'`; updated signal models/validators to include `vwema` in allowed choices and added `VWEMAParams` in indicator schemas so API validates `vwema`. (files: `mean_reversion.py`, `breakout.py`, `validators.py`, `indicators.py`).
- Frontend: added `vwema` to chart settings/store, included `vwema` in `useBtIndicators` request/spec building and response mapping, implemented VWEMA line rendering in `StockChart`, and added a VWEMA toggle/period control in chart controls; added color constant for VWEMA. (files: `chartStore.ts`, `useBtIndicators.ts`, `StockChart.tsx`, `ChartControls.tsx`, `constants.ts`, `ChartsPage.tsx`).
- Contracts: regenerated OpenAPI and TS types so `vwema` is included in `INDICATOR_TYPES` and client types (contracts sync performed). (files: `bt-openapi.json`, generated TS types).
- Tests: added unit tests for VWEMA computation and updated existing indicator/schema and mean-reversion tests to cover VWEMA baseline behavior. (files: tests under `apps/bt/tests/unit/...`).

### Testing
- Ran backend unit tests: `uv run --project apps/bt pytest apps/bt/tests/unit/server/test_indicator_schemas.py apps/bt/tests/unit/utils/test_indicators.py apps/bt/tests/unit/strategies/signals/test_mean_reversion.py` and all tests passed (81 passed). ✅
- Regenerated OpenAPI / contracts: `bun run --filter @trading25/contracts bt:sync` completed successfully and updated `packages/contracts`. ✅
- Frontend typecheck: `bun run quality:typecheck` in `apps/ts` failed in this environment due to missing `bun-types` type definition (environment issue, not code). ⚠️
- Frontend dev server: `bun run dev` for the web package failed to start in this environment due to Node/Vite runtime version mismatch; UI rendering could not be validated end-to-end here. ⚠️

Notes: Implementation and tests are committed; frontend typecheck/dev issues are environment-specific and should succeed in CI or local dev with the project’s recommended Bun/Node toolchain installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abbaba38548331a6629cd4eb8db3e2)