### PR TITLE
fix(dataset): include non-prime TOPIX500 and harden job polling

### DIFF
--- a/apps/bt/src/application/services/dataset_builder_service.py
+++ b/apps/bt/src/application/services/dataset_builder_service.py
@@ -576,8 +576,8 @@ async def _build_dataset(
             success=True,
             totalStocks=len(filtered),
             processedStocks=processed,
-            warnings=warnings if warnings else None,
-            errors=errors if errors else None,
+            warnings=warnings,
+            errors=errors,
             outputPath=str(snapshot_dir),
         )
     finally:

--- a/apps/bt/src/application/services/dataset_builder_service.py
+++ b/apps/bt/src/application/services/dataset_builder_service.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import shutil
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
@@ -58,8 +58,8 @@ class DatasetResult:
     success: bool
     totalStocks: int = 0
     processedStocks: int = 0
-    warnings: list[str] | None = None
-    errors: list[str] | None = None
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
     outputPath: str = ""
 
 

--- a/apps/bt/src/application/services/dataset_presets.py
+++ b/apps/bt/src/application/services/dataset_presets.py
@@ -32,7 +32,7 @@ PRESETS: dict[str, PresetConfig] = {
         scale_categories=["TOPIX Core30", "TOPIX Large70"],
     ),
     "topix500": PresetConfig(
-        markets=["prime"],
+        markets=["prime", "standard", "growth"],
         scale_categories=["TOPIX Core30", "TOPIX Large70", "TOPIX Mid400"],
     ),
     "mid400": PresetConfig(

--- a/apps/bt/src/entrypoints/http/routes/dataset.py
+++ b/apps/bt/src/entrypoints/http/routes/dataset.py
@@ -162,8 +162,8 @@ def get_dataset_job(jobId: str) -> DatasetJobResponse:
             success=job.result.success,
             totalStocks=job.result.totalStocks,
             processedStocks=job.result.processedStocks,
-            warnings=job.result.warnings,
-            errors=job.result.errors,
+            warnings=job.result.warnings or [],
+            errors=job.result.errors or [],
             outputPath=job.result.outputPath,
         )
 

--- a/apps/bt/tests/unit/server/test_dataset_builder_service.py
+++ b/apps/bt/tests/unit/server/test_dataset_builder_service.py
@@ -165,8 +165,8 @@ def test_dataset_result_defaults() -> None:
     r = DatasetResult(success=True)
     assert r.totalStocks == 0
     assert r.processedStocks == 0
-    assert r.warnings is None
-    assert r.errors is None
+    assert r.warnings == []
+    assert r.errors == []
     assert r.outputPath == ""
 
 

--- a/apps/bt/tests/unit/server/test_dataset_builder_service.py
+++ b/apps/bt/tests/unit/server/test_dataset_builder_service.py
@@ -12,7 +12,7 @@ from src.application.services.dataset_builder_service import (
     start_dataset_build,
     dataset_job_manager,
 )
-from src.application.services.dataset_presets import PresetConfig
+from src.application.services.dataset_presets import PresetConfig, get_preset
 
 
 # --- _filter_stocks ---
@@ -76,6 +76,21 @@ def test_filter_stocks_multi_market() -> None:
     preset = PresetConfig(markets=["prime", "growth"])
     result = _filter_stocks(stocks, preset)
     assert len(result) == 2
+
+
+def test_filter_stocks_topix500_includes_standard_when_scale_matches() -> None:
+    stocks = [
+        {"Code": "72030", "MktNm": "プライム", "ScaleCat": "TOPIX Core30"},
+        {"Code": "47160", "MktNm": "スタンダード", "ScaleCat": "TOPIX Mid400"},
+        {"Code": "85720", "MktNm": "スタンダード", "ScaleCat": "TOPIX Mid400"},
+        {"Code": "99990", "MktNm": "グロース", "ScaleCat": ""},
+    ]
+    preset = get_preset("topix500")
+    assert preset is not None
+
+    result = _filter_stocks(stocks, preset)
+
+    assert [row["Code"] for row in result] == ["72030", "47160", "85720"]
 
 
 # --- start_dataset_build ---

--- a/apps/bt/tests/unit/server/test_dataset_builder_service_branches.py
+++ b/apps/bt/tests/unit/server/test_dataset_builder_service_branches.py
@@ -712,7 +712,7 @@ async def test_build_dataset_success_copies_all_enabled_tables(monkeypatch, isol
     assert result.totalStocks == 2
     assert result.processedStocks == 2
     assert result.outputPath == "/tmp/full"
-    assert result.warnings is None
+    assert result.warnings == []
 
     writer = DummyWriter.instances[-1]
     assert "stocks" in writer.calls

--- a/apps/bt/tests/unit/server/test_dataset_presets.py
+++ b/apps/bt/tests/unit/server/test_dataset_presets.py
@@ -40,6 +40,13 @@ def test_topix100_preset() -> None:
     assert p.scale_categories == ["TOPIX Core30", "TOPIX Large70"]
 
 
+def test_topix500_preset_is_not_prime_only() -> None:
+    p = get_preset("topix500")
+    assert p is not None
+    assert p.markets == ["prime", "standard", "growth"]
+    assert p.scale_categories == ["TOPIX Core30", "TOPIX Large70", "TOPIX Mid400"]
+
+
 def test_prime_ex_topix500_preset() -> None:
     p = get_preset("primeExTopix500")
     assert p is not None

--- a/apps/bt/tests/unit/server/test_routes_dataset_jobs.py
+++ b/apps/bt/tests/unit/server/test_routes_dataset_jobs.py
@@ -169,6 +169,8 @@ def test_get_job_completed(client: TestClient) -> None:
     assert data["status"] == "completed"
     assert data["result"]["success"] is True
     assert data["result"]["totalStocks"] == 3
+    assert data["result"]["warnings"] == []
+    assert data["result"]["errors"] == []
 
 
 # --- Cancel Job ---

--- a/apps/ts/packages/web/src/components/Backtest/DatasetJobProgress.test.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetJobProgress.test.tsx
@@ -1,5 +1,6 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '@/lib/api-client';
 import type { DatasetJobResponse } from '@/types/dataset';
 import { DatasetJobProgress } from './DatasetJobProgress';
 
@@ -13,6 +14,7 @@ const mockStoreState = {
 
 const mockHookState = {
   job: null as DatasetJobResponse | null,
+  error: null as Error | null,
   cancelIsPending: false,
 };
 
@@ -57,6 +59,7 @@ vi.mock('@/hooks/useDataset', () => ({
   },
   useDatasetJobStatus: () => ({
     data: mockHookState.job,
+    error: mockHookState.error,
   }),
   useCancelDatasetJob: () => ({
     mutate: (...args: unknown[]) => mockCancelMutate(...args),
@@ -70,6 +73,7 @@ describe('DatasetJobProgress', () => {
     vi.useRealTimers();
     mockStoreState.activeDatasetJobId = null;
     mockHookState.job = null;
+    mockHookState.error = null;
     mockHookState.cancelIsPending = false;
   });
 
@@ -191,5 +195,15 @@ describe('DatasetJobProgress', () => {
 
     expect(screen.getByText('failed')).toBeInTheDocument();
     expect(screen.getByText('dataset creation failed')).toBeInTheDocument();
+  });
+
+  it('clears stale active job id when status endpoint returns 404', async () => {
+    mockStoreState.activeDatasetJobId = 'job-missing';
+    mockHookState.job = null;
+    mockHookState.error = new ApiError('Job not found', 404);
+
+    render(<DatasetJobProgress />);
+
+    await waitFor(() => expect(mockSetActiveDatasetJobId).toHaveBeenCalledWith(null));
   });
 });

--- a/apps/ts/packages/web/src/components/Backtest/DatasetJobProgress.tsx
+++ b/apps/ts/packages/web/src/components/Backtest/DatasetJobProgress.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { datasetKeys, useCancelDatasetJob, useDatasetJobStatus } from '@/hooks/useDataset';
+import { ApiError } from '@/lib/api-client';
 import { useBacktestStore } from '@/stores/backtestStore';
 
 function formatElapsed(seconds: number): string {
@@ -14,7 +15,7 @@ function formatElapsed(seconds: number): string {
 
 export function DatasetJobProgress() {
   const { activeDatasetJobId, setActiveDatasetJobId } = useBacktestStore();
-  const { data: job } = useDatasetJobStatus(activeDatasetJobId);
+  const { data: job, error: jobError } = useDatasetJobStatus(activeDatasetJobId);
   const cancelJob = useCancelDatasetJob();
   const queryClient = useQueryClient();
 
@@ -47,6 +48,12 @@ export function DatasetJobProgress() {
       return () => clearTimeout(timer);
     }
   }, [isTerminal, activeDatasetJobId, setActiveDatasetJobId, queryClient]);
+
+  useEffect(() => {
+    if (!activeDatasetJobId) return;
+    if (!(jobError instanceof ApiError) || jobError.status !== 404) return;
+    setActiveDatasetJobId(null);
+  }, [jobError, activeDatasetJobId, setActiveDatasetJobId]);
 
   if (!activeDatasetJobId || !job) return null;
 

--- a/apps/ts/packages/web/src/hooks/useDataset.test.tsx
+++ b/apps/ts/packages/web/src/hooks/useDataset.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { apiDelete, apiGet, apiPost } from '@/lib/api-client';
+import { ApiError, apiDelete, apiGet, apiPost } from '@/lib/api-client';
 import { createQueryWrapper, createTestQueryClient } from '@/test-utils';
 import type { DatasetCreateRequest } from '@/types/dataset';
 import {
@@ -13,12 +13,16 @@ import {
   useDeleteDataset,
 } from './useDataset';
 
-vi.mock('@/lib/api-client', () => ({
-  apiGet: vi.fn(),
-  apiPost: vi.fn(),
-  apiPut: vi.fn(),
-  apiDelete: vi.fn(),
-}));
+vi.mock('@/lib/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api-client')>('@/lib/api-client');
+  return {
+    ...actual,
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    apiPut: vi.fn(),
+    apiDelete: vi.fn(),
+  };
+});
 
 vi.mock('@/utils/logger', () => ({
   logger: {
@@ -214,6 +218,31 @@ describe('useDatasetJobStatus', () => {
     expect(apiGet).toHaveBeenCalledWith('/api/dataset/jobs/job-1');
   });
 
+  it('normalizes null warnings and errors in job result payloads', async () => {
+    vi.mocked(apiGet).mockResolvedValueOnce({
+      jobId: 'job-1',
+      status: 'completed',
+      preset: 'quickTesting',
+      name: 'quickTesting_404',
+      startedAt: '2026-03-16T00:00:00Z',
+      result: {
+        success: true,
+        totalStocks: 3,
+        processedStocks: 3,
+        warnings: null,
+        errors: null,
+        outputPath: '/tmp/quickTesting_404',
+      },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDatasetJobStatus('job-1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.result?.warnings).toEqual([]);
+    expect(result.current.data?.result?.errors).toEqual([]);
+  });
+
   it('does not fetch when jobId is null', () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useDatasetJobStatus(null), { wrapper });
@@ -235,6 +264,17 @@ describe('useDatasetJobStatus', () => {
 
     await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2), { timeout: 3500 });
   }, 8000);
+
+  it('does not retry when job status returns 404', async () => {
+    vi.mocked(apiGet).mockRejectedValue(new ApiError('Job not found', 404));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDatasetJobStatus('missing-job'), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(ApiError);
+    expect((result.current.error as ApiError).status).toBe(404);
+  });
 });
 
 describe('useCreateDataset', () => {

--- a/apps/ts/packages/web/src/hooks/useDataset.ts
+++ b/apps/ts/packages/web/src/hooks/useDataset.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiDelete, apiGet, apiPost } from '@/lib/api-client';
+import { ApiError, apiDelete, apiGet, apiPost } from '@/lib/api-client';
 import type {
   CancelDatasetJobResponse,
   DatasetCreateJobResponse,
@@ -57,6 +57,13 @@ interface LegacyDatasetListItem {
 type DatasetStorage = DatasetInfoResponse['storage'];
 type LegacySnapshot = LegacyDatasetInfoResponse['snapshot'];
 type LegacyValidation = NonNullable<LegacySnapshot['validation']>;
+type DatasetJobResultPayload = NonNullable<DatasetJobResponse['result']> & {
+  warnings?: string[] | null;
+  errors?: string[] | null;
+};
+type DatasetJobResponsePayload = Omit<DatasetJobResponse, 'result'> & {
+  result?: DatasetJobResultPayload | null;
+};
 
 function inferLegacyStorage(path: string): DatasetStorage {
   const isLegacySqlite = path.endsWith('.db');
@@ -163,6 +170,22 @@ function normalizeDatasetListItem(value: DatasetListItem | LegacyDatasetListItem
   };
 }
 
+function normalizeDatasetJobResponse(value: DatasetJobResponsePayload): DatasetJobResponse {
+  if (value.result == null) {
+    const { result: _result, ...rest } = value;
+    return rest;
+  }
+
+  return {
+    ...value,
+    result: {
+      ...value.result,
+      warnings: value.result.warnings ?? [],
+      errors: value.result.errors ?? [],
+    },
+  };
+}
+
 function fetchDatasets(): Promise<DatasetListResponse> {
   return apiGet<DatasetListResponse | LegacyDatasetListItem[]>('/api/dataset').then((items) =>
     items.map(normalizeDatasetListItem)
@@ -176,7 +199,9 @@ function fetchDatasetInfo(name: string): Promise<DatasetInfoResponse> {
 }
 
 function fetchJobStatus(jobId: string): Promise<DatasetJobResponse> {
-  return apiGet<DatasetJobResponse>(`/api/dataset/jobs/${encodeURIComponent(jobId)}`);
+  return apiGet<DatasetJobResponsePayload>(`/api/dataset/jobs/${encodeURIComponent(jobId)}`).then(
+    normalizeDatasetJobResponse
+  );
 }
 
 function createDataset(request: DatasetCreateRequest): Promise<DatasetCreateJobResponse> {
@@ -228,6 +253,10 @@ export function useDatasetJobStatus(jobId: string | null) {
       const status = query.state.data?.status;
       if (status === 'running' || status === 'pending') return 2000;
       return false;
+    },
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status === 404) return false;
+      return failureCount < 2;
     },
     staleTime: 0,
   });


### PR DESCRIPTION
## Summary
- remove the prime market restriction from the topix500 dataset preset so J-Quants master constituent labels drive inclusion
- normalize dataset job results to always expose array warnings/errors and harden the web polling flow against stale 404 job IDs
- add bt/web regression coverage for the preset filter and dataset job progress handling

## Verification
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/server/test_dataset_presets.py apps/bt/tests/unit/server/test_dataset_builder_service.py apps/bt/tests/unit/server/test_routes_dataset_jobs.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/application/services/dataset_builder_service.py apps/bt/src/application/services/dataset_presets.py apps/bt/src/entrypoints/http/routes/dataset.py apps/bt/tests/unit/server/test_routes_dataset_jobs.py
- bun run --filter @trading25/web test -- src/hooks/useDataset.test.tsx src/components/Backtest/DatasetJobProgress.test.tsx
- bun run --filter @trading25/web typecheck
- manually regenerated topix500_20260313 and verified the snapshot now contains 496 stocks
- manually reproduced the web dataset-create flow in the browser and confirmed no post-completion crash/404 remains
