### PR TITLE
refactor(bt): extract backtest report payload pipeline

### DIFF
--- a/apps/bt/notebooks/templates/strategy_analysis.py
+++ b/apps/bt/notebooks/templates/strategy_analysis.py
@@ -18,56 +18,8 @@ CLI引数経由でパラメータを受け取り、静的HTMLとして出力
 """
 
 import marimo
-import pickle
-from pathlib import Path
-from typing import Any
 
-
-def _load_simulation_payload(
-    simulation_payload_path: str,
-) -> tuple[Any, Any, Any, Any]:
-    if not simulation_payload_path:
-        return None, None, None, None
-
-    payload_path = Path(simulation_payload_path)
-    if not payload_path.exists():
-        return None, None, None, None
-
-    import vectorbt as vbt
-    from src.domains.backtest.vectorbt_adapter import ensure_execution_portfolio
-
-    def _restore_component(value: Any) -> Any:
-        if not isinstance(value, dict):
-            return value
-
-        if value.get("__serialization__") != "vectorbt.dumps":
-            return value
-
-        payload = value.get("payload")
-        if not isinstance(payload, bytes):
-            return None
-
-        try:
-            return ensure_execution_portfolio(vbt.Portfolio.loads(payload))
-        except Exception:
-            return None
-
-    try:
-        with payload_path.open("rb") as f:
-            payload = pickle.load(f)
-    except Exception:
-        return None, None, None, None
-
-    if not isinstance(payload, dict):
-        return None, None, None, None
-
-    return (
-        _restore_component(payload.get("initial_portfolio")),
-        _restore_component(payload.get("kelly_portfolio")),
-        _restore_component(payload.get("allocation_info")),
-        _restore_component(payload.get("all_entries")),
-    )
-
+__generated_with = "0.20.4"
 app = marimo.App(width="full", app_title="Strategy Analysis")
 
 
@@ -115,6 +67,7 @@ def load_parameters(mo, json, sys, Path):
     exit_trigger_params = _params.get("exit_trigger_params", {})
     execution_meta = _params.get("_execution", {})
     output_html_path = execution_meta.get("html_path", "")
+    report_payload_path = execution_meta.get("report_payload_path", "")
     simulation_payload_path = execution_meta.get("simulation_payload_path", "")
 
     return (
@@ -123,6 +76,7 @@ def load_parameters(mo, json, sys, Path):
         exit_trigger_params,
         project_root,
         output_html_path,
+        report_payload_path,
         simulation_payload_path,
     )
 
@@ -222,23 +176,47 @@ def validate_parameters(mo, shared_config, entry_filter_params, exit_trigger_par
         _validation_errors.append(f"ExitTriggerParams: {e}")
 
     if _validation_errors:
-        mo.md("**Validation Errors:**\n" + "\n".join(_validation_errors))
+        _validation_view = mo.md("**Validation Errors:**\n" + "\n".join(_validation_errors))
     else:
-        mo.md("Parameters validated successfully")
+        _validation_view = mo.md("Parameters validated successfully")
+
+    _validation_view
 
 
 @app.cell
-def execute_strategy(mo, shared_config, entry_filter_params, exit_trigger_params, simulation_payload_path):
+def execute_strategy(
+    mo,
+    shared_config,
+    entry_filter_params,
+    exit_trigger_params,
+    report_payload_path,
+    simulation_payload_path,
+):
+    from src.domains.backtest.core.report_payload import (
+        load_backtest_report_inputs,
+        load_legacy_simulation_inputs,
+    )
     from src.domains.strategy.core.factory import StrategyFactory
 
-    initial_portfolio, kelly_portfolio, allocation_info, all_entries = _load_simulation_payload(
-        simulation_payload_path
+    initial_portfolio, kelly_portfolio, allocation_info, all_entries = load_backtest_report_inputs(
+        report_payload_path
     )
 
     if initial_portfolio is not None and kelly_portfolio is not None:
-        mo.md("Loaded precomputed simulation artifact")
+        _status_view = mo.md("Loaded precomputed report payload")
+    else:
+        (
+            initial_portfolio,
+            kelly_portfolio,
+            allocation_info,
+            all_entries,
+        ) = load_legacy_simulation_inputs(simulation_payload_path)
+        _status_view = None
+
+    if initial_portfolio is not None and kelly_portfolio is not None:
+        _status_view = mo.md("Loaded precomputed simulation artifact")
     elif not shared_config:
-        mo.md("**Error**: No shared_config provided. Skipping strategy execution.")
+        _status_view = mo.md("**Error**: No shared_config provided. Skipping strategy execution.")
     else:
         _result = StrategyFactory.execute_strategy_with_config(
             shared_config, entry_filter_params, exit_trigger_params
@@ -249,7 +227,9 @@ def execute_strategy(mo, shared_config, entry_filter_params, exit_trigger_params
         allocation_info = _result.get("allocation_info", _max_concurrent)
         all_entries = _result.get("all_entries", None)
 
-        mo.md("Strategy execution completed")
+        _status_view = mo.md("Strategy execution completed")
+
+    _ = _status_view
 
     return initial_portfolio, kelly_portfolio, allocation_info, all_entries
 

--- a/apps/bt/src/application/services/run_contracts.py
+++ b/apps/bt/src/application/services/run_contracts.py
@@ -42,6 +42,7 @@ _INTERNAL_RAW_RESULT_KEYS = {
     "_metrics_path",
     "_manifest_path",
     "_simulation_payload_path",
+    "_report_payload_path",
     "_render_error",
 }
 _RAW_RESULT_ARTIFACT_PATHS: tuple[tuple[str, ArtifactKind], ...] = (

--- a/apps/bt/src/domains/backtest/core/artifacts.py
+++ b/apps/bt/src/domains/backtest/core/artifacts.py
@@ -1,0 +1,285 @@
+"""Backtest artifact planning and persistence helpers."""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.domains.backtest.vectorbt_adapter import canonical_metrics_from_portfolio
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestArtifactPaths:
+    """Filesystem paths for a single backtest run."""
+
+    html_path: Path
+    metrics_path: Path
+    manifest_path: Path
+    simulation_payload_path: Path
+    report_payload_path: Path | None = None
+
+
+class BacktestArtifactWriter:
+    """Persist and describe backtest artifacts independent from rendering."""
+
+    @staticmethod
+    def artifact_paths_for_html(html_path: Path) -> BacktestArtifactPaths:
+        return BacktestArtifactPaths(
+            html_path=html_path,
+            metrics_path=html_path.with_suffix(".metrics.json"),
+            manifest_path=html_path.with_suffix(".manifest.json"),
+            simulation_payload_path=html_path.with_suffix(".simulation.pkl"),
+            report_payload_path=html_path.with_suffix(".report.json"),
+        )
+
+    def write_metrics(self, *, metrics_path: Path, metrics_payload: dict[str, Any]) -> Path:
+        metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        metrics_path.write_text(
+            json.dumps(
+                _sanitize_json_payload(metrics_payload),
+                ensure_ascii=False,
+                indent=2,
+                allow_nan=False,
+            ),
+            encoding="utf-8",
+        )
+        return metrics_path
+
+    def write_manifest(
+        self,
+        *,
+        html_path: Path | None,
+        manifest_path: Path | None = None,
+        metrics_path: Path | None = None,
+        simulation_payload_path: Path | None = None,
+        report_payload_path: Path | None = None,
+        parameters: dict[str, Any],
+        strategy_name: str,
+        dataset_name: str,
+        elapsed_time: float,
+        total_elapsed_time: float | None = None,
+        walk_forward: dict[str, Any] | None = None,
+        report_status: str = "completed",
+        report_render_time: float | None = None,
+        render_error: str | None = None,
+    ) -> Path:
+        """Persist a manifest compatible with the existing bt-046 layout."""
+
+        resolved_manifest_path = manifest_path
+        if resolved_manifest_path is None:
+            if html_path is None:
+                raise ValueError("manifest_path is required when html_path is not available")
+            resolved_manifest_path = html_path.with_suffix(".manifest.json")
+
+        resolved_execution_time = (
+            total_elapsed_time if total_elapsed_time is not None else elapsed_time
+        )
+
+        manifest = {
+            "generated_at": datetime.now().isoformat(),
+            "strategy_name": strategy_name,
+            "dataset_name": dataset_name,
+            "html_path": str(html_path) if html_path else None,
+            "metrics_path": str(metrics_path) if metrics_path else None,
+            "simulation_payload_path": (
+                str(simulation_payload_path) if simulation_payload_path else None
+            ),
+            "report_payload_path": (
+                str(report_payload_path) if report_payload_path else None
+            ),
+            "execution_time": resolved_execution_time,
+            "simulation_elapsed_time": elapsed_time,
+            "total_elapsed_time": total_elapsed_time,
+            "parameters": parameters,
+            "simulation": {
+                "status": "completed",
+                "execution_time": elapsed_time,
+                "metrics_path": str(metrics_path) if metrics_path else None,
+                "simulation_payload_path": (
+                    str(simulation_payload_path) if simulation_payload_path else None
+                ),
+                "report_payload_path": (
+                    str(report_payload_path) if report_payload_path else None
+                ),
+            },
+            "report": {
+                "renderer": "marimo_html",
+                "status": report_status,
+                "html_path": str(html_path) if html_path else None,
+                "render_time": report_render_time,
+                "error": render_error,
+                "report_payload_path": (
+                    str(report_payload_path) if report_payload_path else None
+                ),
+            },
+            "versions": {
+                "python": self._get_package_version("python"),
+                "vectorbt": self._get_package_version("vectorbt"),
+                "marimo": self._get_package_version("marimo"),
+                "pydantic": self._get_package_version("pydantic"),
+            },
+            "git_commit": self._get_git_commit(),
+        }
+        if walk_forward:
+            manifest["walk_forward"] = walk_forward
+
+        resolved_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        resolved_manifest_path.write_text(
+            json.dumps(
+                _sanitize_json_payload(manifest),
+                ensure_ascii=False,
+                indent=2,
+                allow_nan=False,
+            ),
+            encoding="utf-8",
+        )
+        return resolved_manifest_path
+
+    @staticmethod
+    def _get_package_version(package: str) -> str | None:
+        if package == "python":
+            return sys.version.split()[0]
+        try:
+            from importlib.metadata import version
+
+            return version(package)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _get_git_commit() -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout.strip() or None
+        except Exception:
+            return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return None
+    return coerced if math.isfinite(coerced) else None
+
+
+def _sanitize_json_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _sanitize_json_payload(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_json_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize_json_payload(item) for item in value]
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    return value
+
+
+def _extract_stat(stats: Any, key: str) -> float | None:
+    if stats is None:
+        return None
+    try:
+        if hasattr(stats, "get"):
+            direct_value = stats.get(key)
+            parsed = _coerce_float(direct_value)
+            if parsed is not None:
+                return parsed
+    except Exception:
+        pass
+    if isinstance(stats, pd.Series):
+        return _coerce_float(stats.get(key))
+    if isinstance(stats, pd.DataFrame) and key in stats.index:
+        row = stats.loc[key]
+        if hasattr(row, "mean"):
+            return _coerce_float(row.mean())
+        if hasattr(row, "iloc"):
+            return _coerce_float(row.iloc[0])
+    return None
+
+
+def _extract_optimal_allocation(allocation_info: Any) -> float | None:
+    if hasattr(allocation_info, "allocation"):
+        return _coerce_float(getattr(allocation_info, "allocation"))
+    return _coerce_float(allocation_info)
+
+
+def build_metrics_payload(
+    *,
+    portfolio: Any,
+    allocation_info: Any = None,
+) -> dict[str, Any]:
+    """Build the canonical metrics payload stored beside each result."""
+
+    stats = None
+    if portfolio is not None:
+        try:
+            stats = portfolio.stats()
+        except Exception:
+            stats = None
+    summary_metrics = canonical_metrics_from_portfolio(portfolio)
+
+    metrics_payload: dict[str, Any] = {
+        "total_return": _extract_stat(stats, "Total Return [%]"),
+        "max_drawdown": _extract_stat(stats, "Max Drawdown [%]"),
+        "sharpe_ratio": _extract_stat(stats, "Sharpe Ratio"),
+        "sortino_ratio": _extract_stat(stats, "Sortino Ratio"),
+        "calmar_ratio": _extract_stat(stats, "Calmar Ratio"),
+        "win_rate": _extract_stat(stats, "Win Rate [%]"),
+        "profit_factor": _extract_stat(stats, "Profit Factor"),
+    }
+    total_trades = _extract_stat(stats, "Total Trades")
+    metrics_payload["total_trades"] = int(total_trades) if total_trades is not None else None
+    metrics_payload["trade_count"] = metrics_payload["total_trades"]
+
+    if summary_metrics is not None:
+        metrics_payload["total_return"] = _prefer_metric_value(
+            metrics_payload["total_return"],
+            summary_metrics.total_return,
+        )
+        metrics_payload["max_drawdown"] = _prefer_metric_value(
+            metrics_payload["max_drawdown"],
+            summary_metrics.max_drawdown,
+        )
+        metrics_payload["sharpe_ratio"] = _prefer_metric_value(
+            metrics_payload["sharpe_ratio"],
+            summary_metrics.sharpe_ratio,
+        )
+        metrics_payload["sortino_ratio"] = _prefer_metric_value(
+            metrics_payload["sortino_ratio"],
+            summary_metrics.sortino_ratio,
+        )
+        metrics_payload["calmar_ratio"] = _prefer_metric_value(
+            metrics_payload["calmar_ratio"],
+            summary_metrics.calmar_ratio,
+        )
+        metrics_payload["win_rate"] = _prefer_metric_value(
+            metrics_payload["win_rate"],
+            summary_metrics.win_rate,
+        )
+        if metrics_payload["trade_count"] is None:
+            metrics_payload["trade_count"] = summary_metrics.trade_count
+        if metrics_payload["total_trades"] is None:
+            metrics_payload["total_trades"] = summary_metrics.trade_count
+
+    metrics_payload["optimal_allocation"] = _extract_optimal_allocation(allocation_info)
+    metrics_payload["generated_at"] = datetime.now().isoformat()
+    return metrics_payload
+
+
+def _prefer_metric_value(primary: Any, fallback: Any) -> Any:
+    return primary if primary is not None else fallback

--- a/apps/bt/src/domains/backtest/core/marimo_executor.py
+++ b/apps/bt/src/domains/backtest/core/marimo_executor.py
@@ -4,7 +4,6 @@ Marimo Notebook Executor
 Marimoを使用したNotebook実行・HTML出力ラッパー
 """
 
-from dataclasses import dataclass
 import json
 import os
 import re
@@ -16,17 +15,13 @@ from typing import Any
 
 from loguru import logger
 
+from src.domains.backtest.core.artifacts import (
+    BacktestArtifactPaths,
+    BacktestArtifactWriter,
+)
 from src.shared.utils.snapshot_ids import canonicalize_dataset_snapshot_id
 
-
-@dataclass(frozen=True, slots=True)
-class BacktestReportPaths:
-    """Filesystem paths for backtest report artifacts."""
-
-    html_path: Path
-    metrics_path: Path
-    manifest_path: Path
-    simulation_payload_path: Path
+BacktestReportPaths = BacktestArtifactPaths
 
 
 class MarimoExecutor:
@@ -203,12 +198,7 @@ class MarimoExecutor:
             strategy_name=strategy_name,
             output_filename=output_filename,
         )
-        return BacktestReportPaths(
-            html_path=html_path,
-            metrics_path=html_path.with_suffix(".metrics.json"),
-            manifest_path=html_path.with_suffix(".manifest.json"),
-            simulation_payload_path=html_path.with_suffix(".simulation.pkl"),
-        )
+        return BacktestArtifactWriter.artifact_paths_for_html(html_path)
 
     def execute_notebook(
         self,

--- a/apps/bt/src/domains/backtest/core/report_payload.py
+++ b/apps/bt/src/domains/backtest/core/report_payload.py
@@ -1,0 +1,391 @@
+"""JSON serialization helpers for report rendering payloads."""
+
+from __future__ import annotations
+
+import json
+import math
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.domains.backtest.core.simulation import BacktestSimulationResult
+from src.shared.models.allocation import AllocationInfo
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return None
+    return coerced if math.isfinite(coerced) else None
+
+
+def _coerce_series_value(value: Any) -> Any:
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:
+            return value
+    if isinstance(value, (int, float, str, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _serialize_series(series: Any) -> dict[str, Any] | None:
+    if series is None:
+        return None
+    if isinstance(series, pd.DataFrame):
+        if series.shape[1] == 1:
+            series = series.iloc[:, 0]
+        else:
+            return None
+    if not isinstance(series, pd.Series):
+        try:
+            series = pd.Series(series)
+        except Exception:
+            return None
+    normalized = series.copy()
+    return {
+        "index": [_coerce_series_value(v) for v in normalized.index.tolist()],
+        "values": [_coerce_series_value(v) for v in normalized.tolist()],
+    }
+
+
+def _deserialize_series(payload: dict[str, Any] | None) -> pd.Series:
+    if not isinstance(payload, dict):
+        return pd.Series(dtype=float)
+    index = payload.get("index", [])
+    values = payload.get("values", [])
+    return pd.Series(values, index=index)
+
+
+def _serialize_dataframe(frame: Any) -> list[dict[str, Any]]:
+    if frame is None:
+        return []
+    if isinstance(frame, pd.Series):
+        frame = frame.to_frame(name="value")
+    if not isinstance(frame, pd.DataFrame):
+        try:
+            frame = pd.DataFrame(frame)
+        except Exception:
+            return []
+    normalized = frame.copy()
+    for column in normalized.columns:
+        normalized[column] = normalized[column].map(_coerce_series_value)
+    return [
+        {str(key): value for key, value in record.items()}
+        for record in normalized.to_dict(orient="records")
+    ]
+
+
+def _deserialize_dataframe(records: Any) -> pd.DataFrame:
+    if not isinstance(records, list):
+        return pd.DataFrame()
+    return pd.DataFrame(records)
+
+
+def _serialize_metric_map(portfolio: Any) -> dict[str, float | None]:
+    def _read_metric(method_name: str) -> float | None:
+        if portfolio is None:
+            return None
+        try:
+            method = getattr(portfolio, method_name)
+        except Exception:
+            return None
+        try:
+            value = method() if callable(method) else method
+        except Exception:
+            return None
+        if hasattr(value, "mean"):
+            try:
+                value = value.mean()
+            except Exception:
+                return None
+        return _coerce_float(value)
+
+    return {
+        "annualized_volatility": _read_metric("annualized_volatility"),
+        "sharpe_ratio": _read_metric("sharpe_ratio"),
+        "sortino_ratio": _read_metric("sortino_ratio"),
+        "calmar_ratio": _read_metric("calmar_ratio"),
+        "omega_ratio": _read_metric("omega_ratio"),
+    }
+
+
+def _serialize_stats(stats: Any) -> list[dict[str, Any]]:
+    if stats is None:
+        return []
+    if isinstance(stats, pd.Series):
+        frame = stats.reset_index()
+        frame.columns = ["metric", "value"]
+        return _serialize_dataframe(frame)
+    if isinstance(stats, pd.DataFrame):
+        return _serialize_dataframe(stats.reset_index())
+    try:
+        frame = pd.DataFrame(stats)
+    except Exception:
+        return []
+    return _serialize_dataframe(frame.reset_index())
+
+
+def _deserialize_stats(records: Any) -> pd.Series:
+    frame = _deserialize_dataframe(records)
+    if frame.empty:
+        return pd.Series(dtype=object)
+    if "metric" in frame.columns and "value" in frame.columns:
+        return pd.Series(frame["value"].to_list(), index=frame["metric"].to_list())
+    first = frame.columns[0]
+    return pd.Series(frame.iloc[:, 1].to_list(), index=frame[first].to_list())
+
+
+def _serialize_portfolio(portfolio: Any) -> dict[str, Any] | None:
+    if portfolio is None:
+        return None
+
+    def _read_portfolio_view(method_name: str) -> Any:
+        try:
+            method = getattr(portfolio, method_name)
+        except Exception:
+            return None
+        try:
+            return method() if callable(method) else method
+        except Exception:
+            return None
+
+    trades = getattr(portfolio, "trades", None)
+    trade_records = getattr(trades, "records_readable", None) if trades is not None else None
+    try:
+        trade_stats = trades.stats() if trades is not None else None
+    except Exception:
+        trade_stats = None
+    try:
+        final_stats = portfolio.stats()
+    except Exception:
+        final_stats = None
+    return {
+        "value_series": _serialize_series(_read_portfolio_view("value")),
+        "drawdown_series": _serialize_series(_read_portfolio_view("drawdown")),
+        "returns_series": _serialize_series(_read_portfolio_view("returns")),
+        "trade_records": _serialize_dataframe(trade_records),
+        "trade_stats": _serialize_stats(trade_stats),
+        "final_stats": _serialize_stats(final_stats),
+        "risk_metrics": _serialize_metric_map(portfolio),
+    }
+
+
+def _deserialize_portfolio(payload: dict[str, Any] | None) -> SerializedPortfolioView | None:
+    if not isinstance(payload, dict):
+        return None
+    return SerializedPortfolioView(
+        value_series=_deserialize_series(payload.get("value_series")),
+        drawdown_series=_deserialize_series(payload.get("drawdown_series")),
+        returns_series=_deserialize_series(payload.get("returns_series")),
+        trade_records=_deserialize_dataframe(payload.get("trade_records")),
+        trade_stats=_deserialize_stats(payload.get("trade_stats")),
+        final_stats=_deserialize_stats(payload.get("final_stats")),
+        risk_metrics=payload.get("risk_metrics", {}),
+    )
+
+
+def _serialize_entry_counts(all_entries: Any) -> dict[str, Any] | None:
+    if all_entries is None:
+        return None
+    try:
+        entries_per_day = all_entries.sum(axis=1)
+    except Exception:
+        return None
+    return _serialize_series(entries_per_day)
+
+
+def _deserialize_entry_counts(payload: dict[str, Any] | None) -> pd.DataFrame | None:
+    if not isinstance(payload, dict):
+        return None
+    series = _deserialize_series(payload)
+    if series.empty:
+        return pd.DataFrame(columns=["signal_count"])
+    return pd.DataFrame({"signal_count": series})
+
+
+def _serialize_allocation_info(allocation_info: Any) -> dict[str, Any] | None:
+    if allocation_info is None:
+        return None
+    if isinstance(allocation_info, AllocationInfo):
+        return {"kind": "allocation_info", "payload": allocation_info.model_dump()}
+    if isinstance(allocation_info, (int, float)):
+        return {"kind": "scalar", "payload": allocation_info}
+    if hasattr(allocation_info, "model_dump"):
+        try:
+            return {"kind": "allocation_info", "payload": allocation_info.model_dump()}
+        except Exception:
+            pass
+    return {"kind": "text", "payload": str(allocation_info)}
+
+
+def _deserialize_allocation_info(payload: dict[str, Any] | None) -> Any:
+    if not isinstance(payload, dict):
+        return None
+    kind = payload.get("kind")
+    value = payload.get("payload")
+    if kind == "allocation_info" and isinstance(value, dict):
+        try:
+            return AllocationInfo.model_validate(value)
+        except Exception:
+            return value
+    return value
+
+
+def build_backtest_report_payload(
+    simulation_result: BacktestSimulationResult,
+) -> dict[str, Any]:
+    """Serialize simulation outputs for presentation-only rendering."""
+
+    return {
+        "allocation_info": _serialize_allocation_info(simulation_result.allocation_info),
+        "entry_signal_counts": _serialize_entry_counts(simulation_result.all_entries),
+        "initial_portfolio": _serialize_portfolio(simulation_result.initial_portfolio),
+        "kelly_portfolio": _serialize_portfolio(simulation_result.kelly_portfolio),
+    }
+
+
+def write_backtest_report_payload(
+    *,
+    path: Path,
+    payload: dict[str, Any],
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def load_backtest_report_inputs(path: str | Path) -> tuple[Any, Any, Any, Any]:
+    payload_path = Path(path)
+    if not str(payload_path) or not payload_path.exists():
+        return None, None, None, None
+
+    try:
+        context = load_backtest_report_payload(payload_path)
+    except Exception:
+        return None, None, None, None
+
+    return (
+        context.initial_portfolio,
+        context.kelly_portfolio,
+        context.allocation_info,
+        context.all_entries,
+    )
+
+
+def load_legacy_simulation_inputs(path: str | Path) -> tuple[Any, Any, Any, Any]:
+    payload_path = Path(path)
+    if not str(payload_path) or not payload_path.exists():
+        return None, None, None, None
+
+    import vectorbt as vbt
+    from src.domains.backtest.vectorbt_adapter import ensure_execution_portfolio
+
+    def _restore_component(value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        if value.get("__serialization__") != "vectorbt.dumps":
+            return value
+
+        payload = value.get("payload")
+        if not isinstance(payload, bytes):
+            return None
+
+        try:
+            return ensure_execution_portfolio(vbt.Portfolio.loads(payload))
+        except Exception:
+            return None
+
+    try:
+        with payload_path.open("rb") as file:
+            payload = pickle.load(file)
+    except Exception:
+        return None, None, None, None
+
+    if not isinstance(payload, dict):
+        return None, None, None, None
+
+    return (
+        _restore_component(payload.get("initial_portfolio")),
+        _restore_component(payload.get("kelly_portfolio")),
+        _restore_component(payload.get("allocation_info")),
+        _restore_component(payload.get("all_entries")),
+    )
+
+
+@dataclass(slots=True)
+class SerializedTradesView:
+    records_readable: pd.DataFrame
+    _stats: pd.Series
+
+    def stats(self) -> pd.Series:
+        return self._stats
+
+
+@dataclass(slots=True)
+class SerializedPortfolioView:
+    value_series: pd.Series
+    drawdown_series: pd.Series
+    returns_series: pd.Series
+    trade_records: pd.DataFrame
+    trade_stats: pd.Series
+    final_stats: pd.Series
+    risk_metrics: dict[str, Any]
+
+    @property
+    def trades(self) -> SerializedTradesView:
+        return SerializedTradesView(self.trade_records, self.trade_stats)
+
+    def value(self) -> pd.Series:
+        return self.value_series
+
+    def drawdown(self) -> pd.Series:
+        return self.drawdown_series
+
+    def returns(self) -> pd.Series:
+        return self.returns_series
+
+    def annualized_volatility(self) -> Any:
+        return self.risk_metrics.get("annualized_volatility")
+
+    def sharpe_ratio(self) -> Any:
+        return self.risk_metrics.get("sharpe_ratio")
+
+    def sortino_ratio(self) -> Any:
+        return self.risk_metrics.get("sortino_ratio")
+
+    def calmar_ratio(self) -> Any:
+        return self.risk_metrics.get("calmar_ratio")
+
+    def omega_ratio(self) -> Any:
+        return self.risk_metrics.get("omega_ratio")
+
+    def stats(self) -> pd.Series:
+        return self.final_stats
+
+
+@dataclass(slots=True)
+class BacktestReportRenderContext:
+    initial_portfolio: SerializedPortfolioView | None
+    kelly_portfolio: SerializedPortfolioView | None
+    allocation_info: Any
+    all_entries: pd.DataFrame | None
+
+
+def load_backtest_report_payload(path: str | Path) -> BacktestReportRenderContext:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return BacktestReportRenderContext(
+        initial_portfolio=_deserialize_portfolio(payload.get("initial_portfolio")),
+        kelly_portfolio=_deserialize_portfolio(payload.get("kelly_portfolio")),
+        allocation_info=_deserialize_allocation_info(payload.get("allocation_info")),
+        all_entries=_deserialize_entry_counts(payload.get("entry_signal_counts")),
+    )

--- a/apps/bt/src/domains/backtest/core/runner.py
+++ b/apps/bt/src/domains/backtest/core/runner.py
@@ -8,9 +8,7 @@ import json
 import math
 import pickle
 import subprocess
-import sys
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
@@ -22,8 +20,20 @@ from src.infrastructure.data_access.mode import (
     data_access_mode_context,
     normalize_data_access_mode,
 )
+from src.domains.backtest.core.artifacts import (
+    BacktestArtifactWriter,
+    build_metrics_payload as build_backtest_metrics_payload,
+)
 from src.domains.backtest.vectorbt_adapter import canonical_metrics_from_portfolio
 from src.domains.backtest.core.marimo_executor import BacktestReportPaths, MarimoExecutor
+from src.domains.backtest.core.report_payload import (
+    build_backtest_report_payload,
+    write_backtest_report_payload,
+)
+from src.domains.backtest.core.simulation import (
+    BacktestSimulationExecutor,
+    BacktestSimulationResult,
+)
 from src.domains.strategy.runtime.loader import ConfigLoader
 
 
@@ -36,6 +46,10 @@ class BacktestResult(BaseModel):
     simulation_payload_path: Path | None = Field(
         default=None,
         description="serialized simulation payload artifact path",
+    )
+    report_payload_path: Path | None = Field(
+        default=None,
+        description="serialized report payload artifact path",
     )
     elapsed_time: float = Field(gt=0, description="完了ジョブの総実行時間（秒）")
     simulation_elapsed_time: float | None = Field(
@@ -60,6 +74,8 @@ class BacktestRunner:
     def __init__(self) -> None:
         """初期化"""
         self.config_loader = ConfigLoader()
+        self.artifact_writer = BacktestArtifactWriter()
+        self.simulation_executor = BacktestSimulationExecutor()
 
     def execute(
         self,
@@ -119,16 +135,21 @@ class BacktestRunner:
 
             notify("バックテストを実行中...")
 
-            simulation_result = self._execute_simulation(parameters)
+            simulation_result = self._normalize_simulation_result(
+                self._execute_simulation(parameters)
+            )
             simulation_elapsed_time = time.time() - start_time
 
-            metrics_payload = self._build_metrics_payload(
-                kelly_portfolio=simulation_result.get("kelly_portfolio"),
-                allocation_info=simulation_result.get("allocation_info"),
+            self._write_metrics_artifact(
+                report_paths.metrics_path,
+                simulation_result.metrics_payload,
             )
-            self._write_metrics_artifact(report_paths.metrics_path, metrics_payload)
             self._write_simulation_payload(
                 report_paths.simulation_payload_path,
+                simulation_result,
+            )
+            self._write_report_payload(
+                report_paths.report_payload_path,
                 simulation_result,
             )
 
@@ -138,6 +159,7 @@ class BacktestRunner:
                 manifest_path=report_paths.manifest_path,
                 metrics_path=report_paths.metrics_path,
                 simulation_payload_path=report_paths.simulation_payload_path,
+                report_payload_path=report_paths.report_payload_path,
                 parameters=parameters,
                 strategy_name=strategy_name_only,
                 dataset_name=dataset_name,
@@ -171,6 +193,7 @@ class BacktestRunner:
                 manifest_path=report_paths.manifest_path,
                 metrics_path=report_paths.metrics_path,
                 simulation_payload_path=report_paths.simulation_payload_path,
+                report_payload_path=report_paths.report_payload_path,
                 parameters=parameters,
                 strategy_name=strategy_name_only,
                 dataset_name=dataset_name,
@@ -187,6 +210,7 @@ class BacktestRunner:
                 metrics_path=report_paths.metrics_path,
                 manifest_path=manifest_path,
                 simulation_payload_path=report_paths.simulation_payload_path,
+                report_payload_path=report_paths.report_payload_path,
                 simulation_elapsed_time=simulation_elapsed_time,
                 total_elapsed_time=total_elapsed_time,
                 report_status=report_status,
@@ -207,6 +231,7 @@ class BacktestRunner:
                 metrics_path=report_paths.metrics_path,
                 manifest_path=manifest_path,
                 simulation_payload_path=report_paths.simulation_payload_path,
+                report_payload_path=report_paths.report_payload_path,
                 elapsed_time=total_elapsed_time,
                 simulation_elapsed_time=simulation_elapsed_time,
                 summary=summary,
@@ -233,17 +258,10 @@ class BacktestRunner:
         strategy_config = self.config_loader.load_strategy_config(strategy)
         return self._build_parameters(strategy_config, config_override)
 
-    def _execute_simulation(self, parameters: dict[str, Any]) -> dict[str, Any]:
-        from src.domains.strategy.core.factory import StrategyFactory
-
-        result = StrategyFactory.execute_strategy_with_config(
-            parameters.get("shared_config", {}),
-            parameters.get("entry_filter_params"),
-            parameters.get("exit_trigger_params"),
-        )
-        if not isinstance(result, dict):
-            raise RuntimeError("strategy simulation returned an invalid payload")
-        return result
+    def _execute_simulation(
+        self, parameters: dict[str, Any]
+    ) -> BacktestSimulationResult | dict[str, Any]:
+        return self.simulation_executor.execute(parameters)
 
     def _write_json_artifact(self, path: Path, payload: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -259,22 +277,43 @@ class BacktestRunner:
         )
 
     def _write_metrics_artifact(self, metrics_path: Path, metrics_payload: dict[str, Any]) -> None:
-        self._write_json_artifact(metrics_path, metrics_payload)
+        self.artifact_writer.write_metrics(
+            metrics_path=metrics_path,
+            metrics_payload=metrics_payload,
+        )
 
-    def _write_simulation_payload(self, payload_path: Path, simulation_result: dict[str, Any]) -> None:
+    def _write_simulation_payload(
+        self,
+        payload_path: Path,
+        simulation_result: BacktestSimulationResult | dict[str, Any],
+    ) -> None:
+        normalized = self._normalize_simulation_result(simulation_result)
         payload = {
             "initial_portfolio": self._serialize_simulation_portfolio(
-                simulation_result.get("initial_portfolio")
+                normalized.initial_portfolio
             ),
             "kelly_portfolio": self._serialize_simulation_portfolio(
-                simulation_result.get("kelly_portfolio")
+                normalized.kelly_portfolio
             ),
-            "allocation_info": simulation_result.get("allocation_info"),
-            "all_entries": simulation_result.get("all_entries"),
+            "allocation_info": normalized.allocation_info,
+            "all_entries": normalized.all_entries,
         }
         payload_path.parent.mkdir(parents=True, exist_ok=True)
         with payload_path.open("wb") as file:
             pickle.dump(payload, file)
+
+    def _write_report_payload(
+        self,
+        payload_path: Path | None,
+        simulation_result: BacktestSimulationResult | dict[str, Any],
+    ) -> None:
+        if payload_path is None:
+            return
+        normalized = self._normalize_simulation_result(simulation_result)
+        write_backtest_report_payload(
+            path=payload_path,
+            payload=build_backtest_report_payload(normalized),
+        )
 
     def _serialize_simulation_portfolio(self, portfolio: Any) -> Any:
         if portfolio is None:
@@ -326,7 +365,10 @@ class BacktestRunner:
                 extra_env={DATA_ACCESS_MODE_ENV: data_access_mode},
                 html_path=report_paths.html_path,
                 execution_metadata={
-                    "simulation_payload_path": str(report_paths.simulation_payload_path)
+                    "simulation_payload_path": str(report_paths.simulation_payload_path),
+                    "report_payload_path": str(report_paths.report_payload_path)
+                    if report_paths.report_payload_path is not None
+                    else "",
                 },
             )
             if rendered_html_path.exists():
@@ -345,6 +387,7 @@ class BacktestRunner:
         metrics_path: Path,
         manifest_path: Path,
         simulation_payload_path: Path,
+        report_payload_path: Path | None,
         simulation_elapsed_time: float,
         total_elapsed_time: float,
         report_status: str,
@@ -360,6 +403,7 @@ class BacktestRunner:
             "_metrics_path": str(metrics_path),
             "_manifest_path": str(manifest_path),
             "_simulation_payload_path": str(simulation_payload_path),
+            "_report_payload_path": str(report_payload_path) if report_payload_path else None,
         }
         if render_error is not None:
             summary["_render_error"] = render_error
@@ -374,6 +418,7 @@ class BacktestRunner:
         manifest_path: Path | None = None,
         metrics_path: Path | None = None,
         simulation_payload_path: Path | None = None,
+        report_payload_path: Path | None = None,
         parameters: dict[str, Any],
         strategy_name: str,
         dataset_name: str,
@@ -385,56 +430,22 @@ class BacktestRunner:
         render_error: str | None = None,
     ) -> Path:
         """実行マニフェストをJSONで保存する。"""
-        resolved_manifest_path = manifest_path
-        if resolved_manifest_path is None:
-            if html_path is None:
-                raise ValueError("manifest_path is required when html_path is not available")
-            resolved_manifest_path = html_path.with_suffix(".manifest.json")
-        resolved_execution_time = (
-            total_elapsed_time if total_elapsed_time is not None else elapsed_time
+        return self.artifact_writer.write_manifest(
+            html_path=html_path,
+            manifest_path=manifest_path,
+            metrics_path=metrics_path,
+            simulation_payload_path=simulation_payload_path,
+            report_payload_path=report_payload_path,
+            parameters=parameters,
+            strategy_name=strategy_name,
+            dataset_name=dataset_name,
+            elapsed_time=elapsed_time,
+            total_elapsed_time=total_elapsed_time,
+            walk_forward=walk_forward,
+            report_status=report_status,
+            report_render_time=report_render_time,
+            render_error=render_error,
         )
-
-        manifest = {
-            "generated_at": datetime.now().isoformat(),
-            "strategy_name": strategy_name,
-            "dataset_name": dataset_name,
-            "html_path": str(html_path) if html_path else None,
-            "metrics_path": str(metrics_path) if metrics_path else None,
-            "simulation_payload_path": (
-                str(simulation_payload_path) if simulation_payload_path else None
-            ),
-            "execution_time": resolved_execution_time,
-            "simulation_elapsed_time": elapsed_time,
-            "total_elapsed_time": total_elapsed_time,
-            "parameters": parameters,
-            "simulation": {
-                "status": "completed",
-                "execution_time": elapsed_time,
-                "metrics_path": str(metrics_path) if metrics_path else None,
-                "simulation_payload_path": (
-                    str(simulation_payload_path) if simulation_payload_path else None
-                ),
-            },
-            "report": {
-                "renderer": "marimo_html",
-                "status": report_status,
-                "html_path": str(html_path) if html_path else None,
-                "render_time": report_render_time,
-                "error": render_error,
-            },
-            "versions": {
-                "python": sys.version.split()[0],
-                "vectorbt": self._get_package_version("vectorbt"),
-                "marimo": self._get_package_version("marimo"),
-                "pydantic": self._get_package_version("pydantic"),
-            },
-            "git_commit": self._get_git_commit(),
-        }
-        if walk_forward:
-            manifest["walk_forward"] = walk_forward
-
-        self._write_json_artifact(resolved_manifest_path, manifest)
-        return resolved_manifest_path
 
     @staticmethod
     def _get_package_version(package: str) -> str | None:
@@ -464,70 +475,10 @@ class BacktestRunner:
         kelly_portfolio: Any,
         allocation_info: Any,
     ) -> dict[str, Any]:
-        stats = None
-        if kelly_portfolio is not None and hasattr(kelly_portfolio, "stats"):
-            try:
-                stats = kelly_portfolio.stats()
-            except Exception as exc:
-                logger.warning(f"バックテストstats取得失敗: {exc}")
-
-        canonical_metrics = canonical_metrics_from_portfolio(kelly_portfolio)
-        metrics: dict[str, Any] = {
-            "total_return": self._extract_stat(stats, "Total Return [%]"),
-            "max_drawdown": self._extract_stat(stats, "Max Drawdown [%]"),
-            "sharpe_ratio": self._extract_stat(stats, "Sharpe Ratio"),
-            "sortino_ratio": self._extract_stat(stats, "Sortino Ratio"),
-            "calmar_ratio": self._extract_stat(stats, "Calmar Ratio"),
-            "win_rate": self._extract_stat(stats, "Win Rate [%]"),
-            "profit_factor": self._extract_stat(stats, "Profit Factor"),
-        }
-        total_trades = self._extract_stat(stats, "Total Trades")
-        metrics["total_trades"] = int(total_trades) if total_trades is not None else None
-        metrics["trade_count"] = metrics["total_trades"]
-
-        if canonical_metrics is not None:
-            metrics["total_return"] = self._prefer_metric_value(
-                metrics["total_return"],
-                canonical_metrics.total_return,
-            )
-            metrics["max_drawdown"] = self._prefer_metric_value(
-                metrics["max_drawdown"],
-                canonical_metrics.max_drawdown,
-            )
-            metrics["sharpe_ratio"] = self._prefer_metric_value(
-                metrics["sharpe_ratio"],
-                canonical_metrics.sharpe_ratio,
-            )
-            metrics["sortino_ratio"] = self._prefer_metric_value(
-                metrics["sortino_ratio"],
-                canonical_metrics.sortino_ratio,
-            )
-            metrics["calmar_ratio"] = self._prefer_metric_value(
-                metrics["calmar_ratio"],
-                canonical_metrics.calmar_ratio,
-            )
-            metrics["win_rate"] = self._prefer_metric_value(
-                metrics["win_rate"],
-                canonical_metrics.win_rate,
-            )
-            if metrics["trade_count"] is None:
-                metrics["trade_count"] = canonical_metrics.trade_count
-            if metrics["total_trades"] is None:
-                metrics["total_trades"] = canonical_metrics.trade_count
-
-        if hasattr(allocation_info, "allocation"):
-            metrics["optimal_allocation"] = self._coerce_metric(allocation_info.allocation)
-        elif isinstance(allocation_info, int | float):
-            metrics["optimal_allocation"] = self._coerce_metric(allocation_info)
-        else:
-            metrics["optimal_allocation"] = None
-
-        metrics["generated_at"] = datetime.now().isoformat()
-        return metrics
-
-    @staticmethod
-    def _prefer_metric_value(primary: Any, fallback: Any) -> Any:
-        return primary if primary is not None else fallback
+        return build_backtest_metrics_payload(
+            portfolio=kelly_portfolio,
+            allocation_info=allocation_info,
+        )
 
     def _sanitize_json_payload(self, value: Any) -> Any:
         if isinstance(value, dict):
@@ -540,32 +491,31 @@ class BacktestRunner:
             return value if math.isfinite(value) else None
         return value
 
-    def _extract_stat(self, stats: Any, key: str) -> float | None:
-        if stats is None:
-            return None
+    def _normalize_simulation_result(
+        self,
+        simulation_result: BacktestSimulationResult | dict[str, Any],
+    ) -> BacktestSimulationResult:
+        if isinstance(simulation_result, BacktestSimulationResult):
+            return simulation_result
+        if not isinstance(simulation_result, dict):
+            raise RuntimeError("strategy simulation returned an invalid payload")
 
-        try:
-            if hasattr(stats, "get"):
-                direct_value = stats.get(key)
-                parsed = self._coerce_metric(direct_value)
-                if parsed is not None:
-                    return parsed
-        except Exception:
-            pass
-
-        try:
-            index = getattr(stats, "index", None)
-            if index is not None and key in index:
-                row = stats.loc[key]
-                if hasattr(row, "mean"):
-                    return self._coerce_metric(row.mean())
-                if hasattr(row, "iloc"):
-                    return self._coerce_metric(row.iloc[0])
-                return self._coerce_metric(row)
-        except Exception:
-            return None
-
-        return None
+        allocation_info = simulation_result.get(
+            "allocation_info",
+            simulation_result.get("max_concurrent"),
+        )
+        kelly_portfolio = simulation_result.get("kelly_portfolio")
+        return BacktestSimulationResult(
+            initial_portfolio=simulation_result.get("initial_portfolio"),
+            kelly_portfolio=kelly_portfolio,
+            allocation_info=allocation_info,
+            all_entries=simulation_result.get("all_entries"),
+            summary_metrics=canonical_metrics_from_portfolio(kelly_portfolio),
+            metrics_payload=self._build_metrics_payload(
+                kelly_portfolio=kelly_portfolio,
+                allocation_info=allocation_info,
+            ),
+        )
 
     def _run_walk_forward(self, parameters: dict[str, Any]) -> dict[str, Any] | None:
         """ウォークフォワード分析を実行（設定有効時のみ）"""

--- a/apps/bt/src/domains/backtest/core/simulation.py
+++ b/apps/bt/src/domains/backtest/core/simulation.py
@@ -1,0 +1,55 @@
+"""Pure simulation stage for backtest runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.domains.backtest.contracts import CanonicalExecutionMetrics
+from src.domains.backtest.core.artifacts import build_metrics_payload
+from src.domains.backtest.vectorbt_adapter import canonical_metrics_from_portfolio
+from src.domains.strategy.core.factory import StrategyFactory
+
+
+@dataclass(slots=True)
+class BacktestSimulationResult:
+    """Result of the simulation stage before report rendering."""
+
+    initial_portfolio: Any
+    kelly_portfolio: Any
+    allocation_info: Any
+    all_entries: Any
+    summary_metrics: CanonicalExecutionMetrics | None
+    metrics_payload: dict[str, Any]
+
+
+class BacktestSimulationExecutor:
+    """Execute the core strategy simulation without presentation side effects."""
+
+    def execute(self, parameters: dict[str, Any]) -> BacktestSimulationResult:
+        result = StrategyFactory.execute_strategy_with_config(
+            parameters.get("shared_config", {}),
+            parameters.get("entry_filter_params"),
+            parameters.get("exit_trigger_params"),
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("strategy simulation returned an invalid payload")
+
+        initial_portfolio = result.get("initial_portfolio")
+        kelly_portfolio = result.get("kelly_portfolio")
+        allocation_info = result.get("allocation_info", result.get("max_concurrent"))
+        all_entries = result.get("all_entries")
+        summary_metrics = canonical_metrics_from_portfolio(kelly_portfolio)
+        metrics_payload = build_metrics_payload(
+            portfolio=kelly_portfolio,
+            allocation_info=allocation_info,
+        )
+
+        return BacktestSimulationResult(
+            initial_portfolio=initial_portfolio,
+            kelly_portfolio=kelly_portfolio,
+            allocation_info=allocation_info,
+            all_entries=all_entries,
+            summary_metrics=summary_metrics,
+            metrics_payload=metrics_payload,
+        )

--- a/apps/bt/tests/unit/backtest/test_artifacts.py
+++ b/apps/bt/tests/unit/backtest/test_artifacts.py
@@ -1,0 +1,77 @@
+"""Tests for extracted backtest artifact helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.domains.backtest.core.artifacts import (
+    BacktestArtifactWriter,
+    build_metrics_payload,
+)
+
+
+class _MetricValue:
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def mean(self) -> float:
+        return self._value
+
+
+class _Portfolio:
+    def stats(self):
+        return {
+            "Total Return [%]": 0.0,
+            "Max Drawdown [%]": 0.0,
+            "Sharpe Ratio": 0.0,
+            "Sortino Ratio": 0.0,
+            "Calmar Ratio": 0.0,
+            "Win Rate [%]": 0.0,
+            "Total Trades": 0.0,
+        }
+
+    def total_return(self):
+        return _MetricValue(5.0)
+
+    def sharpe_ratio(self):
+        return _MetricValue(5.0)
+
+    def sortino_ratio(self):
+        return _MetricValue(5.0)
+
+    def calmar_ratio(self):
+        return _MetricValue(5.0)
+
+    def max_drawdown(self):
+        return _MetricValue(5.0)
+
+    @property
+    def trades(self):
+        return SimpleNamespace(
+            count=lambda: 7,
+            win_rate=lambda: _MetricValue(5.0),
+        )
+
+
+def test_artifact_paths_for_html_include_report_payload() -> None:
+    html_path = Path("/tmp/backtest/result.html")
+
+    paths = BacktestArtifactWriter.artifact_paths_for_html(html_path)
+
+    assert paths.metrics_path == html_path.with_suffix(".metrics.json")
+    assert paths.manifest_path == html_path.with_suffix(".manifest.json")
+    assert paths.simulation_payload_path == html_path.with_suffix(".simulation.pkl")
+    assert paths.report_payload_path == html_path.with_suffix(".report.json")
+
+
+def test_build_metrics_payload_preserves_stats_values_over_fallback_metrics() -> None:
+    payload = build_metrics_payload(
+        portfolio=_Portfolio(),
+        allocation_info=0.0,
+    )
+
+    assert payload["total_return"] == 0.0
+    assert payload["sharpe_ratio"] == 0.0
+    assert payload["trade_count"] == 0
+    assert payload["optimal_allocation"] == 0.0

--- a/apps/bt/tests/unit/backtest/test_backtest_runner.py
+++ b/apps/bt/tests/unit/backtest/test_backtest_runner.py
@@ -102,6 +102,7 @@ class _FakeExecutor:
             metrics_path=html_path.with_suffix(".metrics.json"),
             manifest_path=html_path.with_suffix(".manifest.json"),
             simulation_payload_path=html_path.with_suffix(".simulation.pkl"),
+            report_payload_path=html_path.with_suffix(".report.json"),
         )
 
     def execute_notebook(
@@ -163,11 +164,13 @@ def test_backtest_runner_uses_execution_config(monkeypatch, tmp_path: Path):
 
     assert result.html_path.exists()
     assert result.metrics_path is not None and result.metrics_path.exists()
+    assert result.report_payload_path is not None and result.report_payload_path.exists()
     assert fake_executor.executed_template_path == "custom_template.py"
     assert fake_executor.executed_strategy_name == "test_strategy"
     assert fake_executor.executed_extra_env == {"BT_DATA_ACCESS_MODE": "direct"}
     assert fake_executor.execution_metadata is not None
     assert "simulation_payload_path" in fake_executor.execution_metadata
+    assert "report_payload_path" in fake_executor.execution_metadata
 
 
 def test_backtest_runner_allows_http_override(monkeypatch, tmp_path: Path):
@@ -366,6 +369,7 @@ def test_backtest_runner_preserves_core_artifacts_when_html_render_fails(monkeyp
     assert result.metrics_path is not None and result.metrics_path.exists()
     assert result.manifest_path is not None and result.manifest_path.exists()
     assert result.render_error == "HTML file was not created"
+    assert result.report_payload_path is not None and result.report_payload_path.exists()
 
 
 def test_backtest_runner_preserves_core_artifacts_when_walk_forward_fails(
@@ -406,6 +410,7 @@ def test_backtest_runner_preserves_core_artifacts_when_walk_forward_fails(
     assert result.metrics_path is not None and result.metrics_path.exists()
     assert result.manifest_path is not None and result.manifest_path.exists()
     assert result.simulation_payload_path is not None and result.simulation_payload_path.exists()
+    assert result.report_payload_path is not None and result.report_payload_path.exists()
     assert "walk_forward" not in result.summary
 
 

--- a/apps/bt/tests/unit/backtest/test_marimo_executor.py
+++ b/apps/bt/tests/unit/backtest/test_marimo_executor.py
@@ -195,6 +195,7 @@ class TestOutputFilenameGeneration:
             assert paths.metrics_path == paths.html_path.with_suffix(".metrics.json")
             assert paths.manifest_path == paths.html_path.with_suffix(".manifest.json")
             assert paths.simulation_payload_path == paths.html_path.with_suffix(".simulation.pkl")
+            assert paths.report_payload_path == paths.html_path.with_suffix(".report.json")
 
     def test_validate_output_dir_tmp_fallback_when_data_dir_lookup_fails(self, monkeypatch):
         """get_data_dir が失敗しても /tmp は許可される"""

--- a/apps/bt/tests/unit/backtest/test_report_payload.py
+++ b/apps/bt/tests/unit/backtest/test_report_payload.py
@@ -1,0 +1,116 @@
+"""Tests for extracted backtest report payload helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from src.domains.backtest.core.report_payload import (
+    build_backtest_report_payload,
+    load_backtest_report_inputs,
+    load_backtest_report_payload,
+    load_legacy_simulation_inputs,
+    write_backtest_report_payload,
+)
+from src.domains.backtest.core.simulation import BacktestSimulationResult
+
+
+class _Trades:
+    def __init__(self) -> None:
+        self.records_readable = pd.DataFrame(
+            [{"Entry": "2024-01-04", "Exit": "2024-01-05", "PnL": 1.2}]
+        )
+
+    def stats(self) -> pd.Series:
+        return pd.Series({"Total Trades": 1, "Win Rate [%]": 100.0})
+
+
+class _Portfolio:
+    def __init__(self) -> None:
+        index = pd.to_datetime(["2024-01-04", "2024-01-05"])
+        self._value = pd.Series([100.0, 101.2], index=index)
+        self._drawdown = pd.Series([0.0, -0.5], index=index)
+        self._returns = pd.Series([0.0, 0.012], index=index)
+        self._stats = pd.Series({"Total Return [%]": 1.2, "Sharpe Ratio": 1.1})
+        self.trades = _Trades()
+
+    def value(self) -> pd.Series:
+        return self._value
+
+    def drawdown(self) -> pd.Series:
+        return self._drawdown
+
+    def returns(self) -> pd.Series:
+        return self._returns
+
+    def annualized_volatility(self) -> float:
+        return 0.2
+
+    def sharpe_ratio(self) -> float:
+        return 1.1
+
+    def sortino_ratio(self) -> float:
+        return 1.3
+
+    def calmar_ratio(self) -> float:
+        return 0.9
+
+    def omega_ratio(self) -> float:
+        return 1.05
+
+    def stats(self) -> pd.Series:
+        return self._stats
+
+
+def test_report_payload_roundtrip_restores_render_context(tmp_path: Path) -> None:
+    payload_path = tmp_path / "result.report.json"
+    simulation_result = BacktestSimulationResult(
+        initial_portfolio=_Portfolio(),
+        kelly_portfolio=_Portfolio(),
+        allocation_info=0.42,
+        all_entries=pd.DataFrame(
+            {
+                "7203": [True, False],
+                "6758": [False, True],
+            },
+            index=pd.to_datetime(["2024-01-04", "2024-01-05"]),
+        ),
+        summary_metrics=None,
+        metrics_payload={},
+    )
+
+    payload = build_backtest_report_payload(simulation_result)
+    write_backtest_report_payload(path=payload_path, payload=payload)
+    context = load_backtest_report_payload(payload_path)
+
+    assert context.initial_portfolio is not None
+    assert list(context.initial_portfolio.value()) == [100.0, 101.2]
+    assert context.kelly_portfolio is not None
+    assert list(context.kelly_portfolio.returns()) == [0.0, 0.012]
+    assert context.kelly_portfolio.trades.records_readable.iloc[0]["PnL"] == 1.2
+    assert context.allocation_info == 0.42
+    assert context.all_entries is not None
+    assert context.all_entries["signal_count"].tolist() == [1, 1]
+
+
+def test_load_backtest_report_inputs_returns_empty_values_for_corrupt_json(
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "broken.report.json"
+    payload_path.write_text("{", encoding="utf-8")
+
+    result = load_backtest_report_inputs(payload_path)
+
+    assert result == (None, None, None, None)
+
+
+def test_load_legacy_simulation_inputs_returns_empty_values_for_corrupt_pickle(
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "broken.simulation.pkl"
+    payload_path.write_bytes(b"not-a-pickle")
+
+    result = load_legacy_simulation_inputs(payload_path)
+
+    assert result == (None, None, None, None)

--- a/apps/bt/tests/unit/backtest/test_simulation.py
+++ b/apps/bt/tests/unit/backtest/test_simulation.py
@@ -1,0 +1,87 @@
+"""Tests for extracted backtest simulation stage."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.domains.backtest.core.simulation import (
+    BacktestSimulationExecutor,
+    BacktestSimulationResult,
+)
+
+
+class _MetricValue:
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def mean(self) -> float:
+        return self._value
+
+
+class _Portfolio:
+    def stats(self):
+        return {
+            "Total Return [%]": 12.3,
+            "Max Drawdown [%]": -4.5,
+            "Sharpe Ratio": 1.6,
+            "Sortino Ratio": 2.1,
+            "Calmar Ratio": 1.8,
+            "Win Rate [%]": 57.0,
+            "Profit Factor": 1.9,
+            "Total Trades": 11,
+        }
+
+    def total_return(self):
+        return _MetricValue(12.3)
+
+    def sharpe_ratio(self):
+        return _MetricValue(1.6)
+
+    def sortino_ratio(self):
+        return _MetricValue(2.1)
+
+    def calmar_ratio(self):
+        return _MetricValue(1.8)
+
+    def max_drawdown(self):
+        return _MetricValue(-4.5)
+
+    @property
+    def trades(self):
+        return SimpleNamespace(
+            count=lambda: 11,
+            win_rate=lambda: _MetricValue(57.0),
+        )
+
+
+def test_simulation_executor_builds_metrics_and_fallback_allocation(monkeypatch) -> None:
+    executor = BacktestSimulationExecutor()
+    initial_portfolio = _Portfolio()
+    kelly_portfolio = _Portfolio()
+
+    monkeypatch.setattr(
+        "src.domains.backtest.core.simulation.StrategyFactory.execute_strategy_with_config",
+        lambda *_args, **_kwargs: {
+            "initial_portfolio": initial_portfolio,
+            "kelly_portfolio": kelly_portfolio,
+            "max_concurrent": 3,
+            "all_entries": None,
+        },
+    )
+
+    result = executor.execute(
+        {
+            "shared_config": {"dataset": "sample"},
+            "entry_filter_params": {},
+            "exit_trigger_params": {},
+        }
+    )
+
+    assert isinstance(result, BacktestSimulationResult)
+    assert result.initial_portfolio is initial_portfolio
+    assert result.kelly_portfolio is kelly_portfolio
+    assert result.allocation_info == 3
+    assert result.summary_metrics is not None
+    assert result.summary_metrics.trade_count == 11
+    assert result.metrics_payload["profit_factor"] == 1.9
+    assert result.metrics_payload["trade_count"] == 11

--- a/apps/bt/tests/unit/backtest/test_strategy_analysis_template.py
+++ b/apps/bt/tests/unit/backtest/test_strategy_analysis_template.py
@@ -1,4 +1,4 @@
-"""Tests for the backtest strategy analysis template helpers."""
+"""Tests for the backtest strategy analysis template module."""
 
 from __future__ import annotations
 
@@ -21,11 +21,7 @@ def _load_template_module():
     return module
 
 
-def test_load_simulation_payload_returns_empty_values_for_corrupt_pickle(tmp_path: Path):
+def test_strategy_analysis_template_exports_marimo_app():
     module = _load_template_module()
-    payload_path = tmp_path / "broken.simulation.pkl"
-    payload_path.write_bytes(b"not-a-pickle")
 
-    result = module._load_simulation_payload(str(payload_path))
-
-    assert result == (None, None, None, None)
+    assert getattr(module, "app", None) is not None


### PR DESCRIPTION
## Summary
- salvage the reusable report payload / simulation / artifact extraction structure from #232 without reintroducing runner path drift
- move BacktestRunner orchestration onto extracted simulation, artifact, and report-payload helpers while keeping the existing planned report paths and legacy simulation payload fallback
- move notebook render-input loading into domain helpers so strategy_analysis stays marimo-strict compliant

## Testing
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/backtest/test_backtest_runner.py apps/bt/tests/unit/backtest/test_marimo_executor.py apps/bt/tests/unit/backtest/test_strategy_analysis_template.py apps/bt/tests/unit/backtest/test_artifacts.py apps/bt/tests/unit/backtest/test_simulation.py apps/bt/tests/unit/backtest/test_report_payload.py apps/bt/tests/unit/server/test_run_contracts.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/domains/backtest/core/runner.py apps/bt/src/domains/backtest/core/marimo_executor.py apps/bt/src/domains/backtest/core/artifacts.py apps/bt/src/domains/backtest/core/report_payload.py apps/bt/src/domains/backtest/core/simulation.py apps/bt/src/application/services/run_contracts.py apps/bt/notebooks/templates/strategy_analysis.py apps/bt/tests/unit/backtest/test_backtest_runner.py apps/bt/tests/unit/backtest/test_marimo_executor.py apps/bt/tests/unit/backtest/test_strategy_analysis_template.py apps/bt/tests/unit/backtest/test_artifacts.py apps/bt/tests/unit/backtest/test_simulation.py apps/bt/tests/unit/backtest/test_report_payload.py apps/bt/tests/unit/server/test_run_contracts.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pyright
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt marimo check --strict apps/bt/notebooks/templates/strategy_analysis.py