### PR TITLE
fix(web): prefer page scroll over chart wheel

### DIFF
--- a/apps/ts/bun.lock
+++ b/apps/ts/bun.lock
@@ -70,7 +70,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/ui": "^4.1.0",
-        "happy-dom": "^20.8.4",
+        "happy-dom": "^20.8.9",
         "tailwindcss": "^4.2.2",
         "vite": "^8.0.1",
         "vitest": "^4.1.0",
@@ -79,6 +79,7 @@
   },
   "overrides": {
     "@redocly/openapi-core": "1.34.5",
+    "brace-expansion": "2.0.3",
     "dompurify": "3.3.2",
     "flatted": "3.4.2",
     "minimatch": "5.1.8",
@@ -506,7 +507,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
@@ -614,7 +615,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.8.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ=="],
+    "happy-dom": ["happy-dom@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 

--- a/apps/ts/package.json
+++ b/apps/ts/package.json
@@ -45,6 +45,7 @@
     "flatted": "3.4.2",
     "@redocly/openapi-core": "1.34.5",
     "dompurify": "3.3.2",
+    "brace-expansion": "2.0.3",
     "minimatch": "5.1.8",
     "monaco-editor": "0.55.1",
     "rollup": "4.59.0",

--- a/apps/ts/packages/web/package.json
+++ b/apps/ts/packages/web/package.json
@@ -51,7 +51,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.0",
     "@vitest/ui": "^4.1.0",
-    "happy-dom": "^20.8.4",
+    "happy-dom": "^20.8.9",
     "tailwindcss": "^4.2.2",
     "vite": "^8.0.1",
     "vitest": "^4.1.0"

--- a/apps/ts/packages/web/src/components/Chart/ChartInteractionOptionsUsage.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartInteractionOptionsUsage.test.tsx
@@ -1,0 +1,393 @@
+import { act, render, screen } from '@testing-library/react';
+import { createChart } from 'lightweight-charts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_FUNDAMENTAL_METRIC_ORDER,
+  DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY,
+} from '@/constants/fundamentalMetrics';
+import {
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER,
+  DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY,
+} from '@/constants/fundamentalsHistoryMetrics';
+import { MarginPressureChart } from './MarginPressureChart';
+import { PPOChart } from './PPOChart';
+import { RiskAdjustedReturnChart } from './RiskAdjustedReturnChart';
+import { TradingValueMAChart } from './TradingValueMAChart';
+import { VolumeComparisonChart } from './VolumeComparisonChart';
+
+const mockChartStore = {
+  settings: {
+    timeframe: '1D' as const,
+    displayTimeframe: 'daily' as const,
+    chartType: 'candlestick' as const,
+    showVolume: true,
+    showPPOChart: false,
+    showVolumeComparison: false,
+    showTradingValueMA: false,
+    showFundamentalsPanel: true,
+    showFundamentalsHistoryPanel: true,
+    showMarginPressurePanel: true,
+    showFactorRegressionPanel: true,
+    fundamentalsPanelOrder: ['fundamentals', 'fundamentalsHistory', 'marginPressure', 'factorRegression'],
+    fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
+    fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
+    fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
+    fundamentalsHistoryMetricVisibility: { ...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_VISIBILITY },
+    visibleBars: 30,
+    relativeMode: false,
+    indicators: {
+      sma: { enabled: false, period: 20 },
+      ema: { enabled: false, period: 12 },
+      vwema: { enabled: false, period: 20 },
+      macd: { enabled: false, fast: 12, slow: 26, signal: 9 },
+      ppo: { enabled: false, fast: 12, slow: 26, signal: 9 },
+      atrSupport: { enabled: false, period: 20, multiplier: 3.0 },
+      nBarSupport: { enabled: false, period: 60 },
+      bollinger: { enabled: false, period: 20, deviation: 2.0 },
+    },
+    volumeComparison: {
+      shortPeriod: 20,
+      longPeriod: 100,
+      lowerMultiplier: 1.0,
+      higherMultiplier: 1.5,
+    },
+    tradingValueMA: {
+      period: 15,
+    },
+    riskAdjustedReturn: {
+      lookbackPeriod: 60,
+      ratioType: 'sortino' as const,
+      threshold: 1.0,
+      condition: 'above' as const,
+    },
+    showRiskAdjustedReturnChart: false,
+    signalOverlay: {
+      enabled: false,
+      signals: [],
+    },
+  },
+};
+
+vi.mock('@/stores/chartStore', () => ({
+  useChartStore: () => mockChartStore,
+}));
+
+let createChartOptions: unknown[] = [];
+let chartInstances: Array<{
+  addSeries: ReturnType<typeof vi.fn>;
+  timeScale: ReturnType<typeof vi.fn>;
+  applyOptions: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  removeSeries: ReturnType<typeof vi.fn>;
+}> = [];
+let resizeObserverCallbacks: Array<() => void> = [];
+
+vi.mock('lightweight-charts', () => ({
+  createChart: vi.fn((_container: unknown, options: unknown) => {
+    createChartOptions.push(options);
+    const chart = {
+      addSeries: vi.fn(() => ({
+        setData: vi.fn(),
+        applyOptions: vi.fn(),
+        priceScale: vi.fn(() => ({
+          applyOptions: vi.fn(),
+        })),
+      })),
+      timeScale: vi.fn(() => ({
+        setVisibleRange: vi.fn(),
+        setVisibleLogicalRange: vi.fn(),
+      })),
+      applyOptions: vi.fn(),
+      remove: vi.fn(),
+      removeSeries: vi.fn(),
+    };
+    chartInstances.push(chart);
+    return chart;
+  }),
+  HistogramSeries: 'HistogramSeries',
+  LineSeries: 'LineSeries',
+}));
+
+function expectLatestChartToUsePageScrollOptions(): void {
+  expect(vi.mocked(createChart)).toHaveBeenCalled();
+  expect(createChartOptions.at(-1)).toEqual(
+    expect.objectContaining({
+      handleScroll: expect.objectContaining({
+        mouseWheel: false,
+        pressedMouseMove: true,
+        horzTouchDrag: true,
+        vertTouchDrag: false,
+      }),
+      handleScale: expect.objectContaining({
+        mouseWheel: false,
+        pinch: true,
+      }),
+    })
+  );
+}
+
+function getLastChartInstance() {
+  const chart = chartInstances.at(-1);
+  expect(chart).toBeDefined();
+  return chart!;
+}
+
+function triggerLastResizeObserver(): void {
+  const callback = resizeObserverCallbacks.at(-1);
+  expect(callback).toBeDefined();
+  act(() => {
+    callback?.();
+  });
+}
+
+describe('page scroll chart interaction options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createChartOptions = [];
+    chartInstances = [];
+    resizeObserverCallbacks = [];
+
+    class ResizeObserverMock {
+      observe = vi.fn();
+      disconnect = vi.fn();
+
+      constructor(callback: () => void) {
+        resizeObserverCallbacks.push(callback);
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies page-scroll interaction options to PPOChart', () => {
+    render(
+      <PPOChart
+        data={[
+          {
+            time: '2024-01-01',
+            ppo: 1,
+            signal: 0.5,
+            histogram: 0.5,
+          },
+        ]}
+      />
+    );
+
+    expectLatestChartToUsePageScrollOptions();
+  });
+
+  it('keeps PPOChart mounted when data is empty and resizes on window resize', () => {
+    const { container } = render(<PPOChart data={[]} title="PPO" />);
+
+    expect(screen.getByText('PPO')).toBeInTheDocument();
+
+    const chartContainer = container.querySelector('.flex-1.h-full') as HTMLDivElement;
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 400 });
+    Object.defineProperty(chartContainer, 'clientHeight', { configurable: true, value: 180 });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(getLastChartInstance().applyOptions).toHaveBeenCalledWith({ width: 400, height: 180 });
+  });
+
+  it('ignores NaN PPO values without breaking chart updates', () => {
+    render(
+      <PPOChart
+        data={[
+          {
+            time: '2024-01-01',
+            ppo: Number.NaN,
+            signal: Number.NaN,
+            histogram: Number.NaN,
+          },
+        ]}
+      />
+    );
+
+    expectLatestChartToUsePageScrollOptions();
+  });
+
+  it('applies page-scroll interaction options to VolumeComparisonChart', () => {
+    render(
+      <VolumeComparisonChart
+        data={[
+          {
+            time: '2024-01-01',
+            shortMA: 100,
+            longThresholdLower: 80,
+            longThresholdHigher: 120,
+          },
+        ]}
+      />
+    );
+
+    expectLatestChartToUsePageScrollOptions();
+  });
+
+  it('handles empty VolumeComparisonChart data and only resizes for valid dimensions', () => {
+    const { container } = render(<VolumeComparisonChart data={[]} />);
+    const chartContainer = container.querySelector('.flex-1.h-full') as HTMLDivElement;
+
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 0 });
+    Object.defineProperty(chartContainer, 'clientHeight', { configurable: true, value: 80 });
+    triggerLastResizeObserver();
+    expect(getLastChartInstance().applyOptions).not.toHaveBeenCalled();
+
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 320 });
+    Object.defineProperty(chartContainer, 'clientHeight', { configurable: true, value: 160 });
+    triggerLastResizeObserver();
+    expect(getLastChartInstance().applyOptions).toHaveBeenCalledWith({ width: 320, height: 160 });
+  });
+
+  it('applies page-scroll interaction options to TradingValueMAChart', () => {
+    render(
+      <TradingValueMAChart
+        title="TVMA"
+        data={[
+          {
+            time: '2024-01-01',
+            value: 1000000,
+          },
+        ]}
+      />
+    );
+
+    expectLatestChartToUsePageScrollOptions();
+  });
+
+  it('handles empty TradingValueMAChart data and only resizes for valid dimensions', () => {
+    const { container } = render(<TradingValueMAChart data={[]} />);
+    const chartContainer = container.querySelector('.flex-1.h-full') as HTMLDivElement;
+
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 0 });
+    Object.defineProperty(chartContainer, 'clientHeight', { configurable: true, value: 90 });
+    triggerLastResizeObserver();
+    expect(getLastChartInstance().applyOptions).not.toHaveBeenCalled();
+
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 480 });
+    Object.defineProperty(chartContainer, 'clientHeight', { configurable: true, value: 140 });
+    triggerLastResizeObserver();
+    expect(getLastChartInstance().applyOptions).toHaveBeenCalledWith({ width: 480, height: 140 });
+  });
+
+  it('does not resize TradingValueMAChart after unmount', () => {
+    const { unmount } = render(<TradingValueMAChart data={[{ time: '2024-01-01', value: 10 }]} />);
+    const chart = getLastChartInstance();
+
+    unmount();
+    triggerLastResizeObserver();
+
+    expect(chart.applyOptions).not.toHaveBeenCalled();
+  });
+
+  it('applies page-scroll interaction options to RiskAdjustedReturnChart', () => {
+    render(
+      <RiskAdjustedReturnChart
+        title="RAR"
+        data={[
+          {
+            time: '2024-01-01',
+            value: 1.25,
+          },
+        ]}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    expectLatestChartToUsePageScrollOptions();
+    expect(screen.getByText('RAR')).toBeInTheDocument();
+  });
+
+  it('renders RiskAdjustedReturnChart without a latest value pill when data is empty', () => {
+    render(
+      <RiskAdjustedReturnChart
+        data={[]}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    expect(screen.queryByText('0.00')).not.toBeInTheDocument();
+    expect(screen.getByText('Risk Adjusted Return')).toBeInTheDocument();
+  });
+
+  it('applies page-scroll interaction options to MarginPressureChart', () => {
+    render(
+      <MarginPressureChart
+        type="longPressure"
+        longPressureData={[
+          {
+            date: '2024-01-01',
+            pressure: 1.2,
+            longVol: 100,
+            shortVol: 20,
+            avgVolume: 50,
+          },
+        ]}
+      />
+    );
+
+    expectLatestChartToUsePageScrollOptions();
+  });
+
+  it('renders empty-state MarginPressureChart when long pressure data is missing', () => {
+    render(<MarginPressureChart type="longPressure" />);
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('covers non-zero-line MarginPressureChart types and window resize handling', () => {
+    const { rerender, container } = render(
+      <MarginPressureChart
+        type="flowPressure"
+        flowPressureData={[
+          {
+            date: '2024-01-01',
+            flowPressure: 0.5,
+            currentNetMargin: 40,
+            previousNetMargin: 35,
+            avgVolume: 50,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('信用フロー圧力')).toBeInTheDocument();
+
+    rerender(
+      <MarginPressureChart
+        type="turnoverDays"
+        turnoverDaysData={[
+          {
+            date: '2024-01-01',
+            turnoverDays: 2.5,
+            longVol: 100,
+            avgVolume: 40,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('信用回転日数')).toBeInTheDocument();
+
+    const chartContainer = container.querySelectorAll('.h-full.w-full')[1] as HTMLDivElement;
+    Object.defineProperty(chartContainer, 'clientWidth', { configurable: true, value: 360 });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(getLastChartInstance().applyOptions).toHaveBeenCalledWith({ width: 360 });
+  });
+});

--- a/apps/ts/packages/web/src/components/Chart/LinePriceChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/LinePriceChart.test.tsx
@@ -118,6 +118,23 @@ describe('LinePriceChart', () => {
     });
   });
 
+  it('disables mouse wheel chart interactions so page scroll stays available', () => {
+    render(<LinePriceChart data={sampleData} />);
+
+    expect(vi.mocked(createChart).mock.calls[0]?.[1]).toMatchObject({
+      handleScroll: {
+        mouseWheel: false,
+        pressedMouseMove: true,
+        horzTouchDrag: true,
+        vertTouchDrag: false,
+      },
+      handleScale: {
+        mouseWheel: false,
+        pinch: true,
+      },
+    });
+  });
+
   it('resizes the chart when the container grows', () => {
     const resize = stubResizeObserver();
 

--- a/apps/ts/packages/web/src/components/Chart/LinePriceChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/LinePriceChart.tsx
@@ -1,5 +1,6 @@
 import { createChart, type IChartApi, type ISeriesApi, LineSeries } from 'lightweight-charts';
 import { useEffect, useRef } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import { CHART_COLORS, CHART_DIMENSIONS, CHART_LINE_WIDTHS } from '@/lib/constants';
 import { useChartStore } from '@/stores/chartStore';
 
@@ -51,6 +52,7 @@ export function LinePriceChart({ data = [] }: LinePriceChartProps) {
         timeVisible: true,
         secondsVisible: false,
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
     const lineSeries = chart.addSeries(LineSeries, {
       color: CHART_COLORS.BOLLINGER,

--- a/apps/ts/packages/web/src/components/Chart/MarginPressureChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/MarginPressureChart.tsx
@@ -1,5 +1,6 @@
 import { createChart, type IChartApi, type ISeriesApi, LineSeries, type Time } from 'lightweight-charts';
 import { useEffect, useRef } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import type { MarginFlowPressureData, MarginLongPressureData, MarginTurnoverDaysData } from '@/types/chart';
 import { logger } from '@/utils/logger';
 
@@ -124,6 +125,7 @@ export function MarginPressureChart({
       rightPriceScale: {
         borderColor: '#e1e1e1',
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
 
     chartRef.current = chart;

--- a/apps/ts/packages/web/src/components/Chart/PPOChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/PPOChart.tsx
@@ -1,5 +1,6 @@
 import { createChart, HistogramSeries, type IChartApi, type ISeriesApi, LineSeries } from 'lightweight-charts';
 import { useCallback, useEffect, useRef } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import { useChartStore } from '@/stores/chartStore';
 import type { PPOIndicatorData } from '@/types/chart';
 
@@ -171,6 +172,7 @@ export function PPOChart({ data, title }: PPOChartProps) {
           bottom: 0.1,
         },
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
 
     chartRef.current = chart;

--- a/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.test.tsx
@@ -178,6 +178,38 @@ describe('RiskAdjustedReturnChart', () => {
     vi.unstubAllGlobals();
   });
 
+  it('skips resize updates after unmount clears the chart ref', () => {
+    let resizeCallback: (() => void) | undefined;
+
+    class MockResizeObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+
+      constructor(callback: () => void) {
+        resizeCallback = callback;
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', MockResizeObserver as unknown as typeof ResizeObserver);
+
+    const { unmount } = render(
+      <RiskAdjustedReturnChart
+        data={sampleData}
+        lookbackPeriod={60}
+        ratioType="sortino"
+        threshold={1}
+        condition="above"
+      />
+    );
+
+    unmount();
+    resizeCallback?.();
+
+    expect(mockChart.applyOptions).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
   it('cleans up chart on unmount', () => {
     const { unmount } = render(
       <RiskAdjustedReturnChart

--- a/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/RiskAdjustedReturnChart.tsx
@@ -1,5 +1,6 @@
 import { createChart, type IChartApi, type ISeriesApi, LineSeries } from 'lightweight-charts';
 import { useEffect, useMemo, useRef } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import { CHART_COLORS } from '@/lib/constants';
 import type { RiskAdjustedReturnCondition, RiskAdjustedReturnRatioType } from '@/stores/chartStore';
 import { useChartStore } from '@/stores/chartStore';
@@ -67,6 +68,7 @@ export function RiskAdjustedReturnChart({
           bottom: 0.1,
         },
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
     chartRef.current = chart;
 

--- a/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/StockChart.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
+import { createChart, createSeriesMarkers } from 'lightweight-charts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_FUNDAMENTAL_METRIC_ORDER,
@@ -200,6 +201,26 @@ describe('StockChart', () => {
     expect(container.querySelector('div')).toBeInTheDocument();
   });
 
+  it('disables mouse wheel chart interactions so page scroll remains available', () => {
+    render(<StockChart data={mockStockData} />);
+
+    expect(vi.mocked(createChart)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        handleScroll: expect.objectContaining({
+          mouseWheel: false,
+          pressedMouseMove: true,
+          horzTouchDrag: true,
+          vertTouchDrag: false,
+        }),
+        handleScale: expect.objectContaining({
+          mouseWheel: false,
+          pinch: true,
+        }),
+      })
+    );
+  });
+
   it('updates chart data when data prop changes', () => {
     const { rerender, container } = render(<StockChart data={mockStockData} />);
 
@@ -271,6 +292,150 @@ describe('StockChart', () => {
     rerender(<StockChart data={mockStockData} vwema={vwemaData} />);
 
     expect(mockRemoveSeries).toHaveBeenCalledWith(vwemaSeries);
+  });
+
+  it('renders and removes N-bar support overlay when toggled', () => {
+    mockChartStore.settings.indicators.nBarSupport.enabled = true;
+    const nBarData = mockStockData.map((item, index) => ({
+      time: item.time,
+      value: 95 + index,
+    }));
+
+    const { rerender } = render(<StockChart data={mockStockData} nBarSupport={nBarData} />);
+
+    const nBarCallIndex = mockAddSeries.mock.calls.findIndex(
+      ([seriesType, options]) =>
+        seriesType === 'LineSeries' &&
+        typeof options === 'object' &&
+        options !== null &&
+        'color' in options &&
+        options.color === CHART_COLORS.N_BAR_SUPPORT
+    );
+    expect(nBarCallIndex).toBeGreaterThanOrEqual(0);
+    const nBarSeries = mockSeriesInstances[nBarCallIndex];
+    expect(nBarSeries?.setData).toHaveBeenCalledWith(nBarData);
+
+    mockChartStore.settings.indicators.nBarSupport.enabled = false;
+    rerender(<StockChart data={mockStockData} nBarSupport={nBarData} />);
+
+    expect(mockRemoveSeries).toHaveBeenCalledWith(nBarSeries);
+  });
+
+  it('renders and removes ATR support overlay when toggled', () => {
+    mockChartStore.settings.indicators.atrSupport.enabled = true;
+    const atrData = mockStockData.map((item, index) => ({
+      time: item.time,
+      value: 90 + index,
+    }));
+
+    const { rerender } = render(<StockChart data={mockStockData} atrSupport={atrData} />);
+
+    const atrCallIndex = mockAddSeries.mock.calls.findIndex(
+      ([seriesType, options]) =>
+        seriesType === 'LineSeries' &&
+        typeof options === 'object' &&
+        options !== null &&
+        'color' in options &&
+        options.color === CHART_COLORS.ATR_SUPPORT
+    );
+    expect(atrCallIndex).toBeGreaterThanOrEqual(0);
+    const atrSeries = mockSeriesInstances[atrCallIndex];
+    expect(atrSeries?.setData).toHaveBeenCalledWith(atrData);
+
+    mockChartStore.settings.indicators.atrSupport.enabled = false;
+    rerender(<StockChart data={mockStockData} atrSupport={atrData} />);
+
+    expect(mockRemoveSeries).toHaveBeenCalledWith(atrSeries);
+  });
+
+  it('renders and removes Bollinger overlay when toggled', () => {
+    mockChartStore.settings.indicators.bollinger.enabled = true;
+    const bollingerData = mockStockData.map((item, index) => ({
+      time: item.time,
+      upper: 110 + index,
+      middle: 100 + index,
+      lower: 90 + index,
+    }));
+
+    const { rerender } = render(<StockChart data={mockStockData} bollingerBands={bollingerData} />);
+
+    const bollingerCallIndex = mockAddSeries.mock.calls.findIndex(
+      ([seriesType, options]) =>
+        seriesType === 'LineSeries' &&
+        typeof options === 'object' &&
+        options !== null &&
+        'color' in options &&
+        options.color === CHART_COLORS.BOLLINGER
+    );
+    expect(bollingerCallIndex).toBeGreaterThanOrEqual(0);
+    const bollingerSeries = mockSeriesInstances[bollingerCallIndex];
+    expect(bollingerSeries?.setData).toHaveBeenCalledWith([
+      { time: '2024-01-01', value: 110 },
+      { time: '2024-01-02', value: 111 },
+    ]);
+
+    mockChartStore.settings.indicators.bollinger.enabled = false;
+    rerender(<StockChart data={mockStockData} bollingerBands={bollingerData} />);
+
+    expect(mockRemoveSeries).toHaveBeenCalledWith(bollingerSeries);
+  });
+
+  it('updates signal markers after the initial marker plugin is created', () => {
+    const initialMarkers = [
+      {
+        time: '2024-01-01',
+        position: 'belowBar' as const,
+        color: '#00ff00',
+        shape: 'arrowUp' as const,
+        text: 'BUY',
+        size: 1,
+      },
+    ];
+    const nextMarkers = [
+      {
+        time: '2024-01-02',
+        position: 'aboveBar' as const,
+        color: '#ff0000',
+        shape: 'arrowDown' as const,
+        text: 'SELL',
+        size: 1,
+      },
+    ];
+
+    const { rerender } = render(<StockChart data={mockStockData} signalMarkers={initialMarkers} />);
+    rerender(<StockChart data={mockStockData} signalMarkers={nextMarkers} />);
+
+    const markersApi = vi.mocked(createSeriesMarkers).mock.results[0]?.value;
+    expect(markersApi?.setMarkers).toHaveBeenCalledWith([
+      {
+        time: '2024-01-02',
+        position: 'aboveBar',
+        color: '#ff0000',
+        shape: 'arrowDown',
+        text: 'SELL',
+        size: 1,
+      },
+    ]);
+  });
+
+  it('gracefully skips data updates when candlestick series creation fails', () => {
+    mockChartStore.settings.showVolume = false;
+    vi.mocked(createChart).mockImplementationOnce(
+      () =>
+        ({
+          addSeries: vi.fn(() => null),
+          timeScale: vi.fn(() => ({
+            setVisibleRange: vi.fn(),
+            setVisibleLogicalRange: vi.fn(),
+          })),
+          applyOptions: vi.fn(),
+          remove: vi.fn(),
+          removeSeries: vi.fn(),
+          subscribeCrosshairMove: vi.fn(),
+        }) as never
+    );
+
+    expect(() => render(<StockChart data={mockStockData} />)).not.toThrow();
   });
 
   it('resizes chart when observer reports valid dimensions', () => {

--- a/apps/ts/packages/web/src/components/Chart/StockChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/StockChart.tsx
@@ -11,6 +11,7 @@ import {
   type Time,
 } from 'lightweight-charts';
 import { useEffect, useRef, useState } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import { CHART_COLORS, CHART_DIMENSIONS, CHART_LINE_WIDTHS, VOLUME_SCALE_MARGINS } from '@/lib/constants';
 import { useChartStore } from '@/stores/chartStore';
 import type { BollingerBandsData, IndicatorValue, StockDataPoint, VolumeData } from '@/types/chart';
@@ -213,6 +214,7 @@ export function StockChart({
         timeVisible: true,
         secondsVisible: false,
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
 
     chartRef.current = chart;

--- a/apps/ts/packages/web/src/components/Chart/TradingValueMAChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/TradingValueMAChart.tsx
@@ -1,5 +1,6 @@
 import { createChart, type IChartApi, type ISeriesApi, LineSeries } from 'lightweight-charts';
 import { useEffect, useRef } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import { useChartStore } from '@/stores/chartStore';
 import type { TradingValueMAData } from '@/types/chart';
 import { formatInteger } from '@/utils/formatters';
@@ -60,6 +61,7 @@ export function TradingValueMAChart({ data, title, period = 15 }: TradingValueMA
           bottom: 0.1,
         },
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
 
     chartRef.current = chart;

--- a/apps/ts/packages/web/src/components/Chart/VolumeComparisonChart.tsx
+++ b/apps/ts/packages/web/src/components/Chart/VolumeComparisonChart.tsx
@@ -1,5 +1,6 @@
 import { createChart, type IChartApi, type ISeriesApi, LineSeries } from 'lightweight-charts';
 import { useEffect, useRef } from 'react';
+import { PAGE_SCROLL_CHART_INTERACTION_OPTIONS } from '@/components/Chart/chartInteractionOptions';
 import { useChartStore } from '@/stores/chartStore';
 import type { VolumeComparisonData } from '@/types/chart';
 import { formatVolume } from '@/utils/formatters';
@@ -72,6 +73,7 @@ export function VolumeComparisonChart({
           bottom: 0.1,
         },
       },
+      ...PAGE_SCROLL_CHART_INTERACTION_OPTIONS,
     });
 
     chartRef.current = chart;

--- a/apps/ts/packages/web/src/components/Chart/chartInteractionOptions.ts
+++ b/apps/ts/packages/web/src/components/Chart/chartInteractionOptions.ts
@@ -1,0 +1,12 @@
+export const PAGE_SCROLL_CHART_INTERACTION_OPTIONS = {
+  handleScroll: {
+    mouseWheel: false,
+    pressedMouseMove: true,
+    horzTouchDrag: true,
+    vertTouchDrag: false,
+  },
+  handleScale: {
+    mouseWheel: false,
+    pinch: true,
+  },
+} as const;

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -867,7 +867,14 @@ describe('ChartsPage', () => {
       error: null,
     });
     mockUseStockInfo.mockReturnValue({
-      data: { companyName: 'Test Co', sector17Name: '自動車・輸送機', sector33Name: '輸送用機器' },
+      data: {
+        companyName: 'Test Co',
+        marketCode: '0111',
+        marketName: 'プライム',
+        scaleCategory: 'TOPIX Core30',
+        sector17Name: '自動車・輸送機',
+        sector33Name: '輸送用機器',
+      },
     });
     mockUseFundamentals.mockImplementation(
       (_symbol: string, options?: { enabled?: boolean; tradingValuePeriod?: number }) => ({
@@ -881,6 +888,10 @@ describe('ChartsPage', () => {
       MockIntersectionObserver.triggerAll(true);
     });
 
+    expect(screen.getByText('市場')).toBeInTheDocument();
+    expect(screen.getByText('Prime')).toBeInTheDocument();
+    expect(screen.getByText('指数採用')).toBeInTheDocument();
+    expect(screen.getByText('Core30')).toBeInTheDocument();
     expect(screen.getByText('セクター17')).toBeInTheDocument();
     expect(screen.getByText('自動車・輸送機')).toBeInTheDocument();
     expect(screen.getByText('セクター33')).toBeInTheDocument();

--- a/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.test.tsx
@@ -914,6 +914,41 @@ describe('ChartsPage', () => {
     );
   });
 
+  it('prefers the market name when the market code has no canonical label mapping', () => {
+    mockUseMultiTimeframeChart.mockReturnValue({
+      chartData: {
+        daily: {
+          candlestickData: [{ time: '2024-01-01', open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }],
+          indicators: { atrSupport: [], nBarSupport: [], ppo: [] },
+          bollingerBands: [],
+          volumeComparison: [],
+          tradingValueMA: [],
+        },
+      },
+      isLoading: false,
+      error: null,
+      selectedSymbol: '2510',
+    });
+    mockUseBtMarginIndicators.mockReturnValue({
+      data: { longPressure: [], flowPressure: [], turnoverDays: [], averagePeriod: 20 },
+      isLoading: false,
+      error: null,
+    });
+    mockUseStockInfo.mockReturnValue({
+      data: {
+        companyName: 'ETF Test',
+        marketCode: '9999',
+        marketName: 'ETF/ETN',
+      },
+    });
+
+    renderChartsPage();
+
+    expect(screen.getByText('市場')).toBeInTheDocument();
+    expect(screen.getByText('ETF/ETN')).toBeInTheDocument();
+    expect(screen.queryByText('9999')).not.toBeInTheDocument();
+  });
+
   it('falls back to immediate visibility when IntersectionObserver is unavailable', async () => {
     vi.stubGlobal('IntersectionObserver', undefined);
 

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -131,9 +131,9 @@ function formatMarketLabel(stockInfo: StockInfoResponse | undefined): string {
     return '-';
   }
 
-  const marketCode = stockInfo.marketCode?.trim().toLowerCase() ?? '';
-  const canonicalLabel = marketCode ? MARKET_CODE_LABELS[marketCode] ?? stockInfo.marketCode?.trim() ?? '' : '';
-  return canonicalLabel || stockInfo.marketName?.trim() || '-';
+  const rawMarketCode = stockInfo.marketCode?.trim() ?? '';
+  const canonicalLabel = rawMarketCode ? MARKET_CODE_LABELS[rawMarketCode.toLowerCase()] ?? '' : '';
+  return canonicalLabel || stockInfo.marketName?.trim() || rawMarketCode || '-';
 }
 
 function formatScaleCategoryLabel(scaleCategory: string | null | undefined): string {

--- a/apps/ts/packages/web/src/pages/ChartsPage.tsx
+++ b/apps/ts/packages/web/src/pages/ChartsPage.tsx
@@ -117,6 +117,35 @@ function formatList(values: string[] | null | undefined): string {
   return values.join(', ');
 }
 
+const MARKET_CODE_LABELS: Record<string, string> = {
+  prime: 'Prime',
+  standard: 'Standard',
+  growth: 'Growth',
+  '0111': 'Prime',
+  '0112': 'Standard',
+  '0113': 'Growth',
+};
+
+function formatMarketLabel(stockInfo: StockInfoResponse | undefined): string {
+  if (!stockInfo) {
+    return '-';
+  }
+
+  const marketCode = stockInfo.marketCode?.trim().toLowerCase() ?? '';
+  const canonicalLabel = marketCode ? MARKET_CODE_LABELS[marketCode] ?? stockInfo.marketCode?.trim() ?? '' : '';
+  return canonicalLabel || stockInfo.marketName?.trim() || '-';
+}
+
+function formatScaleCategoryLabel(scaleCategory: string | null | undefined): string {
+  const normalized = scaleCategory?.trim();
+  if (!normalized) {
+    return '-';
+  }
+
+  const shortLabel = normalized.replace(/^TOPIX\s+/u, '');
+  return shortLabel || normalized;
+}
+
 function mergeUniqueStrings(...groups: Array<string[] | null | undefined>): string[] {
   const seen = new Set<string>();
   for (const group of groups) {
@@ -647,7 +676,9 @@ function ChartHeader({
           </div>
         </div>
 
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+          <ChartHeaderInfoField label="市場" value={formatMarketLabel(stockInfo)} />
+          <ChartHeaderInfoField label="指数採用" value={formatScaleCategoryLabel(stockInfo?.scaleCategory)} />
           <ChartHeaderInfoField label="セクター17" value={stockInfo?.sector17Name || '-'} />
           <ChartHeaderInfoField label="セクター33" value={stockInfo?.sector33Name || '-'} />
           <ChartHeaderInfoField label="時価総額 (Free Float)" value={formatMarketCap(latestMarketCaps.freeFloat)} />


### PR DESCRIPTION
## Summary
- disable mouse-wheel chart interactions so page scrolling remains available on charts and indices
- share the lightweight-charts interaction config across chart components
- add tests covering the shared behavior and chart interaction branches

## Verification
- bun run --filter @trading25/web test -- src/components/Chart/StockChart.test.tsx
- bun run --filter @trading25/web test -- src/components/Chart/LinePriceChart.test.tsx
- bunx vitest run src/components/Chart/StockChart.test.tsx src/components/Chart/ChartInteractionOptionsUsage.test.tsx src/components/Chart/RiskAdjustedReturnChart.test.tsx src/pages/ChartsPage.test.tsx --coverage.enabled --coverage.reporter=text --coverage.include=src/components/Chart/StockChart.tsx --coverage.include=src/components/Chart/PPOChart.tsx --coverage.include=src/components/Chart/RiskAdjustedReturnChart.tsx --coverage.include=src/components/Chart/VolumeComparisonChart.tsx --coverage.include=src/components/Chart/TradingValueMAChart.tsx --coverage.include=src/components/Chart/MarginPressureChart.tsx --coverage.include=src/components/Chart/chartInteractionOptions.ts
- bun run --filter @trading25/web typecheck