### PR TITLE
fix(bt): index report payload artifacts for backtest runs

### DIFF
--- a/apps/bt/src/application/services/run_contracts.py
+++ b/apps/bt/src/application/services/run_contracts.py
@@ -50,6 +50,7 @@ _RAW_RESULT_ARTIFACT_PATHS: tuple[tuple[str, ArtifactKind], ...] = (
     ("_metrics_path", ArtifactKind.METRICS_JSON),
     ("_manifest_path", ArtifactKind.MANIFEST_JSON),
     ("_simulation_payload_path", ArtifactKind.SIMULATION_PAYLOAD),
+    ("_report_payload_path", ArtifactKind.REPORT_PAYLOAD),
     ("saved_strategy_path", ArtifactKind.STRATEGY_YAML),
     ("saved_history_path", ArtifactKind.HISTORY_YAML),
 )
@@ -313,6 +314,15 @@ def build_artifact_index(job: JobInfo) -> ArtifactIndex | None:
                     kind=ArtifactKind.SIMULATION_PAYLOAD,
                     storage=ArtifactStorage.FILESYSTEM,
                     path=str(simulation_payload_path),
+                )
+            )
+        report_payload_path = html_path.with_suffix(".report.json")
+        if report_payload_path.exists():
+            _append_artifact(
+                ArtifactRecord(
+                    kind=ArtifactKind.REPORT_PAYLOAD,
+                    storage=ArtifactStorage.FILESYSTEM,
+                    path=str(report_payload_path),
                 )
             )
 

--- a/apps/bt/src/domains/backtest/contracts.py
+++ b/apps/bt/src/domains/backtest/contracts.py
@@ -39,6 +39,7 @@ class ArtifactKind(str, Enum):
     METRICS_JSON = "metrics_json"
     MANIFEST_JSON = "manifest_json"
     SIMULATION_PAYLOAD = "simulation_payload"
+    REPORT_PAYLOAD = "report_payload"
     RESULT_SUMMARY = "result_summary"
     RAW_RESULT_JSON = "raw_result_json"
     ATTRIBUTION_JSON = "attribution_json"

--- a/apps/bt/tests/unit/server/test_run_contracts.py
+++ b/apps/bt/tests/unit/server/test_run_contracts.py
@@ -284,6 +284,7 @@ class TestRefreshJobExecutionContracts:
         html_path.write_text("<html>ok</html>", encoding="utf-8")
         html_path.with_suffix(".metrics.json").write_text("{}", encoding="utf-8")
         html_path.with_suffix(".manifest.json").write_text("{}", encoding="utf-8")
+        html_path.with_suffix(".report.json").write_text("{}", encoding="utf-8")
 
         job = JobInfo("job-1", "demo-strategy", job_type="backtest")
         job.status = JobStatus.COMPLETED
@@ -317,6 +318,7 @@ class TestRefreshJobExecutionContracts:
         assert ArtifactKind.HTML in kinds
         assert ArtifactKind.METRICS_JSON in kinds
         assert ArtifactKind.MANIFEST_JSON in kinds
+        assert ArtifactKind.REPORT_PAYLOAD in kinds
         assert ArtifactKind.RESULT_SUMMARY in kinds
         assert ArtifactKind.RAW_RESULT_JSON in kinds
 
@@ -347,6 +349,8 @@ class TestRefreshJobExecutionContracts:
         manifest_path.write_text("{}", encoding="utf-8")
         simulation_payload_path = tmp_path / "result.simulation.pkl"
         simulation_payload_path.write_bytes(b"payload")
+        report_payload_path = tmp_path / "result.report.json"
+        report_payload_path.write_text("{}", encoding="utf-8")
 
         job = JobInfo("job-core", "demo-strategy", job_type="backtest")
         job.status = JobStatus.COMPLETED
@@ -365,6 +369,7 @@ class TestRefreshJobExecutionContracts:
             "_metrics_path": str(metrics_path),
             "_manifest_path": str(manifest_path),
             "_simulation_payload_path": str(simulation_payload_path),
+            "_report_payload_path": str(report_payload_path),
         }
 
         refresh_job_execution_contracts(job)
@@ -375,6 +380,7 @@ class TestRefreshJobExecutionContracts:
         assert ArtifactKind.METRICS_JSON in kinds
         assert ArtifactKind.MANIFEST_JSON in kinds
         assert ArtifactKind.SIMULATION_PAYLOAD in kinds
+        assert ArtifactKind.REPORT_PAYLOAD in kinds
 
     def test_attribution_job_uses_internal_artifact_path_for_index_and_strips_payload(self, tmp_path: Path) -> None:
         artifact_path = tmp_path / "attribution.json"

--- a/apps/ts/packages/api-clients/src/backtest/types.ts
+++ b/apps/ts/packages/api-clients/src/backtest/types.ts
@@ -21,6 +21,7 @@ export type ArtifactKind =
   | 'metrics_json'
   | 'manifest_json'
   | 'simulation_payload'
+  | 'report_payload'
   | 'result_summary'
   | 'raw_result_json'
   | 'attribution_json'

--- a/apps/ts/packages/contracts/openapi/bt-openapi.json
+++ b/apps/ts/packages/contracts/openapi/bt-openapi.json
@@ -366,6 +366,7 @@
           "metrics_json",
           "manifest_json",
           "simulation_payload",
+          "report_payload",
           "result_summary",
           "raw_result_json",
           "attribution_json",

--- a/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
@@ -2726,7 +2726,7 @@ export interface components {
          * @description Artifact role within a run.
          * @enum {string}
          */
-        ArtifactKind: "html" | "metrics_json" | "manifest_json" | "simulation_payload" | "result_summary" | "raw_result_json" | "attribution_json" | "strategy_yaml" | "history_yaml";
+        ArtifactKind: "html" | "metrics_json" | "manifest_json" | "simulation_payload" | "report_payload" | "result_summary" | "raw_result_json" | "attribution_json" | "strategy_yaml" | "history_yaml";
         /**
          * ArtifactRecord
          * @description Artifact registry entry for a run output.


### PR DESCRIPTION
## Summary
- add a dedicated `REPORT_PAYLOAD` artifact kind for backtest-family run contracts
- index sibling `.report.json` artifacts when reconstructing artifact indexes from html paths or raw_result payloads
- cover the new artifact path in `test_run_contracts`

## Testing
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/test_run_contracts.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/backtest/test_backtest_runner.py apps/bt/tests/unit/backtest/test_marimo_executor.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/domains/backtest/contracts.py apps/bt/src/application/services/run_contracts.py apps/bt/tests/unit/server/test_run_contracts.py

## Context
- follow-up to #234 so generated `*.report.json` artifacts are discoverable via `artifact_index`.