### PR TITLE
feat(charts): split header summary panels

### DIFF
--- a/apps/bt/src/domains/fundamentals/calculator.py
+++ b/apps/bt/src/domains/fundamentals/calculator.py
@@ -26,6 +26,14 @@ from .models import (
 class FundamentalsCalculator:
     """Pure(ish) fundamentals computation logic."""
 
+    @staticmethod
+    def _is_valid_share_metric(value: float | None, *, allow_zero: bool = False) -> bool:
+        if value is None or not math.isfinite(value):
+            return False
+        if allow_zero:
+            return value >= 0
+        return value > 0
+
     def _build_shares_map(
         self, statements: list[JQuantsStatement]
     ) -> dict[tuple[str, str, str | None], float | None]:
@@ -50,6 +58,35 @@ class FundamentalsCalculator:
     ) -> float | None:
         snapshots = [(stmt.CurPerType, stmt.DiscDate, stmt.ShOutFY) for stmt in statements]
         return resolve_latest_quarterly_baseline_shares(snapshots)
+
+    def _resolve_latest_treasury_shares_from_latest_quarter(
+        self, statements: list[JQuantsStatement]
+    ) -> float | None:
+        latest_quarter_key: str | None = None
+        latest_quarter_treasury: float | None = None
+        latest_any_key: str | None = None
+        latest_any_treasury: float | None = None
+
+        for stmt in statements:
+            treasury_shares = stmt.TrShFY
+            if not self._is_valid_share_metric(treasury_shares, allow_zero=True):
+                continue
+            assert treasury_shares is not None
+
+            disclosed_key = str(stmt.DiscDate) if stmt.DiscDate is not None else ""
+            treasury_value = float(treasury_shares)
+            normalized_period = normalize_period_type(stmt.CurPerType)
+
+            if normalized_period in {"1Q", "2Q", "3Q"}:
+                if latest_quarter_key is None or disclosed_key > latest_quarter_key:
+                    latest_quarter_key = disclosed_key
+                    latest_quarter_treasury = treasury_value
+
+            if latest_any_key is None or disclosed_key > latest_any_key:
+                latest_any_key = disclosed_key
+                latest_any_treasury = treasury_value
+
+        return latest_quarter_treasury if latest_quarter_treasury is not None else latest_any_treasury
 
     def _compute_adjusted_value(
         self,
@@ -648,6 +685,7 @@ class FundamentalsCalculator:
             return []
 
         baseline_shares = self._resolve_baseline_shares_from_latest_quarter(statements)
+        baseline_treasury_shares = self._resolve_latest_treasury_shares_from_latest_quarter(statements)
         fy_data_points = self._get_applicable_fy_data(statements, prefer_consolidated, baseline_shares)
         if not fy_data_points:
             return []
@@ -663,15 +701,28 @@ class FundamentalsCalculator:
             per = None
             pbr = None
             market_cap = None
+            free_float_market_cap = None
 
             if applicable_fy.eps is not None and applicable_fy.eps != 0:
                 per = round(close / applicable_fy.eps, 2)
             if applicable_fy.bps is not None and applicable_fy.bps > 0:
                 pbr = round(close / applicable_fy.bps, 2)
             if baseline_shares is not None and baseline_shares != 0:
-                market_cap = self._round_or_none(calc_market_cap_scalar(close, baseline_shares))
+                market_cap = self._round_or_none(calc_market_cap_scalar(close, baseline_shares, 0.0))
+                free_float_market_cap = self._round_or_none(
+                    calc_market_cap_scalar(close, baseline_shares, baseline_treasury_shares)
+                )
 
-            result.append(DailyValuationDataPoint(date=date_str, close=close, per=per, pbr=pbr, marketCap=market_cap))
+            result.append(
+                DailyValuationDataPoint(
+                    date=date_str,
+                    close=close,
+                    per=per,
+                    pbr=pbr,
+                    marketCap=market_cap,
+                    freeFloatMarketCap=free_float_market_cap,
+                )
+            )
         return result
 
     def _get_applicable_fy_data(

--- a/apps/bt/src/domains/fundamentals/models.py
+++ b/apps/bt/src/domains/fundamentals/models.py
@@ -85,6 +85,7 @@ class DailyValuationDataPoint(BaseModel):
     per: float | None = None
     pbr: float | None = None
     marketCap: float | None = None
+    freeFloatMarketCap: float | None = None
 
 
 @dataclass

--- a/apps/bt/src/entrypoints/http/schemas/fundamentals.py
+++ b/apps/bt/src/entrypoints/http/schemas/fundamentals.py
@@ -174,7 +174,14 @@ class DailyValuationDataPoint(BaseModel):
     close: float = Field(..., description="Closing price")
     per: float | None = Field(None, description="PER at this date")
     pbr: float | None = Field(None, description="PBR at this date")
-    marketCap: float | None = Field(None, description="Market cap at this date (JPY)")
+    marketCap: float | None = Field(
+        None,
+        description="Market cap at this date using shares outstanding (JPY)",
+    )
+    freeFloatMarketCap: float | None = Field(
+        None,
+        description="Market cap at this date using free-float shares (JPY)",
+    )
 
 
 class FundamentalsComputeResponse(BaseModel):

--- a/apps/bt/tests/server/services/test_fundamentals_service.py
+++ b/apps/bt/tests/server/services/test_fundamentals_service.py
@@ -2598,7 +2598,7 @@ class TestCalculateDailyValuation:
     def test_daily_valuation_without_per_uses_pbr_and_market_cap(
         self, service: FundamentalsService
     ):
-        """EPS=0時はPERなし、BPSと時価総額は計算する"""
+        """EPS=0時はPERなし、BPSと両方の時価総額を計算する"""
         base = self._statement_base()
         statements = [
             JQuantsStatement(
@@ -2608,6 +2608,7 @@ class TestCalculateDailyValuation:
                     "CurPerType": "1Q",
                     "CurPerEn": "2024-06-30",
                     "ShOutFY": 1000,
+                    "TrShFY": 100,
                 }
             ),
             JQuantsStatement(
@@ -2631,6 +2632,7 @@ class TestCalculateDailyValuation:
         assert result[0].per is None
         assert result[0].pbr == 0.5
         assert result[0].marketCap == 500000.0
+        assert result[0].freeFloatMarketCap == 450000.0
 
     def test_daily_valuation_without_pbr_or_market_cap(
         self, service: FundamentalsService

--- a/apps/ts/packages/api-clients/src/backtest/types.ts
+++ b/apps/ts/packages/api-clients/src/backtest/types.ts
@@ -921,6 +921,7 @@ export interface DailyValuationDataPoint {
   per: number | null;
   pbr: number | null;
   marketCap: number | null;
+  freeFloatMarketCap?: number | null;
 }
 
 export interface FundamentalsComputeResponse {

--- a/apps/ts/packages/contracts/openapi/bt-openapi.json
+++ b/apps/ts/packages/contracts/openapi/bt-openapi.json
@@ -1661,6 +1661,18 @@
             "title": "Date",
             "type": "string"
           },
+          "freeFloatMarketCap": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Market cap at this date using free-float shares (JPY)",
+            "title": "Freefloatmarketcap"
+          },
           "marketCap": {
             "anyOf": [
               {
@@ -1670,7 +1682,7 @@
                 "type": "null"
               }
             ],
-            "description": "Market cap at this date (JPY)",
+            "description": "Market cap at this date using shares outstanding (JPY)",
             "title": "Marketcap"
           },
           "pbr": {

--- a/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
@@ -3365,8 +3365,13 @@ export interface components {
              */
             date: string;
             /**
+             * Freefloatmarketcap
+             * @description Market cap at this date using free-float shares (JPY)
+             */
+            freeFloatMarketCap?: number | null;
+            /**
              * Marketcap
-             * @description Market cap at this date (JPY)
+             * @description Market cap at this date using shares outstanding (JPY)
              */
             marketCap?: number | null;
             /**

--- a/apps/ts/packages/contracts/src/types/api-types.ts
+++ b/apps/ts/packages/contracts/src/types/api-types.ts
@@ -145,8 +145,10 @@ export interface ApiDailyValuationDataPoint {
   per: number | null;
   /** Price to Book Ratio using FY BPS (倍) */
   pbr: number | null;
-  /** Market capitalization (円) */
+  /** Market capitalization using shares outstanding (円) */
   marketCap: number | null;
+  /** Market capitalization using free-float shares (円) */
+  freeFloatMarketCap?: number | null;
 }
 
 /**

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -451,7 +451,7 @@ describe('ChartsPage', () => {
     expect(screen.getAllByText('Margin Pressure Chart')).toHaveLength(3);
     expect(screen.getByText('Test Co')).toBeInTheDocument();
     expect(screen.getByText(/7203/)).toBeInTheDocument();
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false, tradingValuePeriod: 15 });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: true, tradingValuePeriod: 15 });
     expect(mockFundamentalsPanelProps.mock.calls.at(-1)?.[0]).toMatchObject({
       symbol: '7203',
       enabled: false,
@@ -559,9 +559,10 @@ describe('ChartsPage', () => {
     expect(screen.queryByText('FY History Panel')).not.toBeInTheDocument();
     expect(screen.queryByText('Factor Regression Panel')).not.toBeInTheDocument();
     expect(screen.queryByText('信用圧力指標')).not.toBeInTheDocument();
-    expect(screen.queryByText(/時価総額/)).not.toBeInTheDocument();
+    expect(screen.getByText('時価総額 (Free Float)')).toBeInTheDocument();
+    expect(screen.getByText('時価総額 (発行済み株式数)')).toBeInTheDocument();
 
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false, tradingValuePeriod: 15 });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: true, tradingValuePeriod: 15 });
     expect(mockUseBtMarginIndicators).toHaveBeenCalledWith('7203', { enabled: false });
     expect(mockFactorRegressionPanelProps).not.toHaveBeenCalled();
   });
@@ -659,7 +660,7 @@ describe('ChartsPage', () => {
 
     renderChartsPage();
 
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false, tradingValuePeriod: 1 });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: true, tradingValuePeriod: 1 });
     expect(mockFundamentalsPanelProps.mock.calls.at(-1)?.[0]).toMatchObject({
       symbol: '7203',
       tradingValuePeriod: 1,
@@ -774,10 +775,14 @@ describe('ChartsPage', () => {
       isLoading: false,
       error: null,
     });
-    mockUseStockInfo.mockReturnValue({ data: { companyName: 'Test Co' } });
+    mockUseStockInfo.mockReturnValue({
+      data: { companyName: 'Test Co', sector17Name: '自動車・輸送機', sector33Name: '輸送用機器' },
+    });
     mockUseFundamentals.mockImplementation(
       (_symbol: string, options?: { enabled?: boolean; tradingValuePeriod?: number }) => ({
-        data: options?.enabled ? { dailyValuation: [{ marketCap: 1000000000 }] } : null,
+        data: options?.enabled
+          ? { dailyValuation: [{ marketCap: 1000000000, freeFloatMarketCap: 800000000 }] }
+          : null,
       })
     );
 
@@ -787,7 +792,12 @@ describe('ChartsPage', () => {
       MockIntersectionObserver.triggerAll(true);
     });
 
-    expect(screen.getByText(/時価総額/)).toBeInTheDocument();
+    expect(screen.getByText('セクター17')).toBeInTheDocument();
+    expect(screen.getByText('自動車・輸送機')).toBeInTheDocument();
+    expect(screen.getByText('セクター33')).toBeInTheDocument();
+    expect(screen.getByText('輸送用機器')).toBeInTheDocument();
+    expect(screen.getByText('時価総額 (Free Float)')).toBeInTheDocument();
+    expect(screen.getByText('時価総額 (発行済み株式数)')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /四季報/i }));
     fireEvent.click(screen.getByRole('button', { name: /B\.C\./i }));
@@ -853,7 +863,7 @@ describe('ChartsPage', () => {
     renderChartsPage();
 
     expect(mockUseBtMarginIndicators).toHaveBeenCalledWith('7203', { enabled: false });
-    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: false, tradingValuePeriod: 15 });
+    expect(mockUseFundamentals).toHaveBeenCalledWith('7203', { enabled: true, tradingValuePeriod: 15 });
     expect(mockFundamentalsPanelProps.mock.calls.at(-1)?.[0]).toMatchObject({
       symbol: '7203',
       enabled: false,
@@ -909,7 +919,7 @@ describe('ChartsPage', () => {
     const { rerender } = renderChartsPage();
 
     expect(mockUseBtMarginIndicators).toHaveBeenLastCalledWith('7203', { enabled: false });
-    expect(mockUseFundamentals).toHaveBeenLastCalledWith('7203', { enabled: false, tradingValuePeriod: 15 });
+    expect(mockUseFundamentals).toHaveBeenLastCalledWith('7203', { enabled: true, tradingValuePeriod: 15 });
 
     chartState = {
       chartData: {

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -20,7 +20,7 @@ import { useChartsRouteState, useMigrateChartsRouteState } from '@/hooks/usePage
 import { useBtMarginIndicators } from '@/hooks/useBtMarginIndicators';
 import { useRefreshStocks } from '@/hooks/useDbSync';
 import { useFundamentals } from '@/hooks/useFundamentals';
-import { stockInfoKeys, useStockInfo } from '@/hooks/useStockInfo';
+import { type StockInfoResponse, stockInfoKeys, useStockInfo } from '@/hooks/useStockInfo';
 import { ApiError } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
 import { type FundamentalsPanelId, useChartStore } from '@/stores/chartStore';
@@ -57,6 +57,43 @@ interface ChartErrorContext {
 interface ChartRefreshFeedback {
   tone: 'success' | 'error';
   message: string;
+}
+
+interface ChartHeaderMarketCaps {
+  freeFloat: number | null;
+  issuedShares: number | null;
+}
+
+function resolveLatestMarketCaps(
+  dailyValuation:
+    | Array<{
+        freeFloatMarketCap?: number | null;
+        marketCap?: number | null;
+      }>
+    | null
+    | undefined
+): ChartHeaderMarketCaps {
+  if (!dailyValuation || dailyValuation.length === 0) {
+    return {
+      freeFloat: null,
+      issuedShares: null,
+    };
+  }
+
+  const latest = dailyValuation[dailyValuation.length - 1];
+  return {
+    freeFloat: latest?.freeFloatMarketCap ?? null,
+    issuedShares: latest?.marketCap ?? null,
+  };
+}
+
+function ChartHeaderInfoField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-border/40 bg-background/60 px-3 py-2">
+      <div className="text-[11px] font-medium text-muted-foreground">{label}</div>
+      <div className="truncate text-sm font-semibold text-foreground">{value}</div>
+    </div>
+  );
 }
 
 // Helper component for margin pressure indicators section
@@ -515,15 +552,15 @@ function ChartHeader({
   settings,
   selectedSymbol,
   stockInfo,
-  latestMarketCap,
+  latestMarketCaps,
   refreshFeedback,
   isRefreshing,
   onRefresh,
 }: {
   settings: ChartSettings;
   selectedSymbol: string;
-  stockInfo: { companyName?: string | null } | undefined;
-  latestMarketCap: number | null;
+  stockInfo: StockInfoResponse | undefined;
+  latestMarketCaps: ChartHeaderMarketCaps;
   refreshFeedback: ChartRefreshFeedback | null;
   isRefreshing: boolean;
   onRefresh: () => void;
@@ -540,9 +577,6 @@ function ChartHeader({
               <h2 className="text-2xl font-bold text-white">
                 {selectedSymbol}
                 {stockInfo?.companyName && <span className="ml-2 font-medium text-white/90">{stockInfo.companyName}</span>}
-                {latestMarketCap != null && (
-                  <span className="ml-3 text-sm font-medium text-white/80">時価総額 {formatMarketCap(latestMarketCap)}</span>
-                )}
                 {settings.relativeMode && <span className="font-medium text-white/70"> / TOPIX</span>}
               </h2>
             </div>
@@ -567,27 +601,44 @@ function ChartHeader({
                 </>
               )}
             </Button>
+            <TimeframeSelector />
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl glass-panel px-6 py-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="grid flex-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <ChartHeaderInfoField label="セクター17" value={stockInfo?.sector17Name || '-'} />
+            <ChartHeaderInfoField label="セクター33" value={stockInfo?.sector33Name || '-'} />
+            <ChartHeaderInfoField
+              label="時価総額 (Free Float)"
+              value={formatMarketCap(latestMarketCaps.freeFloat)}
+            />
+            <ChartHeaderInfoField
+              label="時価総額 (発行済み株式数)"
+              value={formatMarketCap(latestMarketCaps.issuedShares)}
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-2 lg:justify-end">
             <Button
-              variant="ghost"
+              variant="outline"
               size="sm"
               onClick={() => openCompanyPage('https://shikiho.toyokeizai.net/stocks/', selectedSymbol)}
-              className="text-white/80 hover:bg-white/10 hover:text-white"
               title="四季報を開く"
             >
               <BookOpen className="mr-1 h-4 w-4" />
               四季報
             </Button>
             <Button
-              variant="ghost"
+              variant="outline"
               size="sm"
               onClick={() => openCompanyPage('https://www.buffett-code.com/company/', selectedSymbol, '/')}
-              className="text-white/80 hover:bg-white/10 hover:text-white"
               title="Buffett Codeを開く"
             >
               <Wallet className="mr-1 h-4 w-4" />
               B.C.
             </Button>
-            <TimeframeSelector />
           </div>
         </div>
       </div>
@@ -782,9 +833,7 @@ export function ChartsPage() {
   const refreshStocks = useRefreshStocks();
   const [refreshFeedback, setRefreshFeedback] = useState<ChartRefreshFeedback | null>(null);
   const shouldFetchMarginPressure = settings.showMarginPressurePanel && marginSection.isVisible;
-  const shouldFetchFundamentals =
-    (settings.showFundamentalsPanel && fundamentalsPanelSection.isVisible) ||
-    (settings.showFundamentalsHistoryPanel && fundamentalsHistorySection.isVisible);
+  const shouldFetchFundamentals = selectedSymbol != null;
   const {
     data: marginPressureData,
     isLoading: marginPressureLoading,
@@ -807,15 +856,16 @@ export function ChartsPage() {
   });
 
   useEffect(() => {
+    if (selectedSymbol == null) {
+      setRefreshFeedback(null);
+      return;
+    }
     setRefreshFeedback(null);
   }, [selectedSymbol]);
 
-  const latestMarketCap = useMemo(() => {
-    if (!settings.showFundamentalsPanel && !settings.showFundamentalsHistoryPanel) return null;
-    const daily = fundamentalsData?.dailyValuation;
-    if (!daily || daily.length === 0) return null;
-    return daily[daily.length - 1]?.marketCap ?? null;
-  }, [fundamentalsData, settings.showFundamentalsHistoryPanel, settings.showFundamentalsPanel]);
+  const latestMarketCaps = useMemo<ChartHeaderMarketCaps>(() => {
+    return resolveLatestMarketCaps(fundamentalsData?.dailyValuation);
+  }, [fundamentalsData?.dailyValuation]);
   const visibleFundamentalMetricCount = useMemo(
     () => countVisibleFundamentalMetrics(settings.fundamentalsMetricOrder, settings.fundamentalsMetricVisibility),
     [settings.fundamentalsMetricOrder, settings.fundamentalsMetricVisibility]
@@ -865,7 +915,7 @@ export function ChartsPage() {
             settings={settings}
             selectedSymbol={selectedSymbol}
             stockInfo={stockInfo}
-            latestMarketCap={latestMarketCap}
+            latestMarketCaps={latestMarketCaps}
             refreshFeedback={refreshFeedback}
             isRefreshing={refreshStocks.isPending}
             onRefresh={handleRefresh}


### PR DESCRIPTION
## Summary
- split the charts header into two stacked summary panels to make the symbol header less cramped
- add sector 17/33 and both free-float and issued-shares market cap values to the second panel alongside the company links
- extend fundamentals contracts with `freeFloatMarketCap` and fetch header fundamentals whenever a symbol is selected

## Testing
- scripts/prepush-ci.sh --skip-install