### PR TITLE
feat(bt): migrate dataset snapshots to duckdb parquet

### DIFF
--- a/apps/bt/src/application/services/dataset_builder_service.py
+++ b/apps/bt/src/application/services/dataset_builder_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import shutil
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -25,8 +26,17 @@ from src.application.services.index_master_catalog import get_index_catalog_code
 from src.application.services.stock_data_row_builder import build_stock_data_row
 from src.entrypoints.http.schemas.job import JobProgress
 from src.infrastructure.external_api.clients.jquants_client import JQuantsAsyncClient
-from src.infrastructure.db.dataset_io.dataset_writer import DatasetWriter
-from src.infrastructure.db.market.dataset_db import DatasetDb
+from src.infrastructure.db.dataset_io.dataset_writer import (
+    DatasetWriter,
+    compatibility_db_path_for_path,
+    duckdb_path_for_path,
+    parquet_dir_for_path,
+    snapshot_dir_for_path,
+)
+from src.infrastructure.db.market.dataset_snapshot_reader import (
+    build_dataset_snapshot_logical_checksum,
+    inspect_dataset_snapshot_duckdb,
+)
 from src.infrastructure.db.market.query_helpers import normalize_stock_code
 from src.shared.config.reliability import DATASET_BUILD_TIMEOUT_MINUTES
 
@@ -57,8 +67,16 @@ _WARNING_SAMPLE_SIZE = 5
 
 
 def _manifest_path_for_db(db_path: str) -> Path:
-    db_file = Path(db_path)
-    return db_file.with_name(f"{db_file.stem}.manifest.v1.json")
+    return snapshot_dir_for_path(db_path) / "manifest.v1.json"
+
+
+def _delete_dataset_artifacts(resolver: DatasetResolver, name: str) -> None:
+    for path in resolver.get_artifact_paths(name):
+        target = Path(path)
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
 
 
 def _sha256_of_file(path: Path) -> str:
@@ -69,21 +87,6 @@ def _sha256_of_file(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def _build_logical_checksum_payload(
-    *,
-    counts: dict[str, int],
-    coverage: dict[str, int],
-    date_range: dict[str, str] | None,
-) -> str:
-    payload = {
-        "counts": counts,
-        "coverage": coverage,
-        "dateRange": date_range,
-    }
-    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-
-
 def _write_dataset_manifest(
     *,
     db_path: str,
@@ -91,23 +94,18 @@ def _write_dataset_manifest(
     preset_name: str,
     manifest_path: Path | None = None,
 ) -> str:
-    db_file = Path(db_path)
-    if not db_file.exists():
-        raise FileNotFoundError(f"dataset db not found: {db_file}")
+    compatibility_db = compatibility_db_path_for_path(db_path)
+    duckdb_path = duckdb_path_for_path(db_path)
+    parquet_dir = parquet_dir_for_path(db_path)
+    if not compatibility_db.exists():
+        raise FileNotFoundError(f"dataset db not found: {compatibility_db}")
+    if not duckdb_path.exists():
+        raise FileNotFoundError(f"dataset.duckdb not found: {duckdb_path}")
 
-    db = DatasetDb(str(db_file))
-
-    try:
-        counts = db.get_table_counts()
-        date_range = db.get_date_range()
-        coverage = {
-            "totalStocks": db.get_stock_count(),
-            "stocksWithQuotes": db.get_stocks_with_quotes_count(),
-            "stocksWithStatements": db.get_stocks_with_statements_count(),
-            "stocksWithMargin": db.get_stocks_with_margin_count(),
-        }
-    finally:
-        db.close()
+    inspection = inspect_dataset_snapshot_duckdb(duckdb_path)
+    counts = inspection.counts.model_dump()
+    coverage = inspection.coverage.model_dump()
+    date_range = inspection.date_range.model_dump() if inspection.date_range is not None else None
 
     manifest = {
         "schemaVersion": 1,
@@ -115,17 +113,28 @@ def _write_dataset_manifest(
         "dataset": {
             "name": dataset_name,
             "preset": preset_name,
-            "dbFile": db_file.name,
+            "duckdbFile": duckdb_path.name,
+            "compatibilityDbFile": compatibility_db.name,
+            "parquetDir": parquet_dir.name,
+        },
+        "source": {
+            "backend": "duckdb-parquet",
+            "compatibilityArtifact": "dataset.db",
         },
         "counts": counts,
         "coverage": coverage,
         "checksums": {
-            "datasetDbSha256": _sha256_of_file(db_file),
-            "logicalSha256": _build_logical_checksum_payload(
-                counts=counts,
-                coverage=coverage,
-                date_range=date_range,
+            "duckdbSha256": _sha256_of_file(duckdb_path),
+            "compatibilityDbSha256": _sha256_of_file(compatibility_db),
+            "logicalSha256": build_dataset_snapshot_logical_checksum(
+                counts=inspection.counts,
+                coverage=inspection.coverage,
+                date_range=inspection.date_range,
             ),
+            "parquet": {
+                parquet_file.name: _sha256_of_file(parquet_file)
+                for parquet_file in sorted(parquet_dir.glob("*.parquet"))
+            },
         },
     }
     if date_range is not None:
@@ -182,12 +191,16 @@ async def _build_dataset(
     name = job.data.name
     preset_name = job.data.preset
     db_path = resolver.get_db_path(name)
+    snapshot_dir = snapshot_dir_for_path(db_path)
     warnings: list[str] = []
     errors: list[str] = []
 
     preset = get_preset(preset_name)
     if preset is None:
         return DatasetResult(success=False, errors=[f"Unknown preset: {preset_name}"])
+
+    if job.data.overwrite and not job.data.resume:
+        _delete_dataset_artifacts(resolver, name)
 
     def progress(stage: str, current: int, total: int, message: str) -> None:
         pct = (current / total * 100) if total > 0 else 0
@@ -424,7 +437,7 @@ async def _build_dataset(
             processedStocks=processed,
             warnings=warnings if warnings else None,
             errors=errors if errors else None,
-            outputPath=db_path,
+            outputPath=str(snapshot_dir),
         )
     finally:
         writer.close()

--- a/apps/bt/src/application/services/dataset_data_service.py
+++ b/apps/bt/src/application/services/dataset_data_service.py
@@ -7,9 +7,8 @@ DatasetDb の Row オブジェクトを Pydantic スキーマに変換する。
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Any
-
-from sqlalchemy import Row
 
 from src.entrypoints.http.schemas.dataset_data import (
     IndexListItem,
@@ -23,7 +22,7 @@ from src.entrypoints.http.schemas.dataset_data import (
 )
 
 
-def rows_to_ohlcv(rows: list[Row[Any]]) -> list[OHLCVRecord]:
+def rows_to_ohlcv(rows: Sequence[Any]) -> list[OHLCVRecord]:
     """Row → OHLCVRecord 変換"""
     return [
         OHLCVRecord(
@@ -38,7 +37,7 @@ def rows_to_ohlcv(rows: list[Row[Any]]) -> list[OHLCVRecord]:
     ]
 
 
-def rows_to_ohlc(rows: list[Row[Any]]) -> list[OHLCRecord]:
+def rows_to_ohlc(rows: Sequence[Any]) -> list[OHLCRecord]:
     """Row → OHLCRecord 変換（TOPIX/Indices 用、volume なし）"""
     return [
         OHLCRecord(
@@ -52,7 +51,7 @@ def rows_to_ohlc(rows: list[Row[Any]]) -> list[OHLCRecord]:
     ]
 
 
-def rows_to_stock_list(rows: list[Row[Any]]) -> list[StockListItem]:
+def rows_to_stock_list(rows: Sequence[Any]) -> list[StockListItem]:
     """Row → StockListItem 変換"""
     return [
         StockListItem(
@@ -65,7 +64,7 @@ def rows_to_stock_list(rows: list[Row[Any]]) -> list[StockListItem]:
     ]
 
 
-def rows_to_index_list(rows: list[Row[Any]]) -> list[IndexListItem]:
+def rows_to_index_list(rows: Sequence[Any]) -> list[IndexListItem]:
     """Row → IndexListItem 変換"""
     return [
         IndexListItem(
@@ -79,7 +78,7 @@ def rows_to_index_list(rows: list[Row[Any]]) -> list[IndexListItem]:
     ]
 
 
-def rows_to_margin(rows: list[Row[Any]]) -> list[MarginRecord]:
+def rows_to_margin(rows: Sequence[Any]) -> list[MarginRecord]:
     """Row → MarginRecord 変換"""
     return [
         MarginRecord(
@@ -91,7 +90,7 @@ def rows_to_margin(rows: list[Row[Any]]) -> list[MarginRecord]:
     ]
 
 
-def rows_to_margin_list(rows: list[Row[Any]]) -> list[MarginListItem]:
+def rows_to_margin_list(rows: Sequence[Any]) -> list[MarginListItem]:
     """Row → MarginListItem 変換"""
     return [
         MarginListItem(
@@ -106,7 +105,7 @@ def rows_to_margin_list(rows: list[Row[Any]]) -> list[MarginListItem]:
     ]
 
 
-def rows_to_statements(rows: list[Row[Any]]) -> list[StatementRecord]:
+def rows_to_statements(rows: Sequence[Any]) -> list[StatementRecord]:
     """Row → StatementRecord 変換"""
     return [
         StatementRecord(
@@ -141,7 +140,7 @@ def rows_to_statements(rows: list[Row[Any]]) -> list[StatementRecord]:
     ]
 
 
-def rows_to_sector_with_count(rows: list[Row[Any]]) -> list[SectorWithCount]:
+def rows_to_sector_with_count(rows: Sequence[Any]) -> list[SectorWithCount]:
     """Row → SectorWithCount 変換"""
     return [
         SectorWithCount(sectorName=r[0], count=r[1])
@@ -149,16 +148,16 @@ def rows_to_sector_with_count(rows: list[Row[Any]]) -> list[SectorWithCount]:
     ]
 
 
-def batch_to_ohlcv(batch: dict[str, list[Row[Any]]]) -> dict[str, list[OHLCVRecord]]:
+def batch_to_ohlcv(batch: Mapping[str, Sequence[Any]]) -> dict[str, list[OHLCVRecord]]:
     """Batch → {code: [OHLCVRecord]} 変換"""
     return {code: rows_to_ohlcv(rows) for code, rows in batch.items()}
 
 
-def batch_to_margin(batch: dict[str, list[Row[Any]]]) -> dict[str, list[MarginRecord]]:
+def batch_to_margin(batch: Mapping[str, Sequence[Any]]) -> dict[str, list[MarginRecord]]:
     """Batch → {code: [MarginRecord]} 変換"""
     return {code: rows_to_margin(rows) for code, rows in batch.items()}
 
 
-def batch_to_statements(batch: dict[str, list[Row[Any]]]) -> dict[str, list[StatementRecord]]:
+def batch_to_statements(batch: Mapping[str, Sequence[Any]]) -> dict[str, list[StatementRecord]]:
     """Batch → {code: [StatementRecord]} 変換"""
     return {code: rows_to_statements(rows) for code, rows in batch.items()}

--- a/apps/bt/src/application/services/dataset_resolver.py
+++ b/apps/bt/src/application/services/dataset_resolver.py
@@ -1,9 +1,4 @@
-"""
-Dataset Resolver
-
-Dataset 名から DatasetDb インスタンスを解決するキャッシュ付きリゾルバ。
-パストラバーサル防御 + per-dataset ロック付き。
-"""
+"""Dataset snapshot resolver with compatibility fallback."""
 
 from __future__ import annotations
 
@@ -12,6 +7,7 @@ import re
 import threading
 
 from src.infrastructure.db.market.dataset_db import DatasetDb
+from src.infrastructure.db.market.dataset_snapshot_reader import DatasetSnapshotReader
 
 _DATASET_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -21,7 +17,7 @@ class DatasetResolver:
 
     def __init__(self, base_path: str) -> None:
         self._base_path = os.path.realpath(base_path)
-        self._cache: dict[str, DatasetDb] = {}
+        self._cache: dict[str, DatasetDb | DatasetSnapshotReader] = {}
         self._locks: dict[str, threading.Lock] = {}
         self._global_lock = threading.Lock()
 
@@ -30,43 +26,102 @@ class DatasetResolver:
         return self._base_path
 
     def _validate_name(self, name: str) -> str:
-        """名前検証 + パストラバーサル防御。正規化された .db ファイル名を返す。"""
+        """名前検証 + パストラバーサル防御。正規化された dataset 名を返す。"""
         stem = name.removesuffix(".db")
         if not _DATASET_NAME_RE.match(stem):
             raise ValueError(f"Invalid dataset name: {name}")
-        normalized = f"{stem}.db"
-        db_path = os.path.join(self._base_path, normalized)
-        real = os.path.realpath(db_path)
+        real = os.path.realpath(os.path.join(self._base_path, stem))
         if not real.startswith(self._base_path + os.sep):
             raise ValueError(f"Path traversal detected: {name}")
-        return normalized
+        return stem
 
-    def resolve(self, name: str) -> DatasetDb | None:
-        """名前から DatasetDb を解決。存在しない場合は None。"""
+    def get_snapshot_dir(self, name: str) -> str:
         normalized = self._validate_name(name)
-        db_path = os.path.join(self._base_path, normalized)
-        if not os.path.exists(db_path):
+        return os.path.join(self._base_path, normalized)
+
+    def get_db_path(self, name: str) -> str:
+        """新 snapshot layout での compatibility dataset.db パス。"""
+        return os.path.join(self.get_snapshot_dir(name), "dataset.db")
+
+    def get_duckdb_path(self, name: str) -> str:
+        return os.path.join(self.get_snapshot_dir(name), "dataset.duckdb")
+
+    def get_manifest_path(self, name: str) -> str:
+        return os.path.join(self.get_snapshot_dir(name), "manifest.v1.json")
+
+    def get_legacy_db_path(self, name: str) -> str:
+        normalized = self._validate_name(name)
+        return os.path.join(self._base_path, f"{normalized}.db")
+
+    def _snapshot_has_supported_artifacts(self, snapshot_dir: str) -> bool:
+        return os.path.exists(os.path.join(snapshot_dir, "dataset.duckdb")) or os.path.exists(
+            os.path.join(snapshot_dir, "dataset.db")
+        )
+
+    def get_dataset_path(self, name: str) -> str:
+        snapshot_dir = self.get_snapshot_dir(name)
+        if self._snapshot_has_supported_artifacts(snapshot_dir):
+            return snapshot_dir
+        return self.get_legacy_db_path(name)
+
+    def exists(self, name: str) -> bool:
+        snapshot_dir = self.get_snapshot_dir(name)
+        return self._snapshot_has_supported_artifacts(snapshot_dir) or os.path.exists(
+            self.get_legacy_db_path(name)
+        )
+
+    def get_artifact_paths(self, name: str) -> list[str]:
+        normalized = self._validate_name(name)
+        snapshot_dir = self.get_snapshot_dir(normalized)
+        paths: list[str] = []
+        if os.path.isdir(snapshot_dir):
+            paths.append(snapshot_dir)
+
+        legacy_db = self.get_legacy_db_path(normalized)
+        if os.path.exists(legacy_db):
+            paths.append(legacy_db)
+        return paths
+
+    def resolve(self, name: str) -> DatasetDb | DatasetSnapshotReader | None:
+        """名前から snapshot reader を解決。存在しない場合は None。"""
+        normalized = self._validate_name(name)
+        snapshot_dir = self.get_snapshot_dir(normalized)
+        snapshot_duckdb = self.get_duckdb_path(normalized)
+        snapshot_db = self.get_db_path(normalized)
+        legacy_db = self.get_legacy_db_path(normalized)
+        has_snapshot = self._snapshot_has_supported_artifacts(snapshot_dir)
+        if not has_snapshot and not os.path.exists(legacy_db):
             return None
         with self._global_lock:
             if normalized not in self._cache:
-                self._cache[normalized] = DatasetDb(db_path)
+                if os.path.exists(snapshot_duckdb):
+                    self._cache[normalized] = DatasetSnapshotReader(snapshot_dir)
+                elif os.path.exists(snapshot_db):
+                    self._cache[normalized] = DatasetDb(snapshot_db)
+                else:
+                    self._cache[normalized] = DatasetDb(legacy_db)
                 self._locks[normalized] = threading.Lock()
         return self._cache[normalized]
 
     def list_datasets(self) -> list[str]:
-        """利用可能なデータセット名一覧（.db 拡張子なし）を返す。"""
+        """利用可能なデータセット名一覧を返す。snapshot directory を優先する。"""
         if not os.path.isdir(self._base_path):
             return []
         names: list[str] = []
+        seen: set[str] = set()
         for entry in sorted(os.listdir(self._base_path)):
+            path = os.path.join(self._base_path, entry)
+            if os.path.isdir(path) and _DATASET_NAME_RE.match(entry):
+                if self._snapshot_has_supported_artifacts(path):
+                    names.append(entry)
+                    seen.add(entry)
+                continue
             if entry.endswith(".db") and _DATASET_NAME_RE.match(entry.removesuffix(".db")):
-                names.append(entry.removesuffix(".db"))
+                stem = entry.removesuffix(".db")
+                if stem in seen:
+                    continue
+                names.append(stem)
         return names
-
-    def get_db_path(self, name: str) -> str:
-        """バリデーション済みの DB ファイルパスを返す。"""
-        normalized = self._validate_name(name)
-        return os.path.join(self._base_path, normalized)
 
     def evict(self, name: str) -> None:
         """DELETE 時: キャッシュから削除してクローズ。"""

--- a/apps/bt/src/application/services/dataset_service.py
+++ b/apps/bt/src/application/services/dataset_service.py
@@ -7,7 +7,10 @@ Dataset 管理操作（list, info, sample, search, delete）のサービス層�
 from __future__ import annotations
 
 import os
+import shutil
+from collections.abc import Sequence
 from datetime import datetime
+from typing import Protocol
 
 from src.application.services.dataset_presets import get_preset
 from src.application.services.dataset_resolver import DatasetResolver
@@ -29,10 +32,23 @@ from src.entrypoints.http.schemas.dataset import (
     DatasetValidationDetails,
     SearchResultItem,
 )
-from src.infrastructure.db.market.dataset_db import DatasetDb
+class DatasetReadable(Protocol):
+    def get_dataset_info(self) -> dict[str, str]: ...
+    def get_table_counts(self) -> dict[str, int]: ...
+    def get_date_range(self) -> dict[str, str] | None: ...
+    def get_stock_count(self) -> int: ...
+    def get_stocks_with_quotes_count(self) -> int: ...
+    def get_stocks_with_margin_count(self) -> int: ...
+    def get_stocks_with_statements_count(self) -> int: ...
+    def get_fk_orphan_counts(self) -> dict[str, int]: ...
+    def get_stocks_without_quotes_count(self) -> int: ...
+    def get_sample_codes(self, size: int = 10, seed: int | None = None) -> list[str]: ...
+    def search_stocks(
+        self, term: str, exact: bool = False, limit: int = 50
+    ) -> Sequence[object]: ...
 
 
-def _read_dataset_metadata(db: DatasetDb | None) -> tuple[str | None, str | None]:
+def _read_dataset_metadata(db: DatasetReadable | None) -> tuple[str | None, str | None]:
     if db is None:
         return None, None
     try:
@@ -47,17 +63,17 @@ def list_datasets(resolver: DatasetResolver) -> list[DatasetListItem]:
     """利用可能なデータセット一覧を取得"""
     items: list[DatasetListItem] = []
     for name in resolver.list_datasets():
-        db_path = resolver.get_db_path(name)
+        dataset_path = resolver.get_dataset_path(name)
         try:
-            stat = os.stat(db_path)
+            last_modified = _resolve_last_modified(dataset_path)
             preset, created_at = _read_dataset_metadata(resolver.resolve(name))
 
             items.append(
                 DatasetListItem(
                     name=name,
-                    path=db_path,
-                    fileSize=stat.st_size,
-                    lastModified=datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                    path=dataset_path,
+                    fileSize=_resolve_path_size(dataset_path),
+                    lastModified=datetime.fromtimestamp(last_modified).isoformat(),
                     preset=preset,
                     createdAt=created_at,
                 )
@@ -82,8 +98,8 @@ def get_dataset_info(resolver: DatasetResolver, name: str) -> DatasetInfoRespons
     if db is None:
         return None
 
-    db_path = resolver.get_db_path(name)
-    stat = os.stat(db_path)
+    dataset_path = resolver.get_dataset_path(name)
+    last_modified = _resolve_last_modified(dataset_path)
 
     info = db.get_dataset_info()
     table_counts = db.get_table_counts()
@@ -164,9 +180,9 @@ def get_dataset_info(resolver: DatasetResolver, name: str) -> DatasetInfoRespons
 
     return DatasetInfoResponse(
         name=name,
-        path=db_path,
-        fileSize=stat.st_size,
-        lastModified=datetime.fromtimestamp(stat.st_mtime).isoformat(),
+        path=dataset_path,
+        fileSize=_resolve_path_size(dataset_path),
+        lastModified=datetime.fromtimestamp(last_modified).isoformat(),
         snapshot=DatasetSnapshot(
             preset=preset_name,
             createdAt=info.get("created_at"),
@@ -197,13 +213,13 @@ def get_dataset_info(resolver: DatasetResolver, name: str) -> DatasetInfoRespons
     )
 
 
-def get_dataset_sample(db: DatasetDb, count: int = 10, seed: int | None = None) -> DatasetSampleResponse:
+def get_dataset_sample(db: DatasetReadable, count: int = 10, seed: int | None = None) -> DatasetSampleResponse:
     """ランダムサンプル取得"""
     codes = db.get_sample_codes(size=count, seed=seed)
     return DatasetSampleResponse(codes=codes)
 
 
-def search_dataset(db: DatasetDb, q: str, limit: int = 50) -> DatasetSearchResponse:
+def search_dataset(db: DatasetReadable, q: str, limit: int = 50) -> DatasetSearchResponse:
     """銘柄検索"""
     # 完全一致を先に試す
     exact_rows = db.search_stocks(term=q, exact=True, limit=limit)
@@ -228,9 +244,38 @@ def search_dataset(db: DatasetDb, q: str, limit: int = 50) -> DatasetSearchRespo
 
 def delete_dataset(resolver: DatasetResolver, name: str) -> bool:
     """データセット削除"""
-    db_path = resolver.get_db_path(name)
-    if not os.path.exists(db_path):
+    artifact_paths = resolver.get_artifact_paths(name)
+    if not artifact_paths:
         return False
     resolver.evict(name)
-    os.remove(db_path)
+    for path in artifact_paths:
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        elif os.path.exists(path):
+            os.remove(path)
     return True
+
+
+def _resolve_path_size(path: str) -> int:
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+            if os.path.isfile(file_path):
+                total += os.path.getsize(file_path)
+    return total
+
+
+def _resolve_last_modified(path: str) -> float:
+    if os.path.isfile(path):
+        return os.path.getmtime(path)
+
+    latest_mtime = os.path.getmtime(path)
+    for root, _dirs, files in os.walk(path):
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+            if os.path.isfile(file_path):
+                latest_mtime = max(latest_mtime, os.path.getmtime(file_path))
+    return latest_mtime

--- a/apps/bt/src/entrypoints/http/routes/dataset.py
+++ b/apps/bt/src/entrypoints/http/routes/dataset.py
@@ -14,8 +14,6 @@ DELETE /api/dataset/jobs/{jobId}       — ジョブキャンセル
 
 from __future__ import annotations
 
-import os
-
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
@@ -226,9 +224,7 @@ async def create_dataset(request: Request, body: DatasetCreateRequest) -> JSONRe
 
     # Check existing dataset
     name_stem = body.name.removesuffix(".db")
-    db_path = resolver.get_db_path(f"{name_stem}.db")
-
-    if os.path.exists(db_path) and not body.overwrite:
+    if resolver.exists(name_stem) and not body.overwrite:
         raise HTTPException(
             status_code=409,
             detail=f'Dataset "{name_stem}" already exists. Use overwrite=true to replace.',
@@ -279,9 +275,7 @@ async def resume_dataset(request: Request, body: DatasetCreateRequest) -> JSONRe
 
     # Check dataset exists
     name_stem = body.name.removesuffix(".db")
-    db_path = resolver.get_db_path(f"{name_stem}.db")
-
-    if not os.path.exists(db_path):
+    if not resolver.exists(name_stem):
         raise HTTPException(status_code=404, detail=f'Dataset "{name_stem}" not found')
 
     data = DatasetJobData(

--- a/apps/bt/src/infrastructure/data_access/clients.py
+++ b/apps/bt/src/infrastructure/data_access/clients.py
@@ -21,11 +21,12 @@ from src.infrastructure.external_api.dataset_client import DatasetAPIClient
 from src.infrastructure.external_api.market_client import MarketAPIClient
 from src.shared.config.settings import get_settings
 from src.infrastructure.db.market.dataset_db import DatasetDb
+from src.infrastructure.db.market.dataset_snapshot_reader import DatasetSnapshotReader
 from src.infrastructure.db.market.market_reader import MarketDbReader
 
 from .mode import should_use_direct_db
 
-_dataset_db_cache: dict[str, DatasetDb] = {}
+_dataset_db_cache: dict[str, DatasetDb | DatasetSnapshotReader] = {}
 _dataset_db_lock = threading.Lock()
 
 _market_reader: MarketDbReader | None = None
@@ -45,9 +46,30 @@ def _rows_to_records(
     ]
 
 
-def _resolve_dataset_db(dataset_name: str) -> DatasetDb:
+def _resolve_dataset_db(dataset_name: str) -> DatasetDb | DatasetSnapshotReader:
     settings = get_settings()
     stem = Path(dataset_name).stem
+    snapshot_dir = Path(settings.dataset_base_path) / stem
+    duckdb_path = snapshot_dir / "dataset.duckdb"
+    compatibility_db_path = snapshot_dir / "dataset.db"
+    if duckdb_path.exists():
+        cache_key = str(snapshot_dir.resolve())
+        with _dataset_db_lock:
+            db = _dataset_db_cache.get(cache_key)
+            if db is None:
+                db = DatasetSnapshotReader(str(snapshot_dir))
+                _dataset_db_cache[cache_key] = db
+            return db
+
+    if compatibility_db_path.exists():
+        cache_key = str(compatibility_db_path.resolve())
+        with _dataset_db_lock:
+            db = _dataset_db_cache.get(cache_key)
+            if db is None:
+                db = DatasetDb(str(compatibility_db_path))
+                _dataset_db_cache[cache_key] = db
+            return db
+
     db_path = Path(settings.dataset_base_path) / f"{stem}.db"
     cache_key = str(db_path.resolve())
 

--- a/apps/bt/src/infrastructure/db/dataset_io/dataset_writer.py
+++ b/apps/bt/src/infrastructure/db/dataset_io/dataset_writer.py
@@ -1,14 +1,17 @@
 """
-Dataset Writer
+Dataset snapshot writer.
 
-データセット .db ファイルへの書き込み。
-DatasetDb（read-only）の書き込み版。
+Write the new dataset snapshot SoT (`dataset.duckdb + parquet`) while keeping
+`dataset.db` as a compatibility artifact during the migration window.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+import importlib
+from pathlib import Path
+from threading import RLock
+from typing import Any, cast
 
 from sqlalchemy import func, insert, select, text
 
@@ -24,21 +27,54 @@ from src.infrastructure.db.market.tables import (
     statements,
 )
 
+_PARQUET_EXPORTS: tuple[tuple[str, str, str | None], ...] = (
+    ("stocks", "stocks.parquet", "code"),
+    ("stock_data", "stock_data.parquet", None),
+    ("topix_data", "topix_data.parquet", "date"),
+    ("indices_data", "indices_data.parquet", None),
+    ("margin_data", "margin_data.parquet", "code, date"),
+    ("statements", "statements.parquet", "disclosed_date, code"),
+)
 
-class DatasetWriter(BaseDbAccess):
-    """データセット .db ファイルへの書き込み"""
+
+def snapshot_dir_for_path(path: str) -> Path:
+    source = Path(path)
+    if source.suffix == ".db":
+        if source.name == "dataset.db":
+            return source.parent
+        return source.with_suffix("")
+    return source
+
+
+def compatibility_db_path_for_path(path: str) -> Path:
+    source = Path(path)
+    if source.suffix == ".db":
+        if source.name == "dataset.db":
+            return source
+        return snapshot_dir_for_path(path) / "dataset.db"
+    return snapshot_dir_for_path(path) / "dataset.db"
+
+
+def duckdb_path_for_path(path: str) -> Path:
+    return snapshot_dir_for_path(path) / "dataset.duckdb"
+
+
+def parquet_dir_for_path(path: str) -> Path:
+    return snapshot_dir_for_path(path) / "parquet"
+
+
+class _LegacyDatasetWriter(BaseDbAccess):
+    """Compatibility writer for the legacy dataset.db artifact."""
 
     def __init__(self, db_path: str) -> None:
         super().__init__(db_path, read_only=False)
         self._ensure_schema()
 
     def _ensure_schema(self) -> None:
-        """テーブルが存在しない場合は作成"""
         dataset_meta.create_all(self.engine, checkfirst=True)
         self._ensure_statements_columns()
 
     def _ensure_statements_columns(self) -> None:
-        """既存 statements テーブルに不足カラムを追加する。"""
         additional_columns: tuple[tuple[str, str], ...] = (
             ("forecast_dividend_fy", "REAL"),
             ("next_year_forecast_dividend_fy", "REAL"),
@@ -149,3 +185,485 @@ class DatasetWriter(BaseDbAccess):
         with self.engine.connect() as conn:
             rows = conn.execute(select(statements.c.code).distinct()).fetchall()
         return {str(row[0]) for row in rows if row and row[0] is not None}
+
+
+class _DatasetDuckDbStore:
+    """DuckDB + Parquet dataset snapshot store."""
+
+    _STATEMENT_COLUMNS: tuple[str, ...] = (
+        "code",
+        "disclosed_date",
+        "earnings_per_share",
+        "profit",
+        "equity",
+        "type_of_current_period",
+        "type_of_document",
+        "next_year_forecast_earnings_per_share",
+        "bps",
+        "sales",
+        "operating_profit",
+        "ordinary_profit",
+        "operating_cash_flow",
+        "dividend_fy",
+        "forecast_dividend_fy",
+        "next_year_forecast_dividend_fy",
+        "payout_ratio",
+        "forecast_payout_ratio",
+        "next_year_forecast_payout_ratio",
+        "forecast_eps",
+        "investing_cash_flow",
+        "financing_cash_flow",
+        "cash_and_equivalents",
+        "total_assets",
+        "shares_outstanding",
+        "treasury_shares",
+    )
+
+    def __init__(self, *, duckdb_path: str, parquet_dir: str) -> None:
+        self._duckdb_path = Path(duckdb_path)
+        self._parquet_dir = Path(parquet_dir)
+        self._duckdb_path.parent.mkdir(parents=True, exist_ok=True)
+        self._parquet_dir.mkdir(parents=True, exist_ok=True)
+
+        duckdb = importlib.import_module("duckdb")
+        self._conn = cast(Any, duckdb).connect(str(self._duckdb_path))
+        self._lock = RLock()
+        self._dirty_tables: set[str] = set()
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS stocks (
+                    code TEXT PRIMARY KEY,
+                    company_name TEXT NOT NULL,
+                    company_name_english TEXT,
+                    market_code TEXT NOT NULL,
+                    market_name TEXT NOT NULL,
+                    sector_17_code TEXT NOT NULL,
+                    sector_17_name TEXT NOT NULL,
+                    sector_33_code TEXT NOT NULL,
+                    sector_33_name TEXT NOT NULL,
+                    scale_category TEXT,
+                    listed_date TEXT NOT NULL,
+                    created_at TEXT,
+                    updated_at TEXT
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS stock_data (
+                    code TEXT,
+                    date TEXT,
+                    open DOUBLE,
+                    high DOUBLE,
+                    low DOUBLE,
+                    close DOUBLE,
+                    volume BIGINT,
+                    adjustment_factor DOUBLE,
+                    created_at TEXT,
+                    PRIMARY KEY (code, date)
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS topix_data (
+                    date TEXT PRIMARY KEY,
+                    open DOUBLE,
+                    high DOUBLE,
+                    low DOUBLE,
+                    close DOUBLE,
+                    created_at TEXT
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS indices_data (
+                    code TEXT,
+                    date TEXT,
+                    open DOUBLE,
+                    high DOUBLE,
+                    low DOUBLE,
+                    close DOUBLE,
+                    sector_name TEXT,
+                    created_at TEXT,
+                    PRIMARY KEY (code, date)
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS margin_data (
+                    code TEXT,
+                    date TEXT,
+                    long_margin_volume DOUBLE,
+                    short_margin_volume DOUBLE,
+                    PRIMARY KEY (code, date)
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS statements (
+                    code TEXT,
+                    disclosed_date TEXT,
+                    earnings_per_share DOUBLE,
+                    profit DOUBLE,
+                    equity DOUBLE,
+                    type_of_current_period TEXT,
+                    type_of_document TEXT,
+                    next_year_forecast_earnings_per_share DOUBLE,
+                    bps DOUBLE,
+                    sales DOUBLE,
+                    operating_profit DOUBLE,
+                    ordinary_profit DOUBLE,
+                    operating_cash_flow DOUBLE,
+                    dividend_fy DOUBLE,
+                    forecast_dividend_fy DOUBLE,
+                    next_year_forecast_dividend_fy DOUBLE,
+                    payout_ratio DOUBLE,
+                    forecast_payout_ratio DOUBLE,
+                    next_year_forecast_payout_ratio DOUBLE,
+                    forecast_eps DOUBLE,
+                    investing_cash_flow DOUBLE,
+                    financing_cash_flow DOUBLE,
+                    cash_and_equivalents DOUBLE,
+                    total_assets DOUBLE,
+                    shares_outstanding DOUBLE,
+                    treasury_shares DOUBLE,
+                    PRIMARY KEY (code, disclosed_date)
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dataset_info (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    updated_at TEXT
+                )
+                """
+            )
+
+    def upsert_stocks(self, rows: list[dict[str, Any]]) -> int:
+        if not rows:
+            return 0
+        values = [
+            (
+                row.get("code"),
+                row.get("company_name"),
+                row.get("company_name_english"),
+                row.get("market_code"),
+                row.get("market_name"),
+                row.get("sector_17_code"),
+                row.get("sector_17_name"),
+                row.get("sector_33_code"),
+                row.get("sector_33_name"),
+                row.get("scale_category"),
+                row.get("listed_date"),
+                row.get("created_at"),
+                row.get("updated_at"),
+            )
+            for row in rows
+        ]
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO stocks (
+                    code,
+                    company_name,
+                    company_name_english,
+                    market_code,
+                    market_name,
+                    sector_17_code,
+                    sector_17_name,
+                    sector_33_code,
+                    sector_33_name,
+                    scale_category,
+                    listed_date,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (code) DO UPDATE
+                SET company_name = excluded.company_name,
+                    company_name_english = excluded.company_name_english,
+                    market_code = excluded.market_code,
+                    market_name = excluded.market_name,
+                    sector_17_code = excluded.sector_17_code,
+                    sector_17_name = excluded.sector_17_name,
+                    sector_33_code = excluded.sector_33_code,
+                    sector_33_name = excluded.sector_33_name,
+                    scale_category = excluded.scale_category,
+                    listed_date = excluded.listed_date,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("stocks")
+        return len(rows)
+
+    def upsert_stock_data(self, rows: list[dict[str, Any]]) -> int:
+        if not rows:
+            return 0
+        values = [
+            (
+                row.get("code"),
+                row.get("date"),
+                row.get("open"),
+                row.get("high"),
+                row.get("low"),
+                row.get("close"),
+                row.get("volume"),
+                row.get("adjustment_factor"),
+                row.get("created_at"),
+            )
+            for row in rows
+        ]
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO stock_data (
+                    code, date, open, high, low, close, volume, adjustment_factor, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (code, date) DO UPDATE
+                SET open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    volume = excluded.volume,
+                    adjustment_factor = excluded.adjustment_factor,
+                    created_at = excluded.created_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("stock_data")
+        return len(rows)
+
+    def upsert_topix_data(self, rows: list[dict[str, Any]]) -> int:
+        if not rows:
+            return 0
+        values = [
+            (
+                row.get("date"),
+                row.get("open"),
+                row.get("high"),
+                row.get("low"),
+                row.get("close"),
+                row.get("created_at"),
+            )
+            for row in rows
+        ]
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO topix_data (date, open, high, low, close, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (date) DO UPDATE
+                SET open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    created_at = excluded.created_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("topix_data")
+        return len(rows)
+
+    def upsert_indices_data(self, rows: list[dict[str, Any]]) -> int:
+        if not rows:
+            return 0
+        values = [
+            (
+                row.get("code"),
+                row.get("date"),
+                row.get("open"),
+                row.get("high"),
+                row.get("low"),
+                row.get("close"),
+                row.get("sector_name"),
+                row.get("created_at"),
+            )
+            for row in rows
+        ]
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO indices_data (
+                    code, date, open, high, low, close, sector_name, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (code, date) DO UPDATE
+                SET open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    sector_name = excluded.sector_name,
+                    created_at = excluded.created_at
+                """,
+                values,
+            )
+            self._dirty_tables.add("indices_data")
+        return len(rows)
+
+    def upsert_margin_data(self, rows: list[dict[str, Any]]) -> int:
+        if not rows:
+            return 0
+        values = [
+            (
+                row.get("code"),
+                row.get("date"),
+                row.get("long_margin_volume"),
+                row.get("short_margin_volume"),
+            )
+            for row in rows
+        ]
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO margin_data (code, date, long_margin_volume, short_margin_volume)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (code, date) DO UPDATE
+                SET long_margin_volume = excluded.long_margin_volume,
+                    short_margin_volume = excluded.short_margin_volume
+                """,
+                values,
+            )
+            self._dirty_tables.add("margin_data")
+        return len(rows)
+
+    def upsert_statements(self, rows: list[dict[str, Any]]) -> int:
+        if not rows:
+            return 0
+
+        placeholders = ", ".join("?" for _ in self._STATEMENT_COLUMNS)
+        update_columns = ", ".join(
+            f"{column} = COALESCE(excluded.{column}, statements.{column})"
+            for column in self._STATEMENT_COLUMNS[2:]
+        )
+        sql = (
+            "INSERT INTO statements "
+            f"({', '.join(self._STATEMENT_COLUMNS)}) "
+            f"VALUES ({placeholders}) "
+            "ON CONFLICT (code, disclosed_date) DO UPDATE "
+            f"SET {update_columns}"
+        )
+        values = [tuple(row.get(column) for column in self._STATEMENT_COLUMNS) for row in rows]
+        with self._lock:
+            self._conn.executemany(sql, values)
+            self._dirty_tables.add("statements")
+        return len(rows)
+
+    def set_dataset_info(self, key: str, value: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO dataset_info (key, value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT (key) DO UPDATE
+                SET value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                [key, value, datetime.now(UTC).isoformat()],
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            for table_name, parquet_name, order_by in _PARQUET_EXPORTS:
+                if table_name not in self._dirty_tables:
+                    continue
+                output_path = self._parquet_dir / parquet_name
+                if output_path.exists():
+                    output_path.unlink()
+                escaped = str(output_path).replace("'", "''")
+                if order_by:
+                    source_sql = f"(SELECT * FROM {table_name} ORDER BY {order_by})"
+                else:
+                    source_sql = table_name
+                self._conn.execute(f"COPY {source_sql} TO '{escaped}' (FORMAT PARQUET)")
+            self._dirty_tables.clear()
+            self._conn.close()
+
+
+class DatasetWriter:
+    """Dataset snapshot writer with DuckDB SoT and SQLite compatibility artifact."""
+
+    def __init__(self, path: str) -> None:
+        self.snapshot_dir = snapshot_dir_for_path(path)
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+        self.compatibility_db_path = compatibility_db_path_for_path(path)
+        self.duckdb_path = duckdb_path_for_path(path)
+        self.parquet_dir = parquet_dir_for_path(path)
+
+        self._legacy_writer = _LegacyDatasetWriter(str(self.compatibility_db_path))
+        self._duckdb_store = _DatasetDuckDbStore(
+            duckdb_path=str(self.duckdb_path),
+            parquet_dir=str(self.parquet_dir),
+        )
+
+    @property
+    def engine(self):  # noqa: ANN201
+        return self._legacy_writer.engine
+
+    def upsert_stocks(self, rows: list[dict[str, Any]]) -> int:
+        count = self._duckdb_store.upsert_stocks(rows)
+        self._legacy_writer.upsert_stocks(rows)
+        return count
+
+    def upsert_stock_data(self, rows: list[dict[str, Any]]) -> int:
+        count = self._duckdb_store.upsert_stock_data(rows)
+        self._legacy_writer.upsert_stock_data(rows)
+        return count
+
+    def upsert_topix_data(self, rows: list[dict[str, Any]]) -> int:
+        count = self._duckdb_store.upsert_topix_data(rows)
+        self._legacy_writer.upsert_topix_data(rows)
+        return count
+
+    def upsert_indices_data(self, rows: list[dict[str, Any]]) -> int:
+        count = self._duckdb_store.upsert_indices_data(rows)
+        self._legacy_writer.upsert_indices_data(rows)
+        return count
+
+    def upsert_margin_data(self, rows: list[dict[str, Any]]) -> int:
+        count = self._duckdb_store.upsert_margin_data(rows)
+        self._legacy_writer.upsert_margin_data(rows)
+        return count
+
+    def upsert_statements(self, rows: list[dict[str, Any]]) -> int:
+        count = self._duckdb_store.upsert_statements(rows)
+        self._legacy_writer.upsert_statements(rows)
+        return count
+
+    def set_dataset_info(self, key: str, value: str) -> None:
+        self._duckdb_store.set_dataset_info(key, value)
+        self._legacy_writer.set_dataset_info(key, value)
+
+    def get_stock_count(self) -> int:
+        return self._legacy_writer.get_stock_count()
+
+    def get_stock_data_count(self) -> int:
+        return self._legacy_writer.get_stock_data_count()
+
+    def get_existing_stock_data_codes(self) -> set[str]:
+        return self._legacy_writer.get_existing_stock_data_codes()
+
+    def has_topix_data(self) -> bool:
+        return self._legacy_writer.has_topix_data()
+
+    def get_existing_index_codes(self) -> set[str]:
+        return self._legacy_writer.get_existing_index_codes()
+
+    def get_existing_margin_codes(self) -> set[str]:
+        return self._legacy_writer.get_existing_margin_codes()
+
+    def get_existing_statement_codes(self) -> set[str]:
+        return self._legacy_writer.get_existing_statement_codes()
+
+    def close(self) -> None:
+        self._duckdb_store.close()
+        self._legacy_writer.close()

--- a/apps/bt/src/infrastructure/db/market/__init__.py
+++ b/apps/bt/src/infrastructure/db/market/__init__.py
@@ -4,6 +4,7 @@ from src.infrastructure.db.market.base import BaseDbAccess
 from src.infrastructure.db.market.dataset_db import DatasetDb
 from src.infrastructure.db.market.market_db import METADATA_KEYS, MarketDb
 from src.infrastructure.db.market.market_reader import MarketDbReader
+from src.infrastructure.db.market.dataset_snapshot_reader import DatasetSnapshotReader
 from src.infrastructure.db.market.portfolio_db import PortfolioDb
 from src.infrastructure.db.market.query_helpers import (
     expand_stock_code,
@@ -20,6 +21,7 @@ from src.infrastructure.db.market.query_helpers import (
 __all__ = [
     "BaseDbAccess",
     "DatasetDb",
+    "DatasetSnapshotReader",
     "MarketDb",
     "MarketDbReader",
     "PortfolioDb",
@@ -34,4 +36,3 @@ __all__ = [
     "stock_lookup",
     "trading_date_before",
 ]
-

--- a/apps/bt/src/infrastructure/db/market/dataset_snapshot_reader.py
+++ b/apps/bt/src/infrastructure/db/market/dataset_snapshot_reader.py
@@ -1,0 +1,774 @@
+"""Dataset snapshot reader for `dataset.duckdb + parquet + manifest` snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+import hashlib
+import importlib
+import json
+from pathlib import Path
+import random
+import threading
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.infrastructure.db.market.dataset_db import _resolve_period_filter_values
+from src.infrastructure.db.market.query_helpers import normalize_stock_code
+
+_ACTUAL_ONLY_COLUMNS = (
+    "earnings_per_share",
+    "profit",
+    "equity",
+)
+
+
+@dataclass(frozen=True)
+class _DuckDbRow:
+    _columns: tuple[str, ...]
+    _values: tuple[Any, ...]
+    _index_map: dict[str, int]
+
+    def __getitem__(self, key: str | int) -> Any:
+        if isinstance(key, int):
+            return self._values[key]
+        return self._values[self._index_map[str(key)]]
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
+        return iter(zip(self._columns, self._values))
+
+    def keys(self) -> tuple[str, ...]:
+        return self._columns
+
+    def items(self):
+        return zip(self._columns, self._values)
+
+    def values(self) -> tuple[Any, ...]:
+        return self._values
+
+
+@dataclass(frozen=True)
+class DatasetSnapshotInspection:
+    counts: "DatasetSnapshotCounts"
+    coverage: "DatasetSnapshotCoverage"
+    date_range: "DatasetSnapshotDateRange | None"
+
+
+class DatasetSnapshotSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    backend: Literal["duckdb-parquet"] = "duckdb-parquet"
+    compatibilityArtifact: str | None = None
+
+
+class DatasetSnapshotDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    preset: str = Field(min_length=1)
+    duckdbFile: str = "dataset.duckdb"
+    compatibilityDbFile: str | None = "dataset.db"
+    parquetDir: str = "parquet"
+
+
+class DatasetSnapshotChecksums(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    duckdbSha256: str = Field(min_length=1)
+    logicalSha256: str = Field(min_length=1)
+    compatibilityDbSha256: str | None = None
+    parquet: dict[str, str] = Field(default_factory=dict)
+
+
+class DatasetSnapshotCounts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stocks: int = Field(ge=0)
+    stock_data: int = Field(ge=0)
+    topix_data: int = Field(ge=0)
+    indices_data: int = Field(ge=0)
+    margin_data: int = Field(ge=0)
+    statements: int = Field(ge=0)
+    dataset_info: int = Field(ge=0)
+
+
+class DatasetSnapshotCoverage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    totalStocks: int = Field(ge=0)
+    stocksWithQuotes: int = Field(ge=0)
+    stocksWithStatements: int = Field(ge=0)
+    stocksWithMargin: int = Field(ge=0)
+
+
+class DatasetSnapshotDateRange(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    min: str = Field(min_length=1)
+    max: str = Field(min_length=1)
+
+
+class DatasetSnapshotManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schemaVersion: Literal[1] = 1
+    generatedAt: str = Field(min_length=1)
+    dataset: DatasetSnapshotDescriptor
+    source: DatasetSnapshotSource
+    counts: DatasetSnapshotCounts
+    coverage: DatasetSnapshotCoverage
+    checksums: DatasetSnapshotChecksums
+    dateRange: DatasetSnapshotDateRange | None = None
+
+
+def _sha256_of_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def build_dataset_snapshot_logical_checksum(
+    *,
+    counts: DatasetSnapshotCounts,
+    coverage: DatasetSnapshotCoverage,
+    date_range: DatasetSnapshotDateRange | None,
+) -> str:
+    payload = {
+        "counts": counts.model_dump(),
+        "coverage": coverage.model_dump(),
+        "dateRange": date_range.model_dump() if date_range is not None else None,
+    }
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _connect_duckdb(duckdb_path: Path, *, read_only: bool) -> Any:
+    duckdb = importlib.import_module("duckdb")
+    return cast(Any, duckdb).connect(str(duckdb_path), read_only=read_only)
+
+
+def _query_scalar_int(conn: Any, sql: str) -> int:
+    row = conn.execute(sql).fetchone()
+    if row is None or row[0] is None:
+        return 0
+    return int(row[0])
+
+
+def inspect_dataset_snapshot_duckdb(duckdb_path: str | Path) -> DatasetSnapshotInspection:
+    conn = _connect_duckdb(Path(duckdb_path), read_only=True)
+    try:
+        counts = DatasetSnapshotCounts(
+            stocks=_query_scalar_int(conn, "SELECT COUNT(*) FROM stocks"),
+            stock_data=_query_scalar_int(conn, "SELECT COUNT(*) FROM stock_data"),
+            topix_data=_query_scalar_int(conn, "SELECT COUNT(*) FROM topix_data"),
+            indices_data=_query_scalar_int(conn, "SELECT COUNT(*) FROM indices_data"),
+            margin_data=_query_scalar_int(conn, "SELECT COUNT(*) FROM margin_data"),
+            statements=_query_scalar_int(conn, "SELECT COUNT(*) FROM statements"),
+            dataset_info=_query_scalar_int(conn, "SELECT COUNT(*) FROM dataset_info"),
+        )
+        coverage = DatasetSnapshotCoverage(
+            totalStocks=counts.stocks,
+            stocksWithQuotes=_query_scalar_int(conn, "SELECT COUNT(DISTINCT code) FROM stock_data"),
+            stocksWithStatements=_query_scalar_int(conn, "SELECT COUNT(DISTINCT code) FROM statements"),
+            stocksWithMargin=_query_scalar_int(conn, "SELECT COUNT(DISTINCT code) FROM margin_data"),
+        )
+        date_row = conn.execute("SELECT MIN(date), MAX(date) FROM stock_data").fetchone()
+    finally:
+        conn.close()
+
+    date_range = None
+    if date_row is not None and date_row[0] is not None:
+        date_range = DatasetSnapshotDateRange(min=str(date_row[0]), max=str(date_row[1]))
+    return DatasetSnapshotInspection(counts=counts, coverage=coverage, date_range=date_range)
+
+
+def read_dataset_snapshot_manifest(snapshot_dir: str | Path) -> DatasetSnapshotManifest:
+    manifest_path = Path(snapshot_dir) / "manifest.v1.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return DatasetSnapshotManifest.model_validate(payload)
+
+
+def validate_dataset_snapshot(snapshot_dir: str | Path) -> DatasetSnapshotManifest:
+    snapshot_root = Path(snapshot_dir)
+    manifest = read_dataset_snapshot_manifest(snapshot_root)
+    if manifest.schemaVersion != 1:
+        raise RuntimeError(f"Unsupported dataset snapshot schemaVersion: {manifest.schemaVersion}")
+
+    duckdb_path = snapshot_root / manifest.dataset.duckdbFile
+    if not duckdb_path.exists():
+        raise FileNotFoundError(f"dataset.duckdb not found: {duckdb_path}")
+    if _sha256_of_file(duckdb_path) != manifest.checksums.duckdbSha256:
+        raise RuntimeError(f"dataset.duckdb checksum mismatch: {duckdb_path}")
+
+    compatibility_db = manifest.dataset.compatibilityDbFile
+    compatibility_sha = manifest.checksums.compatibilityDbSha256
+    if compatibility_db and compatibility_sha:
+        compatibility_path = snapshot_root / compatibility_db
+        if not compatibility_path.exists():
+            raise FileNotFoundError(f"dataset.db compatibility artifact not found: {compatibility_path}")
+        if _sha256_of_file(compatibility_path) != compatibility_sha:
+            raise RuntimeError(f"dataset.db checksum mismatch: {compatibility_path}")
+
+    parquet_dir = snapshot_root / manifest.dataset.parquetDir
+    if not parquet_dir.exists():
+        raise FileNotFoundError(f"Parquet directory not found: {parquet_dir}")
+    for file_name, expected_sha in manifest.checksums.parquet.items():
+        parquet_path = parquet_dir / file_name
+        if not parquet_path.exists():
+            raise FileNotFoundError(f"Parquet file not found: {parquet_path}")
+        if _sha256_of_file(parquet_path) != expected_sha:
+            raise RuntimeError(f"Parquet checksum mismatch: {parquet_path}")
+
+    inspection = inspect_dataset_snapshot_duckdb(duckdb_path)
+    if inspection.counts != manifest.counts:
+        raise RuntimeError("Dataset snapshot manifest counts mismatch")
+    if inspection.coverage != manifest.coverage:
+        raise RuntimeError("Dataset snapshot manifest coverage mismatch")
+    if inspection.date_range != manifest.dateRange:
+        raise RuntimeError("Dataset snapshot manifest dateRange mismatch")
+    logical_checksum = build_dataset_snapshot_logical_checksum(
+        counts=inspection.counts,
+        coverage=inspection.coverage,
+        date_range=inspection.date_range,
+    )
+    if logical_checksum != manifest.checksums.logicalSha256:
+        raise RuntimeError("Dataset snapshot logical checksum mismatch")
+
+    return manifest
+
+
+class DatasetSnapshotReader:
+    """Resolve and validate a dataset snapshot, then read directly from DuckDB."""
+
+    def __init__(self, snapshot_dir: str) -> None:
+        self._snapshot_dir = Path(snapshot_dir)
+        self._manifest = validate_dataset_snapshot(self._snapshot_dir)
+        compatibility_name = self._manifest.dataset.compatibilityDbFile
+        if not compatibility_name:
+            raise RuntimeError("Dataset snapshot compatibility artifact is not configured")
+        compatibility_path = self._snapshot_dir / compatibility_name
+        if not compatibility_path.exists():
+            raise FileNotFoundError(f"Dataset snapshot compatibility artifact not found: {compatibility_path}")
+
+        self._duckdb_path = self._snapshot_dir / self._manifest.dataset.duckdbFile
+        self._conns: dict[int, Any] = {}
+        self._conn_lock = threading.Lock()
+        self._duckdb_statements_columns_cache: set[str] | None = None
+
+    @property
+    def snapshot_dir(self) -> Path:
+        return self._snapshot_dir
+
+    @property
+    def manifest(self) -> DatasetSnapshotManifest:
+        return self._manifest
+
+    def _create_connection(self) -> Any:
+        return _connect_duckdb(self._duckdb_path, read_only=True)
+
+    def _get_thread_connection(self) -> Any:
+        thread_id = threading.get_ident()
+        conn = self._conns.get(thread_id)
+        if conn is not None:
+            return conn
+
+        with self._conn_lock:
+            conn = self._conns.get(thread_id)
+            if conn is None:
+                conn = self._create_connection()
+                self._conns[thread_id] = conn
+        return conn
+
+    @property
+    def conn(self) -> Any:
+        return self._get_thread_connection()
+
+    def close(self) -> None:
+        with self._conn_lock:
+            conns = list(self._conns.values())
+            self._conns.clear()
+        for conn in conns:
+            conn.close()
+
+    def _adapt_rows(self, cursor: Any, rows: list[tuple[Any, ...]]) -> list[_DuckDbRow]:
+        description = getattr(cursor, "description", None) or []
+        columns = tuple(str(column[0]) for column in description if column)
+        if not columns:
+            return []
+        index_map = {column: idx for idx, column in enumerate(columns)}
+        return [
+            _DuckDbRow(_columns=columns, _values=tuple(row), _index_map=index_map)
+            for row in rows
+        ]
+
+    def query(self, sql: str, params: tuple[Any, ...] = ()) -> list[_DuckDbRow]:
+        cursor = self.conn.execute(sql, params)
+        return self._adapt_rows(cursor, cursor.fetchall())
+
+    def query_one(self, sql: str, params: tuple[Any, ...] = ()) -> _DuckDbRow | None:
+        cursor = self.conn.execute(sql, params)
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        adapted = self._adapt_rows(cursor, [tuple(row)])
+        return adapted[0] if adapted else None
+
+    def _get_statements_columns(self) -> set[str]:
+        if self._duckdb_statements_columns_cache is not None:
+            return self._duckdb_statements_columns_cache
+        rows = self.conn.execute("PRAGMA table_info('statements')").fetchall()
+        columns = {
+            str(row[1])
+            for row in rows
+            if row and len(row) > 1 and row[1]
+        }
+        self._duckdb_statements_columns_cache = columns
+        return columns
+
+    def get_stocks(
+        self,
+        sector: str | None = None,
+        market: str | None = None,
+    ) -> list[_DuckDbRow]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if sector:
+            clauses.append("sector_33_name = ?")
+            params.append(sector)
+        if market:
+            clauses.append("market_code = ?")
+            params.append(market)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        return self.query(
+            f"SELECT * FROM stocks {where_sql} ORDER BY code",
+            tuple(params),
+        )
+
+    def get_stock_ohlcv(
+        self,
+        code: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[_DuckDbRow]:
+        normalized = normalize_stock_code(code)
+        clauses = ["code = ?"]
+        params: list[Any] = [normalized]
+        if start:
+            clauses.append("date >= ?")
+            params.append(start)
+        if end:
+            clauses.append("date <= ?")
+            params.append(end)
+        return self.query(
+            f"SELECT * FROM stock_data WHERE {' AND '.join(clauses)} ORDER BY date",
+            tuple(params),
+        )
+
+    def get_ohlcv_batch(self, codes: list[str]) -> dict[str, list[_DuckDbRow]]:
+        normalized = [normalize_stock_code(code) for code in codes]
+        if not normalized:
+            return {}
+        placeholders = ",".join("?" for _ in normalized)
+        rows = self.query(
+            f"""
+            SELECT * FROM stock_data
+            WHERE code IN ({placeholders})
+            ORDER BY code, date
+            """,
+            tuple(normalized),
+        )
+        result: dict[str, list[_DuckDbRow]] = {code: [] for code in normalized}
+        for row in rows:
+            result.setdefault(str(row.code), []).append(row)
+        return result
+
+    def get_topix(
+        self,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[_DuckDbRow]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if start:
+            clauses.append("date >= ?")
+            params.append(start)
+        if end:
+            clauses.append("date <= ?")
+            params.append(end)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        return self.query(
+            f"SELECT * FROM topix_data {where_sql} ORDER BY date",
+            tuple(params),
+        )
+
+    def get_indices(self) -> list[_DuckDbRow]:
+        return self.query(
+            """
+            SELECT DISTINCT code, sector_name
+            FROM indices_data
+            ORDER BY code
+            """
+        )
+
+    def get_index_data(
+        self,
+        code: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[_DuckDbRow]:
+        clauses = ["code = ?"]
+        params: list[Any] = [code]
+        if start:
+            clauses.append("date >= ?")
+            params.append(start)
+        if end:
+            clauses.append("date <= ?")
+            params.append(end)
+        return self.query(
+            f"SELECT * FROM indices_data WHERE {' AND '.join(clauses)} ORDER BY date",
+            tuple(params),
+        )
+
+    def get_margin(
+        self,
+        code: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[_DuckDbRow]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if code:
+            clauses.append("code = ?")
+            params.append(normalize_stock_code(code))
+        if start:
+            clauses.append("date >= ?")
+            params.append(start)
+        if end:
+            clauses.append("date <= ?")
+            params.append(end)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        return self.query(
+            f"SELECT * FROM margin_data {where_sql} ORDER BY date",
+            tuple(params),
+        )
+
+    def get_margin_batch(self, codes: list[str]) -> dict[str, list[_DuckDbRow]]:
+        normalized = [normalize_stock_code(code) for code in codes]
+        if not normalized:
+            return {}
+        placeholders = ",".join("?" for _ in normalized)
+        rows = self.query(
+            f"""
+            SELECT * FROM margin_data
+            WHERE code IN ({placeholders})
+            ORDER BY code, date
+            """,
+            tuple(normalized),
+        )
+        result: dict[str, list[_DuckDbRow]] = {code: [] for code in normalized}
+        for row in rows:
+            result.setdefault(str(row.code), []).append(row)
+        return result
+
+    def get_statements(
+        self,
+        code: str,
+        start: str | None = None,
+        end: str | None = None,
+        period_type: str = "all",
+        actual_only: bool = True,
+    ) -> list[_DuckDbRow]:
+        normalized = normalize_stock_code(code)
+        clauses = ["code = ?"]
+        params: list[Any] = [normalized]
+        if start:
+            clauses.append("disclosed_date >= ?")
+            params.append(start)
+        if end:
+            clauses.append("disclosed_date <= ?")
+            params.append(end)
+
+        period_values = _resolve_period_filter_values(period_type)
+        if period_values:
+            placeholders = ",".join("?" for _ in period_values)
+            clauses.append(f"type_of_current_period IN ({placeholders})")
+            params.extend(period_values)
+
+        if actual_only:
+            actual_clause = " OR ".join(f"{column} IS NOT NULL" for column in _ACTUAL_ONLY_COLUMNS)
+            clauses.append(f"({actual_clause})")
+
+        return self.query(
+            f"SELECT * FROM statements WHERE {' AND '.join(clauses)} ORDER BY disclosed_date",
+            tuple(params),
+        )
+
+    def get_statements_batch(
+        self,
+        codes: list[str],
+        start: str | None = None,
+        end: str | None = None,
+        period_type: str = "all",
+        actual_only: bool = True,
+    ) -> dict[str, list[_DuckDbRow]]:
+        normalized = [normalize_stock_code(code) for code in codes]
+        if not normalized:
+            return {}
+        code_placeholders = ",".join("?" for _ in normalized)
+        clauses = [f"code IN ({code_placeholders})"]
+        params: list[Any] = list(normalized)
+        if start:
+            clauses.append("disclosed_date >= ?")
+            params.append(start)
+        if end:
+            clauses.append("disclosed_date <= ?")
+            params.append(end)
+        period_values = _resolve_period_filter_values(period_type)
+        if period_values:
+            placeholders = ",".join("?" for _ in period_values)
+            clauses.append(f"type_of_current_period IN ({placeholders})")
+            params.extend(period_values)
+        if actual_only:
+            actual_clause = " OR ".join(f"{column} IS NOT NULL" for column in _ACTUAL_ONLY_COLUMNS)
+            clauses.append(f"({actual_clause})")
+
+        rows = self.query(
+            f"""
+            SELECT * FROM statements
+            WHERE {' AND '.join(clauses)}
+            ORDER BY code, disclosed_date
+            """,
+            tuple(params),
+        )
+        result: dict[str, list[_DuckDbRow]] = {code: [] for code in normalized}
+        for row in rows:
+            result.setdefault(str(row.code), []).append(row)
+        return result
+
+    def get_sectors(self) -> list[dict[str, str]]:
+        rows = self.query(
+            """
+            SELECT DISTINCT sector_33_code, sector_33_name
+            FROM stocks
+            ORDER BY sector_33_code
+            """
+        )
+        return [{"code": str(row[0]), "name": str(row[1])} for row in rows]
+
+    def get_sector_mapping(self) -> dict[str, str]:
+        return {sector["code"]: sector["name"] for sector in self.get_sectors()}
+
+    def get_sector_stock_mapping(self) -> dict[str, list[str]]:
+        rows = self.query(
+            """
+            SELECT sector_33_name, code
+            FROM stocks
+            ORDER BY sector_33_name, code
+            """
+        )
+        result: dict[str, list[str]] = {}
+        for row in rows:
+            result.setdefault(str(row[0]), []).append(str(row[1]))
+        return result
+
+    def get_sector_stocks(self, sector_name: str) -> list[_DuckDbRow]:
+        return self.query(
+            """
+            SELECT *
+            FROM stocks
+            WHERE sector_33_name = ?
+            ORDER BY code
+            """,
+            (sector_name,),
+        )
+
+    def get_dataset_info(self) -> dict[str, str]:
+        rows = self.query("SELECT key, value FROM dataset_info")
+        return {str(row.key): str(row.value) for row in rows}
+
+    def get_stock_count(self) -> int:
+        row = self.query_one("SELECT COUNT(*) AS count FROM stocks")
+        return int(row.count) if row is not None else 0
+
+    def get_stock_list_with_counts(self, min_records: int = 100) -> list[_DuckDbRow]:
+        return self.query(
+            """
+            SELECT
+                s.code AS stockCode,
+                COUNT(sd.date) AS record_count,
+                MIN(sd.date) AS start_date,
+                MAX(sd.date) AS end_date
+            FROM stocks s
+            LEFT JOIN stock_data sd ON s.code = sd.code
+            GROUP BY s.code
+            HAVING COUNT(sd.date) >= ?
+            ORDER BY s.code
+            """,
+            (min_records,),
+        )
+
+    def get_index_list_with_counts(self, min_records: int = 100) -> list[_DuckDbRow]:
+        return self.query(
+            """
+            SELECT
+                code AS indexCode,
+                MIN(sector_name) AS indexName,
+                COUNT(date) AS record_count,
+                MIN(date) AS start_date,
+                MAX(date) AS end_date
+            FROM indices_data
+            GROUP BY code
+            HAVING COUNT(date) >= ?
+            ORDER BY code
+            """,
+            (min_records,),
+        )
+
+    def get_margin_list(self, min_records: int = 10) -> list[_DuckDbRow]:
+        return self.query(
+            """
+            SELECT
+                code AS stockCode,
+                COUNT(date) AS record_count,
+                MIN(date) AS start_date,
+                MAX(date) AS end_date,
+                AVG(long_margin_volume) AS avg_long_margin,
+                AVG(short_margin_volume) AS avg_short_margin
+            FROM margin_data
+            GROUP BY code
+            HAVING COUNT(date) >= ?
+            ORDER BY code
+            """,
+            (min_records,),
+        )
+
+    def search_stocks(self, term: str, exact: bool = False, limit: int = 50) -> list[_DuckDbRow]:
+        if exact:
+            return self.query(
+                """
+                SELECT code, company_name, 'exact' AS match_type
+                FROM stocks
+                WHERE code = ? OR company_name = ?
+                LIMIT ?
+                """,
+                (term, term, limit),
+            )
+        pattern = f"%{term}%"
+        return self.query(
+            """
+            SELECT code, company_name, 'partial' AS match_type
+            FROM stocks
+            WHERE code LIKE ? OR company_name LIKE ?
+            ORDER BY code
+            LIMIT ?
+            """,
+            (pattern, pattern, limit),
+        )
+
+    def get_sample_codes(self, size: int = 10, seed: int | None = None) -> list[str]:
+        rows = self.query("SELECT code FROM stocks ORDER BY code")
+        codes = [str(row[0]) for row in rows]
+        if not codes:
+            return []
+        rng = random.Random(seed)  # noqa: S311
+        return rng.sample(codes, min(size, len(codes)))
+
+    def get_table_counts(self) -> dict[str, int]:
+        tables = (
+            "stocks",
+            "stock_data",
+            "topix_data",
+            "indices_data",
+            "margin_data",
+            "statements",
+            "dataset_info",
+        )
+        result: dict[str, int] = {}
+        for table_name in tables:
+            row = self.query_one(f"SELECT COUNT(*) AS count FROM {table_name}")
+            result[table_name] = int(row.count) if row is not None else 0
+        return result
+
+    def get_date_range(self) -> dict[str, str] | None:
+        row = self.query_one(
+            """
+            SELECT MIN(date) AS min, MAX(date) AS max
+            FROM stock_data
+            """
+        )
+        if row is None or row.min is None:
+            return None
+        return {"min": str(row.min), "max": str(row.max)}
+
+    def get_sectors_with_count(self) -> list[_DuckDbRow]:
+        return self.query(
+            """
+            SELECT sector_33_name AS sectorName, COUNT(code) AS count
+            FROM stocks
+            GROUP BY sector_33_name
+            ORDER BY sector_33_name
+            """
+        )
+
+    def get_stocks_with_quotes_count(self) -> int:
+        row = self.query_one("SELECT COUNT(DISTINCT code) AS count FROM stock_data")
+        return int(row.count) if row is not None else 0
+
+    def get_stocks_with_margin_count(self) -> int:
+        row = self.query_one("SELECT COUNT(DISTINCT code) AS count FROM margin_data")
+        return int(row.count) if row is not None else 0
+
+    def get_stocks_with_statements_count(self) -> int:
+        row = self.query_one("SELECT COUNT(DISTINCT code) AS count FROM statements")
+        return int(row.count) if row is not None else 0
+
+    def get_fk_orphan_counts(self) -> dict[str, int]:
+        stock_data_orphans = self.query_one(
+            """
+            SELECT COUNT(*) AS count
+            FROM stock_data sd
+            LEFT JOIN stocks s ON sd.code = s.code
+            WHERE s.code IS NULL
+            """
+        )
+        margin_data_orphans = self.query_one(
+            """
+            SELECT COUNT(*) AS count
+            FROM margin_data m
+            LEFT JOIN stocks s ON m.code = s.code
+            WHERE s.code IS NULL
+            """
+        )
+        statements_orphans = self.query_one(
+            """
+            SELECT COUNT(*) AS count
+            FROM statements st
+            LEFT JOIN stocks s ON st.code = s.code
+            WHERE s.code IS NULL
+            """
+        )
+        return {
+            "stockDataOrphans": int(stock_data_orphans.count) if stock_data_orphans is not None else 0,
+            "marginDataOrphans": int(margin_data_orphans.count) if margin_data_orphans is not None else 0,
+            "statementsOrphans": int(statements_orphans.count) if statements_orphans is not None else 0,
+        }
+
+    def get_stocks_without_quotes_count(self) -> int:
+        row = self.query_one(
+            """
+            SELECT COUNT(DISTINCT s.code) AS count
+            FROM stocks s
+            LEFT JOIN stock_data sd ON s.code = sd.code
+            WHERE sd.code IS NULL
+            """
+        )
+        return int(row.count) if row is not None else 0

--- a/apps/bt/tests/unit/data/test_access_mode_and_clients.py
+++ b/apps/bt/tests/unit/data/test_access_mode_and_clients.py
@@ -88,6 +88,51 @@ def test_resolve_dataset_db_uses_cache(
     assert len(init_calls) == 1
 
 
+def test_resolve_dataset_db_prefers_snapshot_reader(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_settings(monkeypatch, tmp_path)
+    snapshot_dir = tmp_path / "sample"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "dataset.duckdb").write_text("duckdb", encoding="utf-8")
+
+    init_calls: list[str] = []
+
+    class _FakeSnapshotReader:
+        def __init__(self, snapshot_path: str) -> None:
+            init_calls.append(snapshot_path)
+
+    monkeypatch.setattr(clients, "DatasetSnapshotReader", _FakeSnapshotReader)
+
+    resolved = clients._resolve_dataset_db("sample")
+
+    assert isinstance(resolved, _FakeSnapshotReader)
+    assert init_calls == [str(snapshot_dir)]
+
+
+def test_resolve_dataset_db_uses_snapshot_compatibility_db_when_duckdb_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_settings(monkeypatch, tmp_path)
+    snapshot_dir = tmp_path / "sample"
+    snapshot_dir.mkdir()
+    compatibility_db_path = snapshot_dir / "dataset.db"
+    compatibility_db_path.write_text("", encoding="utf-8")
+
+    init_calls: list[str] = []
+
+    class _FakeDatasetDb:
+        def __init__(self, db_path: str) -> None:
+            init_calls.append(db_path)
+
+    monkeypatch.setattr(clients, "DatasetDb", _FakeDatasetDb)
+
+    resolved = clients._resolve_dataset_db("sample")
+
+    assert isinstance(resolved, _FakeDatasetDb)
+    assert init_calls == [str(compatibility_db_path)]
+
+
 def test_resolve_market_reader_raises_when_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/bt/tests/unit/server/test_dataset_builder_service_branches.py
+++ b/apps/bt/tests/unit/server/test_dataset_builder_service_branches.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import sqlite3
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -18,6 +19,7 @@ from src.application.services.dataset_builder_service import (
 from src.application.services.dataset_presets import PresetConfig
 from src.application.services.generic_job_manager import GenericJobManager
 from src.entrypoints.http.schemas.job import JobStatus
+from src.infrastructure.db.market.dataset_snapshot_reader import validate_dataset_snapshot
 
 
 @pytest.fixture
@@ -32,6 +34,7 @@ def stub_manifest_writer_for_dummy_db_paths(monkeypatch, request):
     if request.node.name in {
         "test_build_dataset_writes_manifest_v1",
         "test_build_dataset_rerun_keeps_logical_checksum_reproducible",
+        "test_build_dataset_manifest_uses_duckdb_state_as_sot",
     }:
         return
 
@@ -55,11 +58,18 @@ async def _create_job(
     *,
     name: str = "dataset",
     preset: str = "quickTesting",
+    overwrite: bool = False,
     resume: bool = False,
     timeout_minutes: int = 35,
 ):
     job = await manager.create_job(
-        DatasetJobData(name=name, preset=preset, resume=resume, timeout_minutes=timeout_minutes)
+        DatasetJobData(
+            name=name,
+            preset=preset,
+            overwrite=overwrite,
+            resume=resume,
+            timeout_minutes=timeout_minutes,
+        )
     )
     assert job is not None
     return job
@@ -241,7 +251,7 @@ async def test_build_dataset_success_with_warnings(monkeypatch, isolated_dataset
     assert result.success is True
     assert result.totalStocks == 2
     assert result.processedStocks == 1
-    assert result.outputPath == "/tmp/full.db"
+    assert result.outputPath == "/tmp/full"
     assert result.warnings is not None
     assert any("Stock 2222" in warning for warning in result.warnings)
     assert any("TOPIX:" in warning for warning in result.warnings)
@@ -344,18 +354,26 @@ async def test_build_dataset_writes_manifest_v1(monkeypatch, isolated_dataset_ma
     result = await _build_dataset(job, resolver, client)
     assert result.success is True
 
-    manifest_path = tmp_path / "manifest.manifest.v1.json"
+    manifest_path = tmp_path / "manifest" / "manifest.v1.json"
     assert manifest_path.exists() is True
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    validated = validate_dataset_snapshot(manifest_path.parent)
 
     assert manifest["schemaVersion"] == 1
     assert manifest["dataset"]["name"] == "dataset"
-    assert manifest["dataset"]["dbFile"] == "manifest.db"
+    assert manifest["dataset"]["duckdbFile"] == "dataset.duckdb"
+    assert manifest["dataset"]["compatibilityDbFile"] == "dataset.db"
     assert manifest["counts"]["stocks"] == 1
     assert manifest["coverage"]["stocksWithQuotes"] == 1
-    assert manifest["checksums"]["datasetDbSha256"]
+    assert manifest["checksums"]["duckdbSha256"]
+    assert manifest["checksums"]["compatibilityDbSha256"]
     assert manifest["checksums"]["logicalSha256"]
-    assert manifest["checksums"]["datasetDbSha256"] == hashlib.sha256(db_path.read_bytes()).hexdigest()
+    assert manifest["checksums"]["parquet"]["stocks.parquet"]
+    assert manifest["checksums"]["parquet"]["stock_data.parquet"]
+    assert manifest["dateRange"] == {"min": "2026-01-01", "max": "2026-01-01"}
+    assert validated.dataset.name == "dataset"
+    compatibility_db = tmp_path / "manifest" / "dataset.db"
+    assert manifest["checksums"]["compatibilityDbSha256"] == hashlib.sha256(compatibility_db.read_bytes()).hexdigest()
 
 
 @pytest.mark.asyncio
@@ -391,7 +409,7 @@ async def test_build_dataset_rerun_keeps_logical_checksum_reproducible(
     first_result = await _build_dataset(job_first, resolver, client)
     assert first_result.success is True
     isolated_dataset_manager.complete_job(job_first.job_id, first_result)
-    first_manifest_path = tmp_path / "repro.manifest.v1.json"
+    first_manifest_path = tmp_path / "repro" / "manifest.v1.json"
     first_manifest = json.loads(first_manifest_path.read_text(encoding="utf-8"))
 
     job_second = await _create_job(isolated_dataset_manager, name="repro", preset="quick")
@@ -403,6 +421,67 @@ async def test_build_dataset_rerun_keeps_logical_checksum_reproducible(
     assert first_manifest["checksums"]["logicalSha256"] == second_manifest["checksums"]["logicalSha256"]
     assert first_manifest["counts"] == second_manifest["counts"]
     assert first_manifest["coverage"] == second_manifest["coverage"]
+
+
+@pytest.mark.asyncio
+async def test_build_dataset_manifest_uses_duckdb_state_as_sot(
+    monkeypatch,
+    isolated_dataset_manager,
+    tmp_path,
+):
+    job = await _create_job(isolated_dataset_manager, name="duckdb-sot", preset="quick")
+    resolver = MagicMock()
+    db_path = tmp_path / "duckdb-sot.db"
+    resolver.get_db_path.return_value = str(db_path)
+
+    preset = PresetConfig(
+        markets=["prime"],
+        include_topix=False,
+        include_statements=False,
+        include_margin=False,
+        include_sector_indices=False,
+    )
+    monkeypatch.setattr(dataset_builder_service, "get_preset", lambda _name: preset)
+
+    async def fake_get_paginated(path: str, params=None):
+        if path == "/equities/master":
+            return [_master_row("11110", "A")]
+        if path == "/equities/bars/daily":
+            return [_daily_bar_row()]
+        return []
+
+    client = AsyncMock()
+    client.get_paginated.side_effect = fake_get_paginated
+
+    result = await _build_dataset(job, resolver, client)
+    assert result.success is True
+
+    compatibility_db = tmp_path / "duckdb-sot" / "dataset.db"
+    conn = sqlite3.connect(compatibility_db)
+    conn.execute(
+        """
+        INSERT INTO stocks (
+            code, company_name, market_code, market_name, sector_17_code, sector_17_name,
+            sector_33_code, sector_33_name, listed_date
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("9999", "Stale", "0111", "Prime", "1", "A", "1010", "A", "2026-01-01"),
+    )
+    conn.commit()
+    conn.close()
+
+    manifest_path = tmp_path / "duckdb-sot" / "manifest.v1.json"
+    dataset_builder_service._write_dataset_manifest(
+        db_path=str(db_path),
+        dataset_name="duckdb-sot",
+        preset_name="quick",
+        manifest_path=manifest_path,
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["counts"]["stocks"] == 1
+    assert manifest["coverage"]["totalStocks"] == 1
+    assert validate_dataset_snapshot(tmp_path / "duckdb-sot").dataset.name == "duckdb-sot"
 
 
 @pytest.mark.asyncio
@@ -566,6 +645,63 @@ async def test_build_dataset_resume_skips_existing_stock_data_codes(monkeypatch,
     assert result.success is True
     assert fetched_codes == ["22220"]
     assert result.processedStocks == 1
+
+
+@pytest.mark.asyncio
+async def test_build_dataset_overwrite_removes_legacy_db_artifact(
+    monkeypatch,
+    isolated_dataset_manager,
+    tmp_path,
+):
+    job = await _create_job(isolated_dataset_manager, name="overwrite", preset="quick", overwrite=True)
+    legacy_db = tmp_path / "overwrite.db"
+    legacy_db.write_text("legacy", encoding="utf-8")
+
+    resolver = MagicMock()
+    resolver.get_db_path.return_value = str(tmp_path / "overwrite" / "dataset.db")
+    resolver.get_artifact_paths.return_value = [str(legacy_db)]
+
+    preset = PresetConfig(
+        markets=["prime"],
+        include_topix=False,
+        include_statements=False,
+        include_margin=False,
+        include_sector_indices=False,
+    )
+    monkeypatch.setattr(dataset_builder_service, "get_preset", lambda _name: preset)
+
+    class DummyWriter:
+        def __init__(self, db_path: str):
+            return None
+
+        def upsert_stocks(self, rows):
+            return len(rows)
+
+        def set_dataset_info(self, key: str, value: str):
+            return None
+
+        def upsert_stock_data(self, rows):
+            return len(rows)
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(dataset_builder_service, "DatasetWriter", DummyWriter)
+
+    async def fake_get_paginated(path: str, params=None):
+        if path == "/equities/master":
+            return [_master_row("11110", "A")]
+        if path == "/equities/bars/daily":
+            return [_daily_bar_row()]
+        return []
+
+    client = AsyncMock()
+    client.get_paginated.side_effect = fake_get_paginated
+
+    result = await _build_dataset(job, resolver, client)
+
+    assert result.success is True
+    assert legacy_db.exists() is False
 
 
 @pytest.mark.asyncio

--- a/apps/bt/tests/unit/server/test_dataset_resolver.py
+++ b/apps/bt/tests/unit/server/test_dataset_resolver.py
@@ -2,31 +2,89 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
+from pathlib import Path
 
 import pytest
 
 from src.application.services.dataset_resolver import DatasetResolver
+from src.infrastructure.db.dataset_io.dataset_writer import DatasetWriter
 
 
 @pytest.fixture
 def resolver_dir(tmp_path):
     """テスト用のデータセットディレクトリ"""
-    # テスト用 .db ファイルを作成
-    for name in ["test-market", "prime_v2", "quickTesting"]:
-        db_path = os.path.join(str(tmp_path), f"{name}.db")
-        conn = sqlite3.connect(db_path)
-        conn.execute("CREATE TABLE IF NOT EXISTS dataset_info (key TEXT PRIMARY KEY, value TEXT)")
-        conn.close()
+    for name in ["test-market", "prime_v2"]:
+        writer = DatasetWriter(str(tmp_path / f"{name}.db"))
+        writer.set_dataset_info("preset", "quickTesting")
+        writer.close()
+    legacy_db_path = tmp_path / "quickTesting.db"
+    conn = sqlite3.connect(legacy_db_path)
+    conn.execute("CREATE TABLE IF NOT EXISTS dataset_info (key TEXT PRIMARY KEY, value TEXT)")
+    conn.close()
+    compat_snapshot_dir = tmp_path / "compat_only"
+    compat_snapshot_dir.mkdir()
+    compat_conn = sqlite3.connect(compat_snapshot_dir / "dataset.db")
+    compat_conn.execute("CREATE TABLE IF NOT EXISTS dataset_info (key TEXT PRIMARY KEY, value TEXT)")
+    compat_conn.close()
     return str(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _patch_manifest_validation(monkeypatch) -> None:
+    from src.infrastructure.db.market import dataset_snapshot_reader as reader_module
+
+    def _fake_validate(snapshot_dir: str | Path):
+        snapshot_path = Path(snapshot_dir)
+        duckdb_path = snapshot_path / "dataset.duckdb"
+        db_path = snapshot_path / "dataset.db"
+        return reader_module.DatasetSnapshotManifest.model_validate(
+            {
+                "schemaVersion": 1,
+                "generatedAt": "2026-03-09T00:00:00+00:00",
+                "dataset": {
+                    "name": snapshot_path.name,
+                    "preset": "quickTesting",
+                    "duckdbFile": "dataset.duckdb",
+                    "compatibilityDbFile": "dataset.db",
+                    "parquetDir": "parquet",
+                },
+                "source": {
+                    "backend": "duckdb-parquet",
+                    "compatibilityArtifact": "dataset.db",
+                },
+                "counts": {
+                    "stocks": 0,
+                    "stock_data": 0,
+                    "topix_data": 0,
+                    "indices_data": 0,
+                    "margin_data": 0,
+                    "statements": 0,
+                    "dataset_info": 1,
+                },
+                "coverage": {
+                    "totalStocks": 0,
+                    "stocksWithQuotes": 0,
+                    "stocksWithStatements": 0,
+                    "stocksWithMargin": 0,
+                },
+                "checksums": {
+                    "duckdbSha256": reader_module._sha256_of_file(duckdb_path),
+                    "compatibilityDbSha256": reader_module._sha256_of_file(db_path),
+                    "logicalSha256": "x",
+                    "parquet": {},
+                },
+            }
+        )
+
+    monkeypatch.setattr(reader_module, "validate_dataset_snapshot", _fake_validate)
 
 
 class TestDatasetResolver:
     def test_list_datasets(self, resolver_dir: str) -> None:
         resolver = DatasetResolver(resolver_dir)
         names = resolver.list_datasets()
-        assert sorted(names) == ["prime_v2", "quickTesting", "test-market"]
+        assert sorted(names) == ["compat_only", "prime_v2", "quickTesting", "test-market"]
 
     def test_resolve_existing(self, resolver_dir: str) -> None:
         resolver = DatasetResolver(resolver_dir)
@@ -80,7 +138,31 @@ class TestDatasetResolver:
     def test_get_db_path(self, resolver_dir: str) -> None:
         resolver = DatasetResolver(resolver_dir)
         path = resolver.get_db_path("test-market")
-        assert path.endswith("test-market.db")
+        assert path.endswith("test-market/dataset.db")
+
+    def test_get_dataset_path_prefers_snapshot_dir(self, resolver_dir: str) -> None:
+        resolver = DatasetResolver(resolver_dir)
+        path = resolver.get_dataset_path("test-market")
+        assert path.endswith("test-market")
+
+    def test_exists_checks_snapshot_and_legacy(self, resolver_dir: str) -> None:
+        resolver = DatasetResolver(resolver_dir)
+        assert resolver.exists("test-market") is True
+        assert resolver.exists("compat_only") is True
+        assert resolver.exists("quickTesting") is True
+        assert resolver.exists("missing") is False
+
+    def test_resolve_uses_snapshot_compatibility_db_when_duckdb_missing(self, resolver_dir: str) -> None:
+        resolver = DatasetResolver(resolver_dir)
+        db = resolver.resolve("compat_only")
+        assert db is not None
+
+    def test_get_dataset_path_prefers_snapshot_dir_when_only_compatibility_db_exists(
+        self, resolver_dir: str
+    ) -> None:
+        resolver = DatasetResolver(resolver_dir)
+        path = resolver.get_dataset_path("compat_only")
+        assert path.endswith("compat_only")
 
     def test_empty_dir(self, tmp_path) -> None:
         resolver = DatasetResolver(str(tmp_path))

--- a/apps/bt/tests/unit/server/test_dataset_service.py
+++ b/apps/bt/tests/unit/server/test_dataset_service.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
+import os
+import sqlite3
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 from src.application.services import dataset_service
+from src.application.services.dataset_resolver import DatasetResolver
 
 
 class DummyResolver:
-    def __init__(self, base_dir: Path, names: list[str], db_by_name: dict[str, object | None]) -> None:
+    def __init__(
+        self,
+        base_dir: Path,
+        names: list[str],
+        db_by_name: dict[str, object | None],
+        path_by_name: dict[str, str] | None = None,
+    ) -> None:
         self._base_dir = base_dir
         self._names = names
         self._db_by_name = db_by_name
+        self._path_by_name = path_by_name or {}
 
     def list_datasets(self) -> list[str]:
         return self._names
@@ -19,11 +30,30 @@ class DummyResolver:
     def get_db_path(self, name: str) -> str:
         return str(self._base_dir / f"{name}.db")
 
+    def get_dataset_path(self, name: str) -> str:
+        return self._path_by_name.get(name, self.get_db_path(name))
+
+    def get_snapshot_dir(self, name: str) -> str:
+        return str(self._base_dir / name)
+
+    def get_legacy_db_path(self, name: str) -> str:
+        return self.get_db_path(name)
+
     def resolve(self, name: str) -> object | None:
         return self._db_by_name.get(name)
 
     def evict(self, name: str) -> None:
         self._db_by_name.pop(name, None)
+
+    def get_artifact_paths(self, name: str) -> list[str]:
+        paths: list[str] = []
+        dataset_path = self.get_dataset_path(name)
+        if os.path.exists(dataset_path):
+            paths.append(dataset_path)
+        legacy_db_path = self.get_legacy_db_path(name)
+        if legacy_db_path != dataset_path and os.path.exists(legacy_db_path):
+            paths.append(legacy_db_path)
+        return paths
 
 
 class DummyDb:
@@ -101,6 +131,29 @@ def test_list_datasets_skips_missing_files_and_handles_optional_metadata(tmp_pat
     assert items[1].preset is None and items[1].createdAt is None
 
 
+def test_list_datasets_uses_latest_file_mtime_for_snapshot_dir(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    latest_file = snapshot_dir / "dataset.duckdb"
+    latest_file.write_text("", encoding="utf-8")
+
+    dir_mtime = 1_700_000_000
+    file_mtime = 1_700_000_500
+    os.utime(snapshot_dir, (dir_mtime, dir_mtime))
+    os.utime(latest_file, (file_mtime, file_mtime))
+
+    resolver = DummyResolver(
+        base_dir=tmp_path,
+        names=["snapshot"],
+        db_by_name={"snapshot": None},
+        path_by_name={"snapshot": str(snapshot_dir)},
+    )
+
+    items = dataset_service.list_datasets(cast(Any, resolver))
+
+    assert items[0].lastModified == datetime.fromtimestamp(file_mtime).isoformat()
+
+
 def test_get_dataset_info_with_sparse_data_returns_errors_and_warnings(tmp_path: Path) -> None:
     db_path = tmp_path / "sparse.db"
     db_path.write_text("", encoding="utf-8")
@@ -142,6 +195,47 @@ def test_get_dataset_info_with_sparse_data_returns_errors_and_warnings(tmp_path:
     assert info.stats.dateRange.from_ == "-"
     assert info.stats.dateRange.to == "-"
     assert info.snapshot.createdAt == "2026-01-01T00:00:00+00:00"
+
+
+def test_get_dataset_info_uses_latest_file_mtime_for_snapshot_dir(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    latest_file = snapshot_dir / "manifest.v1.json"
+    latest_file.write_text("{}", encoding="utf-8")
+
+    dir_mtime = 1_700_001_000
+    file_mtime = 1_700_001_500
+    os.utime(snapshot_dir, (dir_mtime, dir_mtime))
+    os.utime(latest_file, (file_mtime, file_mtime))
+
+    db = DummyDb(
+        info={"preset": "primeMarket"},
+        table_counts={
+            "stock_data": 1,
+            "topix_data": 1,
+            "margin_data": 0,
+            "statements": 0,
+            "indices_data": 0,
+        },
+        date_range={"min": "2024-01-01", "max": "2024-01-01"},
+        stock_count=1,
+        stocks_with_quotes=1,
+        stocks_with_margin=0,
+        stocks_with_statements=0,
+        fk_orphans={"stockDataOrphans": 0, "marginDataOrphans": 0, "statementsOrphans": 0},
+        stocks_without_quotes=0,
+    )
+    resolver = DummyResolver(
+        base_dir=tmp_path,
+        names=["snapshot"],
+        db_by_name={"snapshot": db},
+        path_by_name={"snapshot": str(snapshot_dir)},
+    )
+
+    info = dataset_service.get_dataset_info(cast(Any, resolver), "snapshot")
+
+    assert info is not None
+    assert info.lastModified == datetime.fromtimestamp(file_mtime).isoformat()
 
 
 def test_get_dataset_info_with_healthy_data_has_no_warnings(tmp_path: Path) -> None:
@@ -231,3 +325,21 @@ def test_search_dataset_deduplicates_exact_and_partial_results() -> None:
     assert [row.code for row in result.results] == ["7203", "6758"]
     assert result.results[0].match_type == "exact"
     assert result.results[1].match_type == "partial"
+
+
+def test_delete_dataset_removes_snapshot_and_legacy_artifacts(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "sample"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "dataset.db").write_text("", encoding="utf-8")
+    legacy_db = tmp_path / "sample.db"
+    conn = sqlite3.connect(legacy_db)
+    conn.execute("CREATE TABLE IF NOT EXISTS dataset_info (key TEXT PRIMARY KEY, value TEXT)")
+    conn.close()
+
+    resolver = DatasetResolver(str(tmp_path))
+
+    deleted = dataset_service.delete_dataset(resolver, "sample")
+
+    assert deleted is True
+    assert not snapshot_dir.exists()
+    assert not legacy_db.exists()

--- a/apps/bt/tests/unit/server/test_dataset_snapshot_reader.py
+++ b/apps/bt/tests/unit/server/test_dataset_snapshot_reader.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.infrastructure.db.dataset_io.dataset_writer import DatasetWriter
+from src.infrastructure.db.market.dataset_snapshot_reader import (
+    DatasetSnapshotReader,
+    build_dataset_snapshot_logical_checksum,
+    inspect_dataset_snapshot_duckdb,
+    validate_dataset_snapshot,
+)
+
+
+def _create_snapshot(tmp_path: Path) -> Path:
+    writer = DatasetWriter(str(tmp_path / "sample.db"))
+    writer.upsert_stocks([
+        {
+            "code": "7203",
+            "company_name": "Toyota",
+            "market_code": "0111",
+            "market_name": "プライム",
+            "sector_17_code": "7",
+            "sector_17_name": "輸送用機器",
+            "sector_33_code": "3050",
+            "sector_33_name": "輸送用機器",
+            "listed_date": "1949-05-16",
+        }
+    ])
+    writer.set_dataset_info("preset", "quickTesting")
+    writer.close()
+
+    snapshot_dir = tmp_path / "sample"
+    compatibility_path = snapshot_dir / "dataset.db"
+    duckdb_path = snapshot_dir / "dataset.duckdb"
+    duckdb_sha = hashlib.sha256(duckdb_path.read_bytes()).hexdigest()
+    compatibility_sha = hashlib.sha256(compatibility_path.read_bytes()).hexdigest()
+    parquet_sha = hashlib.sha256((snapshot_dir / "parquet" / "stocks.parquet").read_bytes()).hexdigest()
+    inspection = inspect_dataset_snapshot_duckdb(duckdb_path)
+
+    manifest = {
+        "schemaVersion": 1,
+        "generatedAt": "2026-03-09T00:00:00+00:00",
+        "dataset": {
+            "name": "sample",
+            "preset": "quickTesting",
+            "duckdbFile": "dataset.duckdb",
+            "compatibilityDbFile": "dataset.db",
+            "parquetDir": "parquet",
+        },
+        "source": {
+            "backend": "duckdb-parquet",
+            "compatibilityArtifact": "dataset.db",
+        },
+        "counts": inspection.counts.model_dump(),
+        "coverage": inspection.coverage.model_dump(),
+        "checksums": {
+            "duckdbSha256": duckdb_sha,
+            "compatibilityDbSha256": compatibility_sha,
+            "logicalSha256": build_dataset_snapshot_logical_checksum(
+                counts=inspection.counts,
+                coverage=inspection.coverage,
+                date_range=inspection.date_range,
+            ),
+            "parquet": {
+                "stocks.parquet": parquet_sha,
+            },
+        },
+    }
+    if inspection.date_range is not None:
+        manifest["dateRange"] = inspection.date_range.model_dump()
+    (snapshot_dir / "manifest.v1.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return snapshot_dir
+
+
+def test_validate_dataset_snapshot_accepts_valid_bundle(tmp_path: Path) -> None:
+    snapshot_dir = _create_snapshot(tmp_path)
+
+    manifest = validate_dataset_snapshot(snapshot_dir)
+
+    assert manifest.dataset.name == "sample"
+
+
+def test_dataset_snapshot_reader_uses_compatibility_db(tmp_path: Path) -> None:
+    snapshot_dir = _create_snapshot(tmp_path)
+
+    reader = DatasetSnapshotReader(str(snapshot_dir))
+    try:
+        assert reader.get_dataset_info()["preset"] == "quickTesting"
+    finally:
+        reader.close()
+
+
+def test_dataset_snapshot_reader_prefers_duckdb_over_compatibility_db(tmp_path: Path) -> None:
+    snapshot_dir = _create_snapshot(tmp_path)
+    compatibility_path = snapshot_dir / "dataset.db"
+    conn = sqlite3.connect(compatibility_path)
+    conn.execute("UPDATE dataset_info SET value = 'stale' WHERE key = 'preset'")
+    conn.commit()
+    conn.close()
+    manifest_path = snapshot_dir / "manifest.v1.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["checksums"]["compatibilityDbSha256"] = hashlib.sha256(
+        compatibility_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    reader = DatasetSnapshotReader(str(snapshot_dir))
+    try:
+        assert reader.get_dataset_info()["preset"] == "quickTesting"
+    finally:
+        reader.close()
+
+
+def test_validate_dataset_snapshot_rejects_checksum_mismatch(tmp_path: Path) -> None:
+    snapshot_dir = _create_snapshot(tmp_path)
+    (snapshot_dir / "dataset.duckdb").write_text("tampered", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        validate_dataset_snapshot(snapshot_dir)
+
+
+def test_validate_dataset_snapshot_rejects_logical_checksum_mismatch(tmp_path: Path) -> None:
+    snapshot_dir = _create_snapshot(tmp_path)
+    manifest_path = snapshot_dir / "manifest.v1.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["checksums"]["logicalSha256"] = "stale"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="logical checksum mismatch"):
+        validate_dataset_snapshot(snapshot_dir)
+
+
+def test_validate_dataset_snapshot_rejects_compatibility_checksum_mismatch(tmp_path: Path) -> None:
+    snapshot_dir = _create_snapshot(tmp_path)
+    compatibility_path = snapshot_dir / "dataset.db"
+    conn = sqlite3.connect(compatibility_path)
+    conn.execute("UPDATE dataset_info SET value = 'tampered' WHERE key = 'preset'")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="dataset.db checksum mismatch"):
+        validate_dataset_snapshot(snapshot_dir)

--- a/apps/bt/tests/unit/server/test_dataset_writer.py
+++ b/apps/bt/tests/unit/server/test_dataset_writer.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 import os
+import shutil
 import tempfile
 
 import pytest
@@ -19,6 +20,7 @@ def writer() -> Generator[DatasetWriter, None, None]:
     yield w
     w.close()
     os.unlink(path)
+    shutil.rmtree(w.snapshot_dir)
 
 
 def test_ensure_schema(writer: DatasetWriter) -> None:
@@ -28,6 +30,8 @@ def test_ensure_schema(writer: DatasetWriter) -> None:
     assert "stocks" in tables
     assert "stock_data" in tables
     assert "dataset_info" in tables
+    assert writer.duckdb_path.exists() is True
+    assert writer.parquet_dir.exists() is True
 
 
 def test_upsert_stocks(writer: DatasetWriter) -> None:
@@ -158,3 +162,44 @@ def test_existing_code_helpers_and_topix_presence(writer: DatasetWriter) -> None
     assert writer.get_existing_index_codes() == {"0040"}
     assert writer.get_existing_margin_codes() == {"7203"}
     assert writer.get_existing_statement_codes() == {"7203"}
+
+
+def test_close_exports_parquet_and_compatibility_artifact() -> None:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    writer = DatasetWriter(path)
+    try:
+        writer.upsert_stocks([
+            {
+                "code": "7203",
+                "company_name": "Toyota",
+                "market_code": "111",
+                "market_name": "プライム",
+                "sector_17_code": "7",
+                "sector_17_name": "自動車",
+                "sector_33_code": "3700",
+                "sector_33_name": "輸送用機器",
+                "listed_date": "2000-01-01",
+                "created_at": "2024-01-01",
+            }
+        ])
+        writer.upsert_stock_data([
+            {
+                "code": "7203",
+                "date": "2024-01-04",
+                "open": 100,
+                "high": 110,
+                "low": 90,
+                "close": 105,
+                "volume": 1000,
+                "created_at": "2024-01-04",
+            }
+        ])
+        writer.close()
+        assert writer.compatibility_db_path.exists() is True
+        assert writer.duckdb_path.exists() is True
+        assert (writer.parquet_dir / "stocks.parquet").exists() is True
+        assert (writer.parquet_dir / "stock_data.parquet").exists() is True
+    finally:
+        os.unlink(path)
+        shutil.rmtree(writer.snapshot_dir)

--- a/apps/bt/tests/unit/server/test_routes_dataset.py
+++ b/apps/bt/tests/unit/server/test_routes_dataset.py
@@ -2,88 +2,128 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
 from src.application.services.dataset_resolver import DatasetResolver
 from src.entrypoints.http.app import create_app
+from src.infrastructure.db.dataset_io.dataset_writer import DatasetWriter
+
+
+def _build_snapshot(base_dir: Path, name: str) -> None:
+    writer = DatasetWriter(str(base_dir / f"{name}.db"))
+    writer.upsert_stocks([
+        {
+            "code": "7203",
+            "company_name": "トヨタ自動車",
+            "company_name_english": "TOYOTA",
+            "market_code": "0111",
+            "market_name": "プライム",
+            "sector_17_code": "7",
+            "sector_17_name": "輸送用機器",
+            "sector_33_code": "3050",
+            "sector_33_name": "輸送用機器",
+            "scale_category": "TOPIX Core30",
+            "listed_date": "1949-05-16",
+        },
+        {
+            "code": "9984",
+            "company_name": "ソフトバンク",
+            "company_name_english": "SB",
+            "market_code": "0111",
+            "market_name": "プライム",
+            "sector_17_code": "9",
+            "sector_17_name": "情報・通信業",
+            "sector_33_code": "3700",
+            "sector_33_name": "情報・通信業",
+            "scale_category": "TOPIX Core30",
+            "listed_date": "1994-07-22",
+        },
+    ])
+    writer.upsert_stock_data([
+        {
+            "code": "7203",
+            "date": "2024-01-04",
+            "open": 100,
+            "high": 110,
+            "low": 90,
+            "close": 105,
+            "volume": 1000,
+            "adjustment_factor": 1.0,
+        },
+        {
+            "code": "9984",
+            "date": "2024-01-04",
+            "open": 200,
+            "high": 210,
+            "low": 190,
+            "close": 205,
+            "volume": 500,
+            "adjustment_factor": 1.0,
+        },
+    ])
+    writer.set_dataset_info("preset", "primeMarket")
+    writer.set_dataset_info("created_at", "2026-01-01T00:00:00+00:00")
+    writer.set_dataset_info("stock_count", "2")
+    writer.close()
 
 
 @pytest.fixture
 def test_dataset_dir(tmp_path):
     """テスト用のデータセットディレクトリ"""
-    db_path = os.path.join(str(tmp_path), "test-market.db")
-    conn = sqlite3.connect(db_path)
-    conn.executescript("""
-        CREATE TABLE stocks (
-            code TEXT PRIMARY KEY, company_name TEXT NOT NULL,
-            company_name_english TEXT, market_code TEXT NOT NULL,
-            market_name TEXT NOT NULL, sector_17_code TEXT NOT NULL,
-            sector_17_name TEXT NOT NULL, sector_33_code TEXT NOT NULL,
-            sector_33_name TEXT NOT NULL, scale_category TEXT,
-            listed_date TEXT NOT NULL, created_at TEXT, updated_at TEXT
-        );
-        CREATE TABLE stock_data (
-            code TEXT NOT NULL, date TEXT NOT NULL,
-            open REAL NOT NULL, high REAL NOT NULL, low REAL NOT NULL,
-            close REAL NOT NULL, volume INTEGER NOT NULL,
-            adjustment_factor REAL, created_at TEXT,
-            PRIMARY KEY (code, date)
-        );
-        CREATE TABLE topix_data (
-            date TEXT PRIMARY KEY, open REAL NOT NULL, high REAL NOT NULL,
-            low REAL NOT NULL, close REAL NOT NULL, created_at TEXT
-        );
-        CREATE TABLE indices_data (
-            code TEXT NOT NULL, date TEXT NOT NULL,
-            open REAL, high REAL, low REAL, close REAL,
-            sector_name TEXT, created_at TEXT,
-            PRIMARY KEY (code, date)
-        );
-        CREATE TABLE dataset_info (
-            key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT
-        );
-        CREATE TABLE margin_data (
-            code TEXT NOT NULL, date TEXT NOT NULL,
-            long_margin_volume REAL, short_margin_volume REAL,
-            PRIMARY KEY (code, date)
-        );
-        CREATE TABLE statements (
-            code TEXT NOT NULL, disclosed_date TEXT NOT NULL,
-            earnings_per_share REAL, profit REAL, equity REAL,
-            type_of_current_period TEXT, type_of_document TEXT,
-            next_year_forecast_earnings_per_share REAL,
-            bps REAL, sales REAL, operating_profit REAL,
-            ordinary_profit REAL, operating_cash_flow REAL,
-            dividend_fy REAL, forecast_dividend_fy REAL,
-            next_year_forecast_dividend_fy REAL,
-            payout_ratio REAL, forecast_payout_ratio REAL,
-            next_year_forecast_payout_ratio REAL, forecast_eps REAL,
-            investing_cash_flow REAL, financing_cash_flow REAL,
-            cash_and_equivalents REAL, total_assets REAL,
-            shares_outstanding REAL, treasury_shares REAL,
-            PRIMARY KEY (code, disclosed_date)
-        );
-
-        INSERT INTO stocks VALUES ('7203', 'トヨタ自動車', 'TOYOTA', '0111', 'プライム', '7', '輸送用機器', '3050', '輸送用機器', 'TOPIX Core30', '1949-05-16', NULL, NULL);
-        INSERT INTO stocks VALUES ('9984', 'ソフトバンク', 'SB', '0111', 'プライム', '9', '情報・通信業', '3700', '情報・通信業', 'TOPIX Core30', '1994-07-22', NULL, NULL);
-
-        INSERT INTO stock_data VALUES ('7203', '2024-01-04', 100, 110, 90, 105, 1000, 1.0, NULL);
-        INSERT INTO stock_data VALUES ('9984', '2024-01-04', 200, 210, 190, 205, 500, 1.0, NULL);
-
-        INSERT INTO dataset_info VALUES ('preset', 'primeMarket', NULL);
-        INSERT INTO dataset_info VALUES ('created_at', '2026-01-01T00:00:00+00:00', NULL);
-        INSERT INTO dataset_info VALUES ('stock_count', '2', NULL);
-    """)
-    conn.close()
+    _build_snapshot(Path(tmp_path), "test-market")
     return str(tmp_path)
 
 
 @pytest.fixture
-def client(test_dataset_dir: str):
+def client(test_dataset_dir: str, monkeypatch: pytest.MonkeyPatch):
+    from src.infrastructure.db.market import dataset_snapshot_reader as reader_module
+
+    def _fake_validate(snapshot_dir: str | Path):
+        snapshot_path = Path(snapshot_dir)
+        return reader_module.DatasetSnapshotManifest.model_validate(
+            {
+                "schemaVersion": 1,
+                "generatedAt": "2026-03-09T00:00:00+00:00",
+                "dataset": {
+                    "name": snapshot_path.name,
+                    "preset": "primeMarket",
+                    "duckdbFile": "dataset.duckdb",
+                    "compatibilityDbFile": "dataset.db",
+                    "parquetDir": "parquet",
+                },
+                "source": {
+                    "backend": "duckdb-parquet",
+                    "compatibilityArtifact": "dataset.db",
+                },
+                "counts": {
+                    "stocks": 2,
+                    "stock_data": 2,
+                    "topix_data": 0,
+                    "indices_data": 0,
+                    "margin_data": 0,
+                    "statements": 0,
+                    "dataset_info": 3,
+                },
+                "coverage": {
+                    "totalStocks": 2,
+                    "stocksWithQuotes": 2,
+                    "stocksWithStatements": 0,
+                    "stocksWithMargin": 0,
+                },
+                "checksums": {
+                    "duckdbSha256": "x",
+                    "compatibilityDbSha256": "y",
+                    "logicalSha256": "z",
+                    "parquet": {},
+                },
+            }
+        )
+
+    monkeypatch.setattr(reader_module, "validate_dataset_snapshot", _fake_validate)
     app = create_app()
     app.state.dataset_resolver = DatasetResolver(test_dataset_dir)
     return TestClient(app, raise_server_exceptions=False)
@@ -101,7 +141,7 @@ class TestDatasetManagementRoutes:
         assert data[0]["createdAt"] == "2026-01-01T00:00:00+00:00"
 
     def test_list_datasets_handles_missing_dataset_info_table(self, client: TestClient, test_dataset_dir: str) -> None:
-        broken_db_path = os.path.join(test_dataset_dir, "broken.db")
+        broken_db_path = Path(test_dataset_dir) / "broken.db"
         conn = sqlite3.connect(broken_db_path)
         conn.executescript("""
             CREATE TABLE stocks (
@@ -211,15 +251,16 @@ class TestDatasetManagementRoutes:
 
     def test_delete_dataset(self, client: TestClient, test_dataset_dir: str) -> None:
         # Create a separate dataset for deletion
-        db_path = os.path.join(test_dataset_dir, "to-delete.db")
-        conn = sqlite3.connect(db_path)
-        conn.execute("CREATE TABLE dataset_info (key TEXT PRIMARY KEY, value TEXT)")
-        conn.close()
+        delete_dir = Path(test_dataset_dir) / "to-delete"
+        _build_snapshot(Path(test_dataset_dir), "to-delete")
+        legacy_db = Path(test_dataset_dir) / "to-delete.db"
+        legacy_db.write_text("", encoding="utf-8")
 
         resp = client.delete("/api/dataset/to-delete")
         assert resp.status_code == 200
         assert resp.json()["success"] is True
-        assert not os.path.exists(db_path)
+        assert not delete_dir.exists()
+        assert not legacy_db.exists()
 
     def test_delete_nonexistent(self, client: TestClient) -> None:
         resp = client.delete("/api/dataset/nonexistent")

--- a/apps/bt/tests/unit/server/test_routes_dataset_data.py
+++ b/apps/bt/tests/unit/server/test_routes_dataset_data.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import os
-import sqlite3
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,93 +10,257 @@ from fastapi.testclient import TestClient
 from src.entrypoints.http.routes import dataset_data as dataset_data_routes
 from src.entrypoints.http.app import create_app
 from src.application.services.dataset_resolver import DatasetResolver
+from src.infrastructure.db.dataset_io.dataset_writer import DatasetWriter
+
+
+def _build_snapshot(base_dir: Path, name: str) -> None:
+    writer = DatasetWriter(str(base_dir / f"{name}.db"))
+    writer.upsert_stocks([
+        {
+            "code": "7203",
+            "company_name": "トヨタ自動車",
+            "company_name_english": "TOYOTA",
+            "market_code": "0111",
+            "market_name": "プライム",
+            "sector_17_code": "7",
+            "sector_17_name": "輸送用機器",
+            "sector_33_code": "3050",
+            "sector_33_name": "輸送用機器",
+            "scale_category": "TOPIX Core30",
+            "listed_date": "1949-05-16",
+        },
+        {
+            "code": "9984",
+            "company_name": "ソフトバンク",
+            "company_name_english": "SB",
+            "market_code": "0111",
+            "market_name": "プライム",
+            "sector_17_code": "9",
+            "sector_17_name": "情報・通信業",
+            "sector_33_code": "3700",
+            "sector_33_name": "情報・通信業",
+            "scale_category": "TOPIX Core30",
+            "listed_date": "1994-07-22",
+        },
+    ])
+    writer.upsert_stock_data([
+        {
+            "code": "7203",
+            "date": "2024-01-04",
+            "open": 100,
+            "high": 110,
+            "low": 90,
+            "close": 105,
+            "volume": 1000,
+            "adjustment_factor": 1.0,
+        },
+        {
+            "code": "7203",
+            "date": "2024-01-05",
+            "open": 105,
+            "high": 115,
+            "low": 95,
+            "close": 110,
+            "volume": 1100,
+            "adjustment_factor": 1.0,
+        },
+        {
+            "code": "9984",
+            "date": "2024-01-04",
+            "open": 200,
+            "high": 210,
+            "low": 190,
+            "close": 205,
+            "volume": 500,
+            "adjustment_factor": 1.0,
+        },
+    ])
+    writer.upsert_topix_data([
+        {
+            "date": "2024-01-04",
+            "open": 2500,
+            "high": 2520,
+            "low": 2490,
+            "close": 2510,
+        }
+    ])
+    writer.upsert_indices_data([
+        {
+            "code": "0010",
+            "date": "2024-01-04",
+            "open": 100,
+            "high": 102,
+            "low": 99,
+            "close": 101,
+            "sector_name": "食料品",
+        }
+    ])
+    writer.upsert_margin_data([
+        {
+            "code": "7203",
+            "date": "2024-01-04",
+            "long_margin_volume": 50000,
+            "short_margin_volume": 30000,
+        },
+        {
+            "code": "9984",
+            "date": "2024-01-04",
+            "long_margin_volume": 40000,
+            "short_margin_volume": 20000,
+        },
+    ])
+    writer.upsert_statements([
+        {
+            "code": "7203",
+            "disclosed_date": "2024-01-30",
+            "earnings_per_share": 150.0,
+            "profit": 2000000,
+            "equity": 5000000,
+            "type_of_current_period": "FY",
+            "type_of_document": "AnnualReport",
+            "next_year_forecast_earnings_per_share": 160.0,
+            "bps": 3000,
+            "sales": 20000000,
+            "operating_profit": 1500000,
+            "ordinary_profit": 1600000,
+            "operating_cash_flow": 1800000,
+            "dividend_fy": 60.0,
+            "forecast_dividend_fy": 62.0,
+            "next_year_forecast_dividend_fy": 64.0,
+            "payout_ratio": 30.0,
+            "forecast_payout_ratio": 32.0,
+            "next_year_forecast_payout_ratio": 34.0,
+            "forecast_eps": 165.0,
+            "investing_cash_flow": -500000,
+            "financing_cash_flow": -300000,
+            "cash_and_equivalents": 4000000,
+            "total_assets": 50000000,
+            "shares_outstanding": 330000000,
+            "treasury_shares": 10000000,
+        },
+        {
+            "code": "7203",
+            "disclosed_date": "2024-04-30",
+            "earnings_per_share": 45.0,
+            "profit": 550000,
+            "equity": 5100000,
+            "type_of_current_period": "1Q",
+            "type_of_document": "QuarterlyReport",
+            "next_year_forecast_earnings_per_share": 170.0,
+            "bps": 3050,
+            "sales": 5200000,
+            "operating_profit": 420000,
+            "ordinary_profit": 430000,
+            "operating_cash_flow": 510000,
+            "dividend_fy": 15.0,
+            "forecast_dividend_fy": 16.0,
+            "next_year_forecast_dividend_fy": 17.0,
+            "payout_ratio": 28.0,
+            "forecast_payout_ratio": 29.0,
+            "next_year_forecast_payout_ratio": 30.0,
+            "forecast_eps": 172.0,
+            "investing_cash_flow": -110000,
+            "financing_cash_flow": -90000,
+            "cash_and_equivalents": 4100000,
+            "total_assets": 50100000,
+            "shares_outstanding": 331000000,
+            "treasury_shares": 10000000,
+        },
+        {
+            "code": "7203",
+            "disclosed_date": "2024-07-30",
+            "earnings_per_share": 48.0,
+            "profit": 600000,
+            "equity": 5200000,
+            "type_of_current_period": "Q1",
+            "type_of_document": "QuarterlyReport",
+            "next_year_forecast_earnings_per_share": 175.0,
+            "bps": 3100,
+            "sales": 5400000,
+            "operating_profit": 450000,
+            "ordinary_profit": 460000,
+            "operating_cash_flow": 530000,
+            "dividend_fy": 16.0,
+            "forecast_dividend_fy": 17.0,
+            "next_year_forecast_dividend_fy": 18.0,
+            "payout_ratio": 29.0,
+            "forecast_payout_ratio": 30.0,
+            "next_year_forecast_payout_ratio": 31.0,
+            "forecast_eps": 176.0,
+            "investing_cash_flow": -100000,
+            "financing_cash_flow": -85000,
+            "cash_and_equivalents": 4200000,
+            "total_assets": 50200000,
+            "shares_outstanding": 332000000,
+            "treasury_shares": 10000000,
+        },
+        {
+            "code": "7203",
+            "disclosed_date": "2024-10-30",
+            "type_of_current_period": "FY",
+            "type_of_document": "ForecastRevision",
+            "next_year_forecast_earnings_per_share": 180.0,
+            "forecast_eps": 180.0,
+        },
+    ])
+    writer.set_dataset_info("preset", "primeMarket")
+    writer.close()
 
 
 @pytest.fixture
 def test_dataset_dir(tmp_path):
     """テスト用のデータセットディレクトリ + .db ファイル"""
-    db_path = os.path.join(str(tmp_path), "test-market.db")
-    conn = sqlite3.connect(db_path)
-    conn.executescript("""
-        CREATE TABLE stocks (
-            code TEXT PRIMARY KEY, company_name TEXT NOT NULL,
-            company_name_english TEXT, market_code TEXT NOT NULL,
-            market_name TEXT NOT NULL, sector_17_code TEXT NOT NULL,
-            sector_17_name TEXT NOT NULL, sector_33_code TEXT NOT NULL,
-            sector_33_name TEXT NOT NULL, scale_category TEXT,
-            listed_date TEXT NOT NULL, created_at TEXT, updated_at TEXT
-        );
-        CREATE TABLE stock_data (
-            code TEXT NOT NULL, date TEXT NOT NULL,
-            open REAL NOT NULL, high REAL NOT NULL, low REAL NOT NULL,
-            close REAL NOT NULL, volume INTEGER NOT NULL,
-            adjustment_factor REAL, created_at TEXT,
-            PRIMARY KEY (code, date)
-        );
-        CREATE TABLE topix_data (
-            date TEXT PRIMARY KEY, open REAL NOT NULL, high REAL NOT NULL,
-            low REAL NOT NULL, close REAL NOT NULL, created_at TEXT
-        );
-        CREATE TABLE indices_data (
-            code TEXT NOT NULL, date TEXT NOT NULL,
-            open REAL, high REAL, low REAL, close REAL,
-            sector_name TEXT, created_at TEXT,
-            PRIMARY KEY (code, date)
-        );
-        CREATE TABLE dataset_info (
-            key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT
-        );
-        CREATE TABLE margin_data (
-            code TEXT NOT NULL, date TEXT NOT NULL,
-            long_margin_volume REAL, short_margin_volume REAL,
-            PRIMARY KEY (code, date)
-        );
-        CREATE TABLE statements (
-            code TEXT NOT NULL, disclosed_date TEXT NOT NULL,
-            earnings_per_share REAL, profit REAL, equity REAL,
-            type_of_current_period TEXT, type_of_document TEXT,
-            next_year_forecast_earnings_per_share REAL,
-            bps REAL, sales REAL, operating_profit REAL,
-            ordinary_profit REAL, operating_cash_flow REAL,
-            dividend_fy REAL, forecast_dividend_fy REAL,
-            next_year_forecast_dividend_fy REAL,
-            payout_ratio REAL, forecast_payout_ratio REAL,
-            next_year_forecast_payout_ratio REAL, forecast_eps REAL,
-            investing_cash_flow REAL, financing_cash_flow REAL,
-            cash_and_equivalents REAL, total_assets REAL,
-            shares_outstanding REAL, treasury_shares REAL,
-            PRIMARY KEY (code, disclosed_date)
-        );
-
-        INSERT INTO stocks VALUES ('7203', 'トヨタ自動車', 'TOYOTA', '0111', 'プライム', '7', '輸送用機器', '3050', '輸送用機器', 'TOPIX Core30', '1949-05-16', NULL, NULL);
-        INSERT INTO stocks VALUES ('9984', 'ソフトバンク', 'SB', '0111', 'プライム', '9', '情報・通信業', '3700', '情報・通信業', 'TOPIX Core30', '1994-07-22', NULL, NULL);
-
-        INSERT INTO stock_data VALUES ('7203', '2024-01-04', 100, 110, 90, 105, 1000, 1.0, NULL);
-        INSERT INTO stock_data VALUES ('7203', '2024-01-05', 105, 115, 95, 110, 1100, 1.0, NULL);
-        INSERT INTO stock_data VALUES ('9984', '2024-01-04', 200, 210, 190, 205, 500, 1.0, NULL);
-
-        INSERT INTO topix_data VALUES ('2024-01-04', 2500, 2520, 2490, 2510, NULL);
-
-        INSERT INTO indices_data VALUES ('0010', '2024-01-04', 100, 102, 99, 101, '食料品', NULL);
-
-        INSERT INTO margin_data VALUES ('7203', '2024-01-04', 50000, 30000);
-        INSERT INTO margin_data VALUES ('9984', '2024-01-04', 40000, 20000);
-
-        INSERT INTO statements VALUES ('7203', '2024-01-30', 150.0, 2000000, 5000000, 'FY', 'AnnualReport', 160.0, 3000, 20000000, 1500000, 1600000, 1800000, 60.0, 62.0, 64.0, 30.0, 32.0, 34.0, 165.0, -500000, -300000, 4000000, 50000000, 330000000, 10000000);
-        INSERT INTO statements VALUES ('7203', '2024-04-30', 45.0, 550000, 5100000, '1Q', 'QuarterlyReport', 170.0, 3050, 5200000, 420000, 430000, 510000, 15.0, 16.0, 17.0, 28.0, 29.0, 30.0, 172.0, -110000, -90000, 4100000, 50100000, 331000000, 10000000);
-        INSERT INTO statements VALUES ('7203', '2024-07-30', 48.0, 600000, 5200000, 'Q1', 'QuarterlyReport', 175.0, 3100, 5400000, 450000, 460000, 530000, 16.0, 17.0, 18.0, 29.0, 30.0, 31.0, 176.0, -100000, -85000, 4200000, 50200000, 332000000, 10000000);
-        -- forecast-only row (actual_only=true では除外される)
-        INSERT INTO statements VALUES ('7203', '2024-10-30', NULL, NULL, NULL, 'FY', 'ForecastRevision', 180.0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 180.0, NULL, NULL, NULL, NULL, NULL, NULL);
-
-        INSERT INTO dataset_info VALUES ('preset', 'primeMarket', NULL);
-    """)
-    conn.close()
+    _build_snapshot(Path(tmp_path), "test-market")
     return str(tmp_path)
 
 
 @pytest.fixture
-def client(test_dataset_dir: str):
+def client(test_dataset_dir: str, monkeypatch: pytest.MonkeyPatch):
     """テスト用 FastAPI クライアント"""
+    from src.infrastructure.db.market import dataset_snapshot_reader as reader_module
+
+    def _fake_validate(snapshot_dir: str | Path):
+        snapshot_path = Path(snapshot_dir)
+        return reader_module.DatasetSnapshotManifest.model_validate(
+            {
+                "schemaVersion": 1,
+                "generatedAt": "2026-03-09T00:00:00+00:00",
+                "dataset": {
+                    "name": snapshot_path.name,
+                    "preset": "primeMarket",
+                    "duckdbFile": "dataset.duckdb",
+                    "compatibilityDbFile": "dataset.db",
+                    "parquetDir": "parquet",
+                },
+                "source": {
+                    "backend": "duckdb-parquet",
+                    "compatibilityArtifact": "dataset.db",
+                },
+                "counts": {
+                    "stocks": 2,
+                    "stock_data": 3,
+                    "topix_data": 1,
+                    "indices_data": 1,
+                    "margin_data": 2,
+                    "statements": 2,
+                    "dataset_info": 2,
+                },
+                "coverage": {
+                    "totalStocks": 2,
+                    "stocksWithQuotes": 2,
+                    "stocksWithStatements": 2,
+                    "stocksWithMargin": 2,
+                },
+                "checksums": {
+                    "duckdbSha256": "x",
+                    "compatibilityDbSha256": "y",
+                    "logicalSha256": "z",
+                    "parquet": {},
+                },
+            }
+        )
+
+    monkeypatch.setattr(reader_module, "validate_dataset_snapshot", _fake_validate)
     app = create_app()
     app.state.dataset_resolver = DatasetResolver(test_dataset_dir)
     return TestClient(app, raise_server_exceptions=False)

--- a/apps/bt/tests/unit/server/test_routes_dataset_jobs.py
+++ b/apps/bt/tests/unit/server/test_routes_dataset_jobs.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import tempfile
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -46,22 +44,17 @@ def test_create_dataset_invalid_preset(client: TestClient) -> None:
 
 
 def test_create_dataset_existing_no_overwrite(client: TestClient) -> None:
-    fd, path = tempfile.mkstemp(suffix=".db")
-    os.close(fd)
-    try:
-        resolver = _dataset_resolver(client)
-        resolver.get_db_path.return_value = path
+    resolver = _dataset_resolver(client)
+    resolver.exists.return_value = True
 
-        resp = client.post("/api/dataset", json={"name": "test", "preset": "quickTesting"})
-        assert resp.status_code == 409
-        assert "already exists" in resp.json()["message"]
-    finally:
-        os.unlink(path)
+    resp = client.post("/api/dataset", json={"name": "test", "preset": "quickTesting"})
+    assert resp.status_code == 409
+    assert "already exists" in resp.json()["message"]
 
 
 def test_create_dataset_success(client: TestClient) -> None:
     resolver = _dataset_resolver(client)
-    resolver.get_db_path.return_value = "/nonexistent/test.db"
+    resolver.exists.return_value = False
 
     mock_job = MagicMock()
     mock_job.job_id = "test-job-id"
@@ -83,7 +76,7 @@ def test_create_dataset_success(client: TestClient) -> None:
 
 def test_create_dataset_conflict(client: TestClient) -> None:
     resolver = _dataset_resolver(client)
-    resolver.get_db_path.return_value = "/nonexistent/test.db"
+    resolver.exists.return_value = False
 
     with patch("src.entrypoints.http.routes.dataset.start_dataset_build", new_callable=AsyncMock) as mock_start:
         mock_start.return_value = None
@@ -98,39 +91,34 @@ def test_create_dataset_conflict(client: TestClient) -> None:
 
 def test_resume_dataset_not_found(client: TestClient) -> None:
     resolver = _dataset_resolver(client)
-    resolver.get_db_path.return_value = "/nonexistent/test.db"
+    resolver.exists.return_value = False
 
     resp = client.post("/api/dataset/resume", json={"name": "test", "preset": "quickTesting"})
     assert resp.status_code == 404
 
 
 def test_resume_dataset_success(client: TestClient) -> None:
-    fd, path = tempfile.mkstemp(suffix=".db")
-    os.close(fd)
-    try:
-        resolver = _dataset_resolver(client)
-        resolver.get_db_path.return_value = path
+    resolver = _dataset_resolver(client)
+    resolver.exists.return_value = True
 
-        mock_job = MagicMock()
-        mock_job.job_id = "resume-job-id"
+    mock_job = MagicMock()
+    mock_job.job_id = "resume-job-id"
 
-        with patch("src.entrypoints.http.routes.dataset.start_dataset_build", new_callable=AsyncMock) as mock_start:
-            mock_start.return_value = mock_job
-            resp = client.post(
-                "/api/dataset/resume",
-                json={"name": "test", "preset": "quickTesting", "timeoutMinutes": 90},
-            )
+    with patch("src.entrypoints.http.routes.dataset.start_dataset_build", new_callable=AsyncMock) as mock_start:
+        mock_start.return_value = mock_job
+        resp = client.post(
+            "/api/dataset/resume",
+            json={"name": "test", "preset": "quickTesting", "timeoutMinutes": 90},
+        )
 
-        assert resp.status_code == 202
-        mock_start.assert_awaited_once()
-        data_arg: DatasetJobData = mock_start.await_args.args[0]
-        assert data_arg.resume is True
-        assert data_arg.timeout_minutes == 90
-        data = resp.json()
-        assert data["jobId"] == "resume-job-id"
-        assert data["message"] == "Dataset resume job started"
-    finally:
-        os.unlink(path)
+    assert resp.status_code == 202
+    mock_start.assert_awaited_once()
+    data_arg: DatasetJobData = mock_start.await_args.args[0]
+    assert data_arg.resume is True
+    assert data_arg.timeout_minutes == 90
+    data = resp.json()
+    assert data["jobId"] == "resume-job-id"
+    assert data["message"] == "Dataset resume job started"
 
 
 # --- Get Job ---

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -53,6 +53,7 @@ bun run --filter @trading25/contracts bt:sync
 | File | Status | Description |
 |---|---|---|
 | `dataset-schema.json` | **Deprecated** | Minimal dataset snapshot schema (legacy v1). Do not use for new work. |
+| `dataset-snapshot-manifest-v1.schema.json` | **Active** | Dataset snapshot manifest contract for `dataset.duckdb + parquet + manifest.v1.json`. |
 | `dataset-db-schema-v2.json` | **Active** | Dataset DB schema contract aligned with `apps/ts` Drizzle tables (395 lines). Use this for all new development. |
 | `market-db-schema-v2.json` | **Active** | Market DB schema contract with `statements` and `margin_data` tables for DuckDB sync/screening (v2 minor update). |
 | `backtest-run-manifest-v1.schema.json` | **Active** | Backtest run manifest emitted by `apps/bt`. |
@@ -90,3 +91,9 @@ bun run --filter @trading25/contracts bt:sync
 
 `dataset-db-schema-v2.json` が現行の authoritative contract です。  
 新規実装は v2 基準で整合を取ってください。
+
+dataset snapshot の artifact contract は `dataset-snapshot-manifest-v1.schema.json` が current です。  
+`dataset.db` は migration window の compatibility artifact であり、SoT ではありません。
+
+- `schemaVersion=1` の間は additive 変更のみ許可する。
+- manifest reader は `duckdbSha256` / `compatibilityDbSha256` / `parquet.*` に加えて、DuckDB inspection から導いた `counts` / `coverage` / `dateRange` / `logicalSha256` を検証する。

--- a/contracts/dataset-snapshot-manifest-v1.schema.json
+++ b/contracts/dataset-snapshot-manifest-v1.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trading25.dev/contracts/dataset-snapshot-manifest-v1.schema.json",
+  "title": "Dataset Snapshot Manifest v1",
+  "description": "Schema for dataset snapshot bundles emitted by apps/bt.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "dataset",
+    "source",
+    "counts",
+    "coverage",
+    "checksums"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "generatedAt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "preset",
+        "duckdbFile",
+        "compatibilityDbFile",
+        "parquetDir"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "preset": {
+          "type": "string",
+          "minLength": 1
+        },
+        "duckdbFile": {
+          "type": "string",
+          "const": "dataset.duckdb"
+        },
+        "compatibilityDbFile": {
+          "type": "string",
+          "const": "dataset.db"
+        },
+        "parquetDir": {
+          "type": "string",
+          "const": "parquet"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "backend",
+        "compatibilityArtifact"
+      ],
+      "properties": {
+        "backend": {
+          "type": "string",
+          "const": "duckdb-parquet"
+        },
+        "compatibilityArtifact": {
+          "type": "string",
+          "const": "dataset.db"
+        }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stocks",
+        "stock_data",
+        "topix_data",
+        "indices_data",
+        "margin_data",
+        "statements",
+        "dataset_info"
+      ],
+      "properties": {
+        "stocks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stock_data": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "topix_data": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indices_data": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "margin_data": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "statements": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dataset_info": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalStocks",
+        "stocksWithQuotes",
+        "stocksWithStatements",
+        "stocksWithMargin"
+      ],
+      "properties": {
+        "totalStocks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stocksWithQuotes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stocksWithStatements": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stocksWithMargin": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "checksums": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "duckdbSha256",
+        "logicalSha256",
+        "compatibilityDbSha256",
+        "parquet"
+      ],
+      "properties": {
+        "duckdbSha256": {
+          "type": "string",
+          "minLength": 1
+        },
+        "logicalSha256": {
+          "type": "string",
+          "minLength": 1
+        },
+        "compatibilityDbSha256": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parquet": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "dateRange": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "string",
+              "minLength": 1
+            },
+            "max": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/issues/bt-038-migrate-dataset-snapshots-to-duckdb-parquet.md
+++ b/issues/bt-038-migrate-dataset-snapshots-to-duckdb-parquet.md
@@ -1,12 +1,12 @@
 ---
 id: bt-038
 title: "Dataset snapshot SoT を dataset.duckdb + parquet へ移行"
-status: open
+status: done
 priority: high
 labels: [dataset, duckdb, parquet, migration, bt]
 project: bt
 created: 2026-03-08
-updated: 2026-03-08
+updated: 2026-03-09
 depends_on: [bt-028]
 blocks: [bt-043]
 parent: bt-037
@@ -19,21 +19,24 @@ parent: bt-037
 - market plane と dataset plane の物理フォーマットと query model を揃える。
 
 ## 受け入れ条件
-- [ ] dataset create/resume が `datasets/{name}/dataset.duckdb` と `parquet/*.parquet` を出力する。
-- [ ] manifest に snapshot schema/version/count/checksum/source 情報が揃う。
-- [ ] 既存 `DatasetDb` 読み出し経路は移行期間中 compatibility artifact として継続できる。
-- [ ] backtest / dataset API / validation テストが新 snapshot 形式で通る。
+- [x] dataset create/resume が `datasets/{name}/dataset.duckdb` と `parquet/*.parquet` を出力する。
+- [x] manifest に snapshot schema/version/count/checksum/source 情報が揃う。
+- [x] 既存 `DatasetDb` 読み出し経路は移行期間中 compatibility artifact として継続できる。
+- [x] backtest / dataset API / validation テストが新 snapshot 形式で通る。
 
 ## 実施内容
-- [ ] dataset writer を DuckDB + Parquet 出力へ拡張する。
-- [ ] `apps/bt/src/infrastructure/db/market/dataset_db.py` の後継 reader を追加する。
-- [ ] 旧 `dataset.db` との compatibility policy を定義する。
-- [ ] manifest reader/validator と連携し、異常時は早期失敗させる。
+- [x] dataset writer を DuckDB + Parquet 出力へ拡張する。
+- [x] `apps/bt/src/infrastructure/db/market/dataset_db.py` の後継 reader を追加する。
+- [x] 旧 `dataset.db` との compatibility policy を定義する。
+- [x] manifest reader/validator と連携し、異常時は早期失敗させる。
 
 ## 結果
-- 未着手
+- `DatasetWriter` は `dataset.duckdb + parquet` を SoT としつつ、`dataset.db` を compatibility artifact として同時出力するように変更した。
+- `DatasetResolver` / direct access client は snapshot directory を優先解決し、legacy flat `*.db` を fallback にした。
+- `DatasetSnapshotReader` を追加し、manifest / checksum 検証を通した上で DuckDB を直接 query する read path へ置換した。
+- manifest shape は strict Pydantic validation と `contracts/dataset-snapshot-manifest-v1.schema.json` で固定した。
+- dataset API / builder / validation / direct mode の targeted tests は新 snapshot 形式で通過した。
 
 ## 補足
 - `bt-028` の manifest reader / schema validation を前提に進める。
 - 参照: `docs/backtest-greenfield-rebuild.md` Section 4.3, 10
-


### PR DESCRIPTION
## Summary
- migrate dataset snapshot writing to `dataset.duckdb + parquet + manifest` while keeping compatibility artifacts
- add a snapshot reader that validates manifest and reads DuckDB snapshots directly
- unify dataset resolver, services, and direct data-access clients around the new snapshot layout

## Stack
- stacked PR `2/4`
- base branch: `codex/bt-039-run-registry`
- head branch: `codex/bt-038-dataset-snapshots`

## Validation
- `uv run pyright src`
- `uv run ruff check ...`
- `uv run pytest tests/unit/server/test_dataset_resolver.py tests/unit/server/test_dataset_service.py tests/unit/server/test_routes_dataset.py tests/unit/server/test_routes_dataset_jobs.py tests/unit/server/test_dataset_builder_service.py tests/unit/server/test_dataset_builder_service_branches.py tests/unit/data/test_access_mode_and_clients.py tests/unit/server/test_dataset_snapshot_reader.py tests/unit/server/test_routes_dataset_data.py`
- `uv run coverage run --data-file=/tmp/bt038-aicheck.coverage --branch -m pytest ...`
