### PR TITLE
fix(bt): keep dataset snapshot writes thread-affine

### DIFF
--- a/apps/bt/src/application/services/dataset_builder_service.py
+++ b/apps/bt/src/application/services/dataset_builder_service.py
@@ -12,8 +12,10 @@ import hashlib
 import json
 import shutil
 from collections.abc import Iterable, Iterator, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from functools import partial
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Protocol
@@ -102,6 +104,45 @@ class MarketDatasetSource(Protocol):
     def query(self, sql: str, params: tuple[Any, ...] = ()) -> list[Any]:
         """Read-only DuckDB query interface."""
         ...
+
+
+class _DatasetWriterWorker:
+    """Keep DuckDB-backed DatasetWriter calls on one dedicated thread."""
+
+    def __init__(self, snapshot_path: str) -> None:
+        self._snapshot_path = snapshot_path
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dataset-writer")
+        self._writer: DatasetWriter | None = None
+
+    def _get_writer(self) -> DatasetWriter:
+        if self._writer is None:
+            self._writer = DatasetWriter(self._snapshot_path)
+        return self._writer
+
+    def _call(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        writer = self._get_writer()
+        method = getattr(writer, method_name)
+        return method(*args, **kwargs)
+
+    def _close(self) -> None:
+        if self._writer is None:
+            return
+        self._writer.close()
+        self._writer = None
+
+    async def call(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            partial(self._call, method_name, *args, **kwargs),
+        )
+
+    async def close(self) -> None:
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(self._executor, self._close)
+        finally:
+            self._executor.shutdown(wait=True)
 
 
 def _is_missing_value(value: Any) -> bool:
@@ -302,7 +343,7 @@ async def _build_dataset(
 
     # Step 2: Writer 作成
     progress("init", 1, _TOTAL_STAGES, f"Creating dataset with {len(filtered)} stocks...")
-    writer = DatasetWriter(snapshot_path)
+    writer_worker = _DatasetWriterWorker(snapshot_path)
     direct_copy_enabled = source_duckdb_path is not None
     copy_mode = "duckdb-direct" if direct_copy_enabled else "legacy-query"
     success_result: DatasetResult | None = None
@@ -311,10 +352,10 @@ async def _build_dataset(
     try:
         # 銘柄データ書き込み
         stock_rows = _convert_stocks(filtered)
-        await asyncio.to_thread(writer.upsert_stocks, stock_rows)
-        writer.set_dataset_info("preset", preset_name)
-        writer.set_dataset_info("created_at", datetime.now(UTC).isoformat())
-        writer.set_dataset_info("stock_count", str(len(filtered)))
+        await writer_worker.call("upsert_stocks", stock_rows)
+        await writer_worker.call("set_dataset_info", "preset", preset_name)
+        await writer_worker.call("set_dataset_info", "created_at", datetime.now(UTC).isoformat())
+        await writer_worker.call("set_dataset_info", "stock_count", str(len(filtered)))
 
         # Step 3: 株価データ取得
         stock_data_started = perf_counter()
@@ -333,8 +374,8 @@ async def _build_dataset(
 
             batch_codes = [normalize_stock_code(stock.get("Code", "")) for stock in batch]
             if direct_copy_enabled and source_duckdb_path is not None:
-                copy_result = await asyncio.to_thread(
-                    writer.copy_stock_data_from_source,
+                copy_result = await writer_worker.call(
+                    "copy_stock_data_from_source",
                     source_duckdb_path=source_duckdb_path,
                     normalized_codes=batch_codes,
                 )
@@ -376,7 +417,7 @@ async def _build_dataset(
                     else:
                         empty_ohlcv_codes.append(code4)
                 if rows_to_write:
-                    await asyncio.to_thread(writer.upsert_stock_data, rows_to_write)
+                    await writer_worker.call("upsert_stock_data", rows_to_write)
             processed += len(batch)
             progress(
                 "stock_data",
@@ -421,8 +462,8 @@ async def _build_dataset(
                 return DatasetResult(success=False, processedStocks=processed, errors=["Cancelled"])
             inserted_rows = 0
             if direct_copy_enabled and source_duckdb_path is not None:
-                inserted_rows = await asyncio.to_thread(
-                    writer.copy_topix_data_from_source,
+                inserted_rows = await writer_worker.call(
+                    "copy_topix_data_from_source",
                     source_duckdb_path=source_duckdb_path,
                 )
             else:
@@ -431,7 +472,7 @@ async def _build_dataset(
                     return DatasetResult(success=False, processedStocks=processed, errors=["Cancelled"])
                 if topix_rows:
                     inserted_rows = len(topix_rows)
-                    await asyncio.to_thread(writer.upsert_topix_data, topix_rows)
+                    await writer_worker.call("upsert_topix_data", topix_rows)
             log_stage_elapsed(
                 "topix",
                 topix_started,
@@ -455,8 +496,8 @@ async def _build_dataset(
                 return DatasetResult(success=False, processedStocks=processed, errors=["Cancelled"])
             inserted_rows = 0
             if direct_copy_enabled and source_duckdb_path is not None:
-                inserted_rows = await asyncio.to_thread(
-                    writer.copy_indices_data_from_source,
+                inserted_rows = await writer_worker.call(
+                    "copy_indices_data_from_source",
                     source_duckdb_path=source_duckdb_path,
                     normalized_codes=target_index_codes,
                 )
@@ -471,7 +512,7 @@ async def _build_dataset(
                 ]
                 if rows_to_write:
                     inserted_rows = len(rows_to_write)
-                    await asyncio.to_thread(writer.upsert_indices_data, rows_to_write)
+                    await writer_worker.call("upsert_indices_data", rows_to_write)
             log_stage_elapsed(
                 "indices",
                 indices_started,
@@ -495,8 +536,8 @@ async def _build_dataset(
                     return DatasetResult(success=False, processedStocks=processed, errors=["Cancelled"])
                 batch_codes = [normalize_stock_code(stock.get("Code", "")) for stock in batch]
                 if direct_copy_enabled and source_duckdb_path is not None:
-                    await asyncio.to_thread(
-                        writer.copy_statements_from_source,
+                    await writer_worker.call(
+                        "copy_statements_from_source",
                         source_duckdb_path=source_duckdb_path,
                         normalized_codes=batch_codes,
                     )
@@ -510,7 +551,7 @@ async def _build_dataset(
                         for row in statement_rows.get(normalize_stock_code(stock.get("Code", "")), [])
                     ]
                     if rows_to_write:
-                        await asyncio.to_thread(writer.upsert_statements, rows_to_write)
+                        await writer_worker.call("upsert_statements", rows_to_write)
                 statements_processed += len(batch)
                 progress(
                     "statements",
@@ -540,8 +581,8 @@ async def _build_dataset(
                     return DatasetResult(success=False, processedStocks=processed, errors=["Cancelled"])
                 batch_codes = [normalize_stock_code(stock.get("Code", "")) for stock in batch]
                 if direct_copy_enabled and source_duckdb_path is not None:
-                    await asyncio.to_thread(
-                        writer.copy_margin_data_from_source,
+                    await writer_worker.call(
+                        "copy_margin_data_from_source",
                         source_duckdb_path=source_duckdb_path,
                         normalized_codes=batch_codes,
                     )
@@ -555,7 +596,7 @@ async def _build_dataset(
                         for row in margin_rows.get(normalize_stock_code(stock.get("Code", "")), [])
                     ]
                     if rows_to_write:
-                        await asyncio.to_thread(writer.upsert_margin_data, rows_to_write)
+                        await writer_worker.call("upsert_margin_data", rows_to_write)
                 margin_processed += len(batch)
                 progress(
                     "margin",
@@ -570,8 +611,8 @@ async def _build_dataset(
                 target_count=len(filtered),
             )
 
-        writer.set_dataset_info("manifest_path", str(manifest_path))
-        writer.set_dataset_info("manifest_schema_version", "2")
+        await writer_worker.call("set_dataset_info", "manifest_path", str(manifest_path))
+        await writer_worker.call("set_dataset_info", "manifest_schema_version", "2")
         success_result = DatasetResult(
             success=True,
             totalStocks=len(filtered),
@@ -581,7 +622,7 @@ async def _build_dataset(
             outputPath=str(snapshot_dir),
         )
     finally:
-        writer.close()
+        await writer_worker.close()
 
     if success_result is None:
         raise RuntimeError("dataset build result was not prepared")

--- a/apps/bt/tests/unit/server/test_dataset_builder_service_branches.py
+++ b/apps/bt/tests/unit/server/test_dataset_builder_service_branches.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 import json
 import sqlite3
+import threading
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import cast
@@ -436,6 +437,73 @@ def test_convert_stocks_maps_jquants_fields():
 
 
 @pytest.mark.asyncio
+async def test_dataset_writer_worker_close_without_writer_is_noop():
+    worker = dataset_builder_service._DatasetWriterWorker("/tmp/unused-dataset-writer")
+
+    await worker.close()
+
+
+def test_normalize_index_code_handles_empty_and_short_numeric_values():
+    assert dataset_builder_service._normalize_index_code(None) == ""
+    assert dataset_builder_service._normalize_index_code("40") == "0040"
+
+
+@pytest.mark.asyncio
+async def test_query_market_rows_awaits_coroutine_results():
+    class _CoroutineReader:
+        def query(self, sql: str, params: tuple[object, ...] = ()):
+            del sql, params
+
+            async def _rows():
+                return [{"value": 1}]
+
+            return _rows()
+
+    rows = await dataset_builder_service._query_market_rows(_CoroutineReader(), "SELECT 1")
+
+    assert rows == [{"value": 1}]
+
+
+@pytest.mark.asyncio
+async def test_load_market_index_data_batch_returns_empty_when_no_codes():
+    rows = await dataset_builder_service._load_market_index_data_batch(_StaticRowsMarketReader([]), [])
+
+    assert rows == {}
+
+
+@pytest.mark.asyncio
+async def test_load_market_index_data_batch_skips_rows_without_date_or_code():
+    reader = _StaticRowsMarketReader(
+        [
+            {
+                "code": "0040",
+                "date": "",
+                "open": 1,
+                "high": 1,
+                "low": 1,
+                "close": 1,
+                "sector_name": "Sector",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            },
+            {
+                "code": None,
+                "date": "2026-01-01",
+                "open": 1,
+                "high": 1,
+                "low": 1,
+                "close": 1,
+                "sector_name": "Sector",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            },
+        ]
+    )
+
+    rows = await dataset_builder_service._load_market_index_data_batch(reader, ["0040"])
+
+    assert rows == {}
+
+
+@pytest.mark.asyncio
 async def test_load_market_stock_data_batch_merges_alias_rows_before_validation():
     reader = _StaticRowsMarketReader(
         [
@@ -779,6 +847,67 @@ async def test_build_dataset_returns_partial_result_when_cancelled_during_stock_
     assert result.processedStocks == 0
     assert result.errors == ["Cancelled"]
     assert DummyWriter.instances[-1].closed is True
+
+
+@pytest.mark.asyncio
+async def test_build_dataset_keeps_dataset_writer_on_one_worker_thread(
+    monkeypatch,
+    isolated_dataset_manager,
+):
+    job = await _create_job(isolated_dataset_manager, preset="quick")
+    resolver = MagicMock()
+    resolver.get_dataset_path.return_value = "/tmp/thread-affinity.db"
+
+    preset = PresetConfig(
+        markets=["prime"],
+        include_topix=False,
+        include_statements=False,
+        include_margin=False,
+        include_sector_indices=False,
+    )
+    monkeypatch.setattr(dataset_builder_service, "get_preset", lambda _name: preset)
+
+    main_thread_id = threading.get_ident()
+    thread_ids: list[int] = []
+
+    class DummyWriter:
+        def __init__(self, db_path: str):
+            del db_path
+            thread_ids.append(threading.get_ident())
+
+        def upsert_stocks(self, rows):
+            thread_ids.append(threading.get_ident())
+            return len(rows)
+
+        def set_dataset_info(self, key: str, value: str):
+            del key, value
+            thread_ids.append(threading.get_ident())
+            return None
+
+        def upsert_stock_data(self, rows):
+            thread_ids.append(threading.get_ident())
+            return len(rows)
+
+        def close(self):
+            thread_ids.append(threading.get_ident())
+
+    monkeypatch.setattr(dataset_builder_service, "DatasetWriter", DummyWriter)
+
+    async def fake_get_paginated(path: str, params=None):
+        if path == "/equities/master":
+            return [_master_row("11110", "A")]
+        if path == "/equities/bars/daily":
+            return [_daily_bar_row()]
+        return []
+
+    reader = _reader_from_fetch(fake_get_paginated)
+
+    result = await _build_dataset(job, resolver, reader)
+
+    assert result.success is True
+    assert thread_ids
+    assert len(set(thread_ids)) == 1
+    assert thread_ids[0] != main_thread_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep dataset snapshot writer creation, writes, metadata updates, and close on one dedicated worker thread
- add regression tests for writer thread affinity and helper edge cases around dataset builder paths
- validate dataset builder coverage stays above the aicheck threshold

## Testing
- .venv/bin/python -m py_compile src/application/services/dataset_builder_service.py tests/unit/server/test_dataset_builder_service_branches.py
- .venv/bin/python -m coverage run --branch -m pytest -p no:cov tests/unit/server/test_dataset_builder_service.py tests/unit/server/test_dataset_builder_service_branches.py
- .venv/bin/python -m coverage report -m --include='src/application/services/dataset_builder_service.py'