### PR TITLE
Improve mobile UX and Value Scores EPS basis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,15 @@ Open / active task tracking の SoT は GitHub Issues（`https://github.com/d250
 - local archive は `issues/done/`（local issue 時代の closed archive）と `issues/archive/migrated-to-github/`（2026-04-22 に GitHub Issues へ移行した元 local issue）
 - 旧 local issue ID（例: `bt-027`）は GitHub Issue タイトルや本文に残し、検索キーとして使う
 
+## OpenClaw guardrails
+
+OpenClaw 固有の詳細運用メモは repo 外（例: `/home/open_shiro/.openclaw/workspace/notes/openclaw/openclaw-agent-ops.md`）に置き、プロダクト repo の履歴には混ぜない。ただし、この repo で OpenClaw が作業する場合は以下を必ず守る。
+
+- OpenClaw が GitHub に push する remote branch は必ず `openclaw/*` にする。`feature/*` / `fix/*` / `docs/*` 等はローカル作業名としてのみ使い、直接 remote push しない。
+- `git push` / PR 作成 / merge は project owner の明示指示がある場合のみ行う。
+- Git commit author は `open-shiro <279403866+open-shiro@users.noreply.github.com>` を使う。
+- repo と無関係な OpenClaw 個人運用メモや外部サービス調査メモは repo 外へ置く。
+
 ## Skills ガバナンス
 
 - プロジェクト正本のスキルは `/.codex/skills` に配置する

--- a/apps/bt/src/application/services/ranking_service.py
+++ b/apps/bt/src/application/services/ranking_service.py
@@ -62,6 +62,7 @@ from src.entrypoints.http.schemas.ranking import (
     Topix100StudyMode,
     ValueCompositeRankingItem,
     ValueCompositeRankingResponse,
+    ValueCompositeForwardEpsMode,
     ValueCompositeScoreMethod,
 )
 
@@ -233,6 +234,10 @@ _VALUE_COMPOSITE_SCORE_POLICY_BY_METHOD: dict[ValueCompositeScoreMethod, str] = 
         "Walk-forward research weights: 55% small market cap + 25% low PBR + "
         f"20% low forward PER; {_VALUE_COMPOSITE_SCORE_POLICY_SUFFIX}"
     ),
+}
+_VALUE_COMPOSITE_FORWARD_EPS_MODE_LABELS: dict[ValueCompositeForwardEpsMode, str] = {
+    "latest": "latest revised forecast EPS when available, otherwise FY forecast EPS",
+    "fy": "latest FY forecast EPS only",
 }
 
 
@@ -722,11 +727,14 @@ class RankingService:
         limit: int = 50,
         markets: str = "standard",
         score_method: ValueCompositeScoreMethod = "walkforward_regression_weight",
+        forward_eps_mode: ValueCompositeForwardEpsMode = "latest",
     ) -> ValueCompositeRankingResponse:
         """Standard市場向けの小型バリュー複合スコアランキングを取得"""
 
         if score_method not in _VALUE_COMPOSITE_WEIGHTS_BY_METHOD:
             raise ValueError(f"Unsupported scoreMethod: {score_method}")
+        if forward_eps_mode not in _VALUE_COMPOSITE_FORWARD_EPS_MODE_LABELS:
+            raise ValueError(f"Unsupported forwardEpsMode: {forward_eps_mode}")
         weights = _normalize_value_composite_weights(_VALUE_COMPOSITE_WEIGHTS_BY_METHOD[score_method])
         requested_market_codes, query_market_codes = resolve_market_codes(
             markets,
@@ -780,9 +788,10 @@ class RankingService:
                 statements,
                 as_of_date=target_date,
             )
-            forecast_snapshot = self._resolve_latest_forecast_snapshot(
+            forecast_snapshot = self._resolve_value_composite_forecast_snapshot(
                 statements,
                 baseline_shares,
+                forward_eps_mode=forward_eps_mode,
                 as_of_date=target_date,
             )
             latest_fy = self._latest_value_fy_statement(raw_statements, as_of_date=target_date)
@@ -853,7 +862,11 @@ class RankingService:
             markets=requested_market_codes,
             metricKey=_VALUE_COMPOSITE_METRIC_KEY,
             scoreMethod=score_method,
-            scorePolicy=_VALUE_COMPOSITE_SCORE_POLICY_BY_METHOD[score_method],
+            forwardEpsMode=forward_eps_mode,
+            scorePolicy=(
+                f"{_VALUE_COMPOSITE_SCORE_POLICY_BY_METHOD[score_method]}; "
+                f"forward EPS basis: {_VALUE_COMPOSITE_FORWARD_EPS_MODE_LABELS[forward_eps_mode]}"
+            ),
             weights={
                 "smallMarketCap": weights["small_market_cap_score"],
                 "lowPbr": weights["low_pbr_score"],
@@ -1457,6 +1470,23 @@ class RankingService:
             baseline_shares,
             as_of_date=as_of_date,
         )
+
+    def _resolve_value_composite_forecast_snapshot(
+        self,
+        rows: list[_StatementRow],
+        baseline_shares: float | None,
+        *,
+        forward_eps_mode: ValueCompositeForwardEpsMode,
+        as_of_date: str | None = None,
+    ) -> _ForecastValue | None:
+        if forward_eps_mode == "latest":
+            return self._resolve_latest_forecast_snapshot(
+                rows,
+                baseline_shares,
+                as_of_date=as_of_date,
+            )
+        latest_fy = self._fundamental_calculator.resolve_latest_fy_row(rows, as_of_date=as_of_date)
+        return self._resolve_latest_fy_forecast_snapshot(latest_fy, baseline_shares)
 
     def _resolve_latest_ratio_snapshot(
         self,

--- a/apps/bt/src/entrypoints/http/routes/analytics_complex.py
+++ b/apps/bt/src/entrypoints/http/routes/analytics_complex.py
@@ -28,6 +28,7 @@ from src.entrypoints.http.schemas.ranking import (
     Topix100RankingResponse,
     Topix100StudyMode,
     ValueCompositeRankingResponse,
+    ValueCompositeForwardEpsMode,
     ValueCompositeScoreMethod,
 )
 from src.entrypoints.http.schemas.screening import (
@@ -186,6 +187,7 @@ async def get_value_composite_ranking(
     limit: int = Query(50, ge=1, le=200),
     markets: str = Query("standard"),
     scoreMethod: ValueCompositeScoreMethod = Query("walkforward_regression_weight"),
+    forwardEpsMode: ValueCompositeForwardEpsMode = Query("latest"),
 ) -> ValueCompositeRankingResponse:
     """小型バリュー複合スコアランキングを取得"""
     from src.application.services.ranking_service import RankingService
@@ -201,6 +203,7 @@ async def get_value_composite_ranking(
             limit=limit,
             markets=markets,
             score_method=scoreMethod,
+            forward_eps_mode=forwardEpsMode,
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/apps/bt/src/entrypoints/http/schemas/ranking.py
+++ b/apps/bt/src/entrypoints/http/schemas/ranking.py
@@ -11,6 +11,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 ValueCompositeScoreMethod = Literal["equal_weight", "walkforward_regression_weight"]
+ValueCompositeForwardEpsMode = Literal["latest", "fy"]
 
 
 class RankingItem(BaseModel):
@@ -207,6 +208,7 @@ class ValueCompositeRankingResponse(BaseModel):
     markets: list[str]
     metricKey: Literal["standard_value_composite"] = "standard_value_composite"
     scoreMethod: ValueCompositeScoreMethod
+    forwardEpsMode: ValueCompositeForwardEpsMode
     scorePolicy: str
     weights: dict[str, float]
     itemCount: int

--- a/apps/bt/tests/unit/server/routes/test_analytics_complex.py
+++ b/apps/bt/tests/unit/server/routes/test_analytics_complex.py
@@ -526,6 +526,7 @@ class TestValueCompositeRanking:
         data = resp.json()
         assert data["metricKey"] == "standard_value_composite"
         assert data["scoreMethod"] == "walkforward_regression_weight"
+        assert data["forwardEpsMode"] == "latest"
         assert data["markets"] == ["standard"]
         assert "no ADV60 floor" in data["scorePolicy"]
         assert data["weights"] == {
@@ -541,6 +542,13 @@ class TestValueCompositeRanking:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data["items"]) <= 1
+
+    def test_forward_eps_mode_parameter(self, analytics_client):
+        resp = analytics_client.get("/api/analytics/value-composite-ranking?forwardEpsMode=fy")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["forwardEpsMode"] == "fy"
+        assert "FY forecast EPS" in data["scorePolicy"]
 
     def test_equal_weight_score_method(self, analytics_client):
         resp = analytics_client.get("/api/analytics/value-composite-ranking?scoreMethod=equal_weight")

--- a/apps/bt/tests/unit/server/services/test_ranking_service.py
+++ b/apps/bt/tests/unit/server/services/test_ranking_service.py
@@ -1048,6 +1048,50 @@ class TestGetValueCompositeRanking:
         assert result.items[0].forwardPer == pytest.approx(5.0)
         assert result.items[0].marketCapBilJpy == pytest.approx(5.2)
 
+    def test_value_composite_ranking_can_use_latest_revised_forward_eps(self, ranking_db):
+        conn = duckdb.connect(ranking_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO statements (
+                    code, disclosed_date, earnings_per_share, type_of_current_period,
+                    next_year_forecast_earnings_per_share, bps, shares_outstanding
+                )
+                VALUES (?,?,?,?,?,?,?)
+                """,
+                ("99840", "2024-01-10", 50.0, "FY", 104.0, 1000.0, 10_000_000.0),
+            )
+            conn.execute(
+                """
+                INSERT INTO statements (
+                    code, disclosed_date, type_of_current_period, forecast_eps, shares_outstanding
+                )
+                VALUES (?,?,?,?,?)
+                """,
+                ("99840", "2024-01-18", "1Q", 130.0, 10_000_000.0),
+            )
+        finally:
+            conn.close()
+
+        reader = MarketDbReader(ranking_db)
+        svc = RankingService(reader)
+        latest = svc.get_value_composite_ranking(limit=10)
+        fy_only = svc.get_value_composite_ranking(limit=10, forward_eps_mode="fy")
+        reader.close()
+
+        latest_item = next((row for row in latest.items if row.code == "99840"), None)
+        fy_item = next((row for row in fy_only.items if row.code == "99840"), None)
+        assert latest.forwardEpsMode == "latest"
+        assert fy_only.forwardEpsMode == "fy"
+        assert latest_item is not None
+        assert fy_item is not None
+        assert latest_item.forwardEpsSource == "revised"
+        assert latest_item.forwardEps == pytest.approx(130.0)
+        assert latest_item.forwardPer == pytest.approx(4.0)
+        assert fy_item.forwardEpsSource == "fy"
+        assert fy_item.forwardEps == pytest.approx(104.0)
+        assert fy_item.forwardPer == pytest.approx(5.0)
+
     def test_value_composite_ranking_ignores_future_disclosures(self, ranking_db):
         conn = duckdb.connect(ranking_db)
         try:

--- a/apps/ts/packages/api-clients/src/analytics/AnalyticsClient.test.ts
+++ b/apps/ts/packages/api-clients/src/analytics/AnalyticsClient.test.ts
@@ -116,10 +116,11 @@ describe('AnalyticsClient', () => {
       limit: 50,
       markets: 'standard',
       scoreMethod: 'equal_weight',
+      forwardEpsMode: 'fy',
     });
 
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      'http://localhost:3002/api/analytics/value-composite-ranking?date=2026-04-24&limit=50&markets=standard&scoreMethod=equal_weight'
+      'http://localhost:3002/api/analytics/value-composite-ranking?date=2026-04-24&limit=50&markets=standard&scoreMethod=equal_weight&forwardEpsMode=fy'
     );
   });
 
@@ -175,9 +176,7 @@ describe('AnalyticsClient', () => {
     );
 
     await client.getCostStructureAnalysis({ symbol: '7203' });
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      'http://localhost:3002/api/analytics/stocks/7203/cost-structure'
-    );
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe('http://localhost:3002/api/analytics/stocks/7203/cost-structure');
 
     await client.getCostStructureAnalysis({ symbol: '7203', view: 'same_quarter', windowQuarters: 20 });
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(

--- a/apps/ts/packages/api-clients/src/analytics/AnalyticsClient.ts
+++ b/apps/ts/packages/api-clients/src/analytics/AnalyticsClient.ts
@@ -93,14 +93,13 @@ export class AnalyticsClient {
     });
   }
 
-  async getValueCompositeRanking(
-    params: ValueCompositeRankingParams = {}
-  ): Promise<ValueCompositeRankingResponse> {
+  async getValueCompositeRanking(params: ValueCompositeRankingParams = {}): Promise<ValueCompositeRankingResponse> {
     return this.request<ValueCompositeRankingResponse>('/api/analytics/value-composite-ranking', undefined, {
       date: params.date,
       limit: params.limit,
       markets: params.markets,
       scoreMethod: params.scoreMethod,
+      forwardEpsMode: params.forwardEpsMode,
     });
   }
 

--- a/apps/ts/packages/api-clients/src/analytics/types.ts
+++ b/apps/ts/packages/api-clients/src/analytics/types.ts
@@ -277,6 +277,7 @@ export interface FundamentalRankingParams {
 }
 
 export type ValueCompositeScoreMethod = 'equal_weight' | 'walkforward_regression_weight';
+export type ValueCompositeForwardEpsMode = 'latest' | 'fy';
 
 export interface ValueCompositeRankingItem {
   rank: number;
@@ -305,6 +306,7 @@ export interface ValueCompositeRankingResponse {
   markets: string[];
   metricKey: 'standard_value_composite';
   scoreMethod: ValueCompositeScoreMethod;
+  forwardEpsMode: ValueCompositeForwardEpsMode;
   scorePolicy: string;
   weights: Record<string, number>;
   itemCount: number;
@@ -317,6 +319,7 @@ export interface ValueCompositeRankingParams {
   limit?: number;
   markets?: string;
   scoreMethod?: ValueCompositeScoreMethod;
+  forwardEpsMode?: ValueCompositeForwardEpsMode;
 }
 
 // ===== SCREENING TYPES =====

--- a/apps/ts/packages/contracts/openapi/bt-openapi.json
+++ b/apps/ts/packages/contracts/openapi/bt-openapi.json
@@ -16919,6 +16919,14 @@
             "title": "Date",
             "type": "string"
           },
+          "forwardEpsMode": {
+            "enum": [
+              "latest",
+              "fy"
+            ],
+            "title": "Forwardepsmode",
+            "type": "string"
+          },
           "itemCount": {
             "title": "Itemcount",
             "type": "integer"
@@ -16971,6 +16979,7 @@
           "date",
           "markets",
           "scoreMethod",
+          "forwardEpsMode",
           "scorePolicy",
           "weights",
           "itemCount",
@@ -19451,6 +19460,20 @@
                 "walkforward_regression_weight"
               ],
               "title": "Scoremethod",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "forwardEpsMode",
+            "required": false,
+            "schema": {
+              "default": "latest",
+              "enum": [
+                "latest",
+                "fy"
+              ],
+              "title": "Forwardepsmode",
               "type": "string"
             }
           }

--- a/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
@@ -10642,6 +10642,11 @@ export interface components {
         ValueCompositeRankingResponse: {
             /** Date */
             date: string;
+            /**
+             * Forwardepsmode
+             * @enum {string}
+             */
+            forwardEpsMode: "latest" | "fy";
             /** Itemcount */
             itemCount: number;
             /** Items */
@@ -10661,11 +10666,6 @@ export interface components {
              * @enum {string}
              */
             scoreMethod: "equal_weight" | "walkforward_regression_weight";
-            /**
-             * Forwardepsmode
-             * @enum {string}
-             */
-            forwardEpsMode: "latest" | "fy";
             /** Scorepolicy */
             scorePolicy: string;
             /** Weights */

--- a/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
+++ b/apps/ts/packages/contracts/src/clients/backtest/generated/bt-api-types.ts
@@ -10661,6 +10661,11 @@ export interface components {
              * @enum {string}
              */
             scoreMethod: "equal_weight" | "walkforward_regression_weight";
+            /**
+             * Forwardepsmode
+             * @enum {string}
+             */
+            forwardEpsMode: "latest" | "fy";
             /** Scorepolicy */
             scorePolicy: string;
             /** Weights */
@@ -12055,6 +12060,7 @@ export interface operations {
                 limit?: number;
                 markets?: string;
                 scoreMethod?: "equal_weight" | "walkforward_regression_weight";
+                forwardEpsMode?: "latest" | "fy";
             };
             header?: never;
             path?: never;

--- a/apps/ts/packages/contracts/src/types/api-response-types.ts
+++ b/apps/ts/packages/contracts/src/types/api-response-types.ts
@@ -157,6 +157,7 @@ export interface MarketFundamentalRankingResponse {
 }
 
 export type ValueCompositeScoreMethod = 'equal_weight' | 'walkforward_regression_weight';
+export type ValueCompositeForwardEpsMode = 'latest' | 'fy';
 
 export interface ValueCompositeRankingItem {
   rank: number;
@@ -185,6 +186,7 @@ export interface ValueCompositeRankingResponse {
   markets: string[];
   metricKey: 'standard_value_composite';
   scoreMethod: ValueCompositeScoreMethod;
+  forwardEpsMode: ValueCompositeForwardEpsMode;
   scorePolicy: string;
   weights: Record<string, number>;
   itemCount: number;

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -64,6 +64,21 @@ const mockChartStore = {
       'marginPressure',
       'factorRegression',
     ],
+    workbenchPanelOrder: [
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
+      'fundamentals',
+      'fundamentalsHistory',
+      'costStructure',
+      'marginPressure',
+      'factorRegression',
+    ],
     fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
     fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
     fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
@@ -170,6 +185,21 @@ describe('ChartControls', () => {
     mockChartStore.settings.showMarginPressurePanel = true;
     mockChartStore.settings.showFactorRegressionPanel = true;
     mockChartStore.settings.fundamentalsPanelOrder = [
+      'fundamentals',
+      'fundamentalsHistory',
+      'costStructure',
+      'marginPressure',
+      'factorRegression',
+    ];
+    mockChartStore.settings.workbenchPanelOrder = [
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
       'fundamentals',
       'fundamentalsHistory',
       'costStructure',
@@ -322,14 +352,41 @@ describe('ChartControls', () => {
     await user.click(firstDownButton);
 
     expect(mockChartStore.updateSettings).toHaveBeenCalledWith({
-      fundamentalsPanelOrder: [
-        'fundamentalsHistory',
+      workbenchPanelOrder: [
+        'riskAdjustedReturn',
+        'ppo',
+        'recentReturn',
+        'volumeComparison',
+        'cmf',
+        'chaikinOscillator',
+        'obvFlowScore',
+        'tradingValueMA',
         'fundamentals',
+        'fundamentalsHistory',
+        'costStructure',
+        'marginPressure',
+        'factorRegression',
+      ],
+      fundamentalsPanelOrder: [
+        'fundamentals',
+        'fundamentalsHistory',
         'costStructure',
         'marginPressure',
         'factorRegression',
       ],
     });
+  });
+
+  it('toggles sub-chart visibility from panel layout dialog', async () => {
+    const user = userEvent.setup();
+    mockChartStore.updateSettings = vi.fn();
+
+    renderChartControls();
+
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
+    await user.click(screen.getByRole('switch', { name: /^Risk Adjusted Return$/i }));
+
+    expect(mockChartStore.updateSettings).toHaveBeenCalledWith({ showRiskAdjustedReturnChart: true });
   });
 
   it('opens panel layout dialog and toggles cost structure panel visibility', async () => {
@@ -357,11 +414,19 @@ describe('ChartControls', () => {
     expect(downButton).toBeDefined();
     if (!upButton || !downButton) return;
 
-    mockChartStore.settings.fundamentalsPanelOrder = [];
+    mockChartStore.settings.workbenchPanelOrder = [];
     fireEvent.click(downButton);
     expect(mockChartStore.updateSettings).not.toHaveBeenCalled();
 
-    mockChartStore.settings.fundamentalsPanelOrder = [
+    mockChartStore.settings.workbenchPanelOrder = [
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
       'fundamentals',
       'fundamentalsHistory',
       'costStructure',
@@ -372,13 +437,7 @@ describe('ChartControls', () => {
     fireEvent.click(upButton);
     expect(mockChartStore.updateSettings).not.toHaveBeenCalled();
 
-    mockChartStore.settings.fundamentalsPanelOrder = [
-      'fundamentals',
-      undefined as unknown as 'fundamentalsHistory',
-      'costStructure',
-      'marginPressure',
-      'factorRegression',
-    ];
+    mockChartStore.settings.workbenchPanelOrder = ['ppo', undefined as unknown as 'riskAdjustedReturn'];
     fireEvent.click(downButton);
     expect(mockChartStore.updateSettings).not.toHaveBeenCalled();
   });

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -236,11 +236,14 @@ describe('ChartControls', () => {
     }));
   });
 
-  it('renders symbol search input and search button', () => {
+  it('renders symbol search as the primary sidebar action', () => {
     renderChartControls();
 
+    expect(screen.getByText('Main action')).toBeInTheDocument();
+    expect(screen.getByText('Symbol Search')).toBeInTheDocument();
+    expect(screen.getByText('銘柄コード・会社名でワークベンチを切り替え')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('銘柄コードまたは会社名で検索...')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /検索/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Symbol を開く/i })).toBeInTheDocument();
   });
 
   it('uses non-password-search input attributes for symbol search', () => {
@@ -267,7 +270,7 @@ describe('ChartControls', () => {
 
     const input = screen.getByPlaceholderText('銘柄コードまたは会社名で検索...');
     await user.type(input, '7203');
-    await user.click(screen.getByRole('button', { name: /検索/i }));
+    await user.click(screen.getByRole('button', { name: /Symbol を開く/i }));
 
     expect(mockOnSelectSymbol).toHaveBeenCalledWith('7203');
   });
@@ -805,7 +808,7 @@ describe('ChartControls', () => {
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: /検索/i }));
+    await user.click(screen.getByRole('button', { name: /Symbol を開く/i }));
 
     expect(mockOnSelectSymbol).not.toHaveBeenCalled();
   });

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.test.tsx
@@ -582,13 +582,15 @@ describe('ChartControls', () => {
     expect(mockChartStore.updateSettings).not.toHaveBeenCalled();
   });
 
-  it('opens sub-chart indicators dialog and toggles risk adjusted return', async () => {
+  it('toggles risk adjusted return from panel layout', async () => {
     const user = userEvent.setup();
     mockChartStore.updateSettings = vi.fn();
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: 'Sub-Chart Indicators' }));
+    expect(screen.queryByRole('button', { name: 'Sub-Chart Indicators' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
     await user.click(screen.getByRole('switch', { name: /risk adjusted return/i }));
 
     expect(mockChartStore.updateSettings).toHaveBeenCalledWith({ showRiskAdjustedReturnChart: true });
@@ -600,13 +602,13 @@ describe('ChartControls', () => {
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: 'Sub-Chart Indicators' }));
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
     await user.click(screen.getByRole('switch', { name: /recent return/i }));
 
     expect(mockChartStore.updateSettings).toHaveBeenCalledWith({ showRecentReturnChart: true });
   });
 
-  it('updates sub-chart indicator numeric settings', async () => {
+  it('updates sub-chart numeric settings from panel layout', async () => {
     const user = userEvent.setup();
     mockChartStore.settings.showRiskAdjustedReturnChart = true;
     mockChartStore.settings.showRecentReturnChart = true;
@@ -621,7 +623,7 @@ describe('ChartControls', () => {
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: 'Sub-Chart Indicators' }));
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
 
     fireEvent.change(screen.getByLabelText('Lookback'), { target: { value: '80' } });
     fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '1.5' } });
@@ -677,7 +679,7 @@ describe('ChartControls', () => {
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: 'Sub-Chart Indicators' }));
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
 
     const dialog = screen.getByRole('dialog');
     const [ratioTypeSelect, conditionSelect] = within(dialog).getAllByRole('combobox');
@@ -737,7 +739,7 @@ describe('ChartControls', () => {
     expect(mockChartStore.updateIndicatorSettings).toHaveBeenCalledWith('vwema', { enabled: true });
   });
 
-  it('shows signal metadata in sub-chart indicators when reference API is available', async () => {
+  it('shows signal metadata in panel layout when reference API is available', async () => {
     const user = userEvent.setup();
     mockChartStore.settings.signalOverlay.signals = [
       { type: 'volume_ratio_above', enabled: true, mode: 'entry', params: {} },
@@ -765,7 +767,7 @@ describe('ChartControls', () => {
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: 'Sub-Chart Indicators' }));
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
     expect(screen.getAllByText('Signal req: volume | Signals: volume_ratio_above').length).toBeGreaterThan(0);
   });
 
@@ -781,7 +783,7 @@ describe('ChartControls', () => {
 
     renderChartControls();
 
-    await user.click(screen.getByRole('button', { name: 'Sub-Chart Indicators' }));
+    await user.click(screen.getByRole('button', { name: 'Panel Layout' }));
     expect(screen.queryByText(/Signal req:/i)).not.toBeInTheDocument();
   });
 

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -959,34 +959,42 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto p-4">
-      <ChartPresetSelector />
-
-      <section className="space-y-3 border-t border-border/60 pt-4 first:border-t-0 first:pt-0">
-        <SectionHeader icon={Search} title="Symbol Search" />
-        <div className="space-y-2">
-          <form onSubmit={handleSymbolSubmit} className="space-y-2" autoComplete="off">
-            <StockSearchInput
-              id={symbolSearchId}
-              name="symbol-search"
-              value={symbolInput}
-              onValueChange={setSymbolInput}
-              onSelect={handleSelectStock}
-              className="border-border/60 bg-transparent focus:border-primary/50 transition-colors"
-              searchLimit={50}
-            />
-            <Button type="submit" size="sm" className="w-full">
-              <Search className="h-3.5 w-3.5 mr-1.5" />
-              検索
-            </Button>
-          </form>
-          {selectedSymbol && (
-            <div className="flex items-center gap-1.5 rounded-xl border border-border/60 bg-[var(--app-surface-muted)] px-2.5 py-2">
-              <TrendingUp className="h-3 w-3 text-primary" />
-              <span className="text-xs font-medium text-primary">選択中: {selectedSymbol}</span>
-            </div>
-          )}
+      <section className="rounded-2xl border border-primary/25 bg-primary/5 p-3.5 shadow-sm shadow-primary/5">
+        <div className="mb-3 flex items-start gap-2.5">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
+            <Search className="h-4.5 w-4.5" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-primary">Main action</p>
+            <h2 className="text-base font-semibold text-foreground">Symbol Search</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">銘柄コード・会社名でワークベンチを切り替え</p>
+          </div>
         </div>
+
+        <form onSubmit={handleSymbolSubmit} className="space-y-2" autoComplete="off">
+          <StockSearchInput
+            id={symbolSearchId}
+            name="symbol-search"
+            value={symbolInput}
+            onValueChange={setSymbolInput}
+            onSelect={handleSelectStock}
+            className="h-11 border-primary/30 bg-background text-base shadow-sm transition-colors placeholder:text-muted-foreground/70 focus:border-primary/70 focus:ring-primary/20"
+            searchLimit={50}
+          />
+          <Button type="submit" className="h-10 w-full shadow-sm">
+            <Search className="mr-1.5 h-4 w-4" />
+            Symbol を開く
+          </Button>
+        </form>
+        {selectedSymbol && (
+          <div className="mt-3 flex items-center gap-2 rounded-xl border border-primary/20 bg-background/80 px-3 py-2">
+            <TrendingUp className="h-3.5 w-3.5 text-primary" />
+            <span className="text-xs font-medium text-primary">選択中: {selectedSymbol}</span>
+          </div>
+        )}
       </section>
+
+      <ChartPresetSelector />
 
       <section className="space-y-3 border-t border-border/60 pt-4">
         <SectionHeader icon={SettingsIcon} title="Settings" />

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -28,8 +28,13 @@ import {
 } from '@/constants/fundamentalsHistoryMetrics';
 import { useSignalReference } from '@/hooks/useBacktest';
 import type { StockSearchResultItem } from '@/hooks/useStockSearch';
-import type { ChartSettings, FundamentalsPanelId } from '@/stores/chartStore';
-import { useChartStore } from '@/stores/chartStore';
+import {
+  type ChartSettings,
+  DEFAULT_WORKBENCH_PANEL_ORDER,
+  type FundamentalsPanelId,
+  useChartStore,
+  type WorkbenchPanelId,
+} from '@/stores/chartStore';
 import { logger } from '@/utils/logger';
 import { ChartPresetSelector } from './ChartPresetSelector';
 import { IndicatorToggle, NumberInput } from './IndicatorToggle';
@@ -46,6 +51,14 @@ const VISIBLE_BAR_OPTIONS = [
 ] as const;
 
 type PanelVisibilitySettingKey =
+  | 'showPPOChart'
+  | 'showRiskAdjustedReturnChart'
+  | 'showRecentReturnChart'
+  | 'showVolumeComparison'
+  | 'showCMF'
+  | 'showChaikinOscillator'
+  | 'showOBVFlowScore'
+  | 'showTradingValueMA'
   | 'showFundamentalsPanel'
   | 'showFundamentalsHistoryPanel'
   | 'showCostStructurePanel'
@@ -56,16 +69,78 @@ interface PanelVisibilityToggle {
   id: string;
   label: string;
   settingKey: PanelVisibilitySettingKey;
-  panelId: FundamentalsPanelId;
+  panelId: WorkbenchPanelId;
+  kind: 'subChart' | 'panel';
   linkPanel?: SignalLinkedPanel;
 }
 
 const PANEL_VISIBILITY_TOGGLES: PanelVisibilityToggle[] = [
   {
+    id: 'show-ppo-chart',
+    label: 'PPO',
+    settingKey: 'showPPOChart',
+    panelId: 'ppo',
+    kind: 'subChart',
+    linkPanel: 'ppo',
+  },
+  {
+    id: 'show-risk-adjusted-return-chart',
+    label: 'Risk Adjusted Return',
+    settingKey: 'showRiskAdjustedReturnChart',
+    panelId: 'riskAdjustedReturn',
+    kind: 'subChart',
+    linkPanel: 'riskAdjustedReturn',
+  },
+  {
+    id: 'show-recent-return-chart',
+    label: 'Recent Return',
+    settingKey: 'showRecentReturnChart',
+    panelId: 'recentReturn',
+    kind: 'subChart',
+  },
+  {
+    id: 'show-volume-comparison-chart',
+    label: 'Volume Comparison',
+    settingKey: 'showVolumeComparison',
+    panelId: 'volumeComparison',
+    kind: 'subChart',
+    linkPanel: 'volumeComparison',
+  },
+  {
+    id: 'show-cmf-chart',
+    label: 'CMF',
+    settingKey: 'showCMF',
+    panelId: 'cmf',
+    kind: 'subChart',
+  },
+  {
+    id: 'show-chaikin-oscillator-chart',
+    label: 'Chaikin Oscillator',
+    settingKey: 'showChaikinOscillator',
+    panelId: 'chaikinOscillator',
+    kind: 'subChart',
+  },
+  {
+    id: 'show-obv-flow-score-chart',
+    label: 'OBV Flow Score',
+    settingKey: 'showOBVFlowScore',
+    panelId: 'obvFlowScore',
+    kind: 'subChart',
+  },
+  {
+    id: 'show-trading-value-ma-chart',
+    label: 'Trading Value MA',
+    settingKey: 'showTradingValueMA',
+    panelId: 'tradingValueMA',
+    kind: 'subChart',
+    linkPanel: 'tradingValueMA',
+  },
+  {
     id: 'show-fundamentals-panel',
     label: 'Fundamentals',
     settingKey: 'showFundamentalsPanel',
     panelId: 'fundamentals',
+    kind: 'panel',
     linkPanel: 'fundamentals',
   },
   {
@@ -73,6 +148,7 @@ const PANEL_VISIBILITY_TOGGLES: PanelVisibilityToggle[] = [
     label: 'FY History',
     settingKey: 'showFundamentalsHistoryPanel',
     panelId: 'fundamentalsHistory',
+    kind: 'panel',
     linkPanel: 'fundamentalsHistory',
   },
   {
@@ -80,12 +156,14 @@ const PANEL_VISIBILITY_TOGGLES: PanelVisibilityToggle[] = [
     label: 'Cost Structure',
     settingKey: 'showCostStructurePanel',
     panelId: 'costStructure',
+    kind: 'panel',
   },
   {
     id: 'show-margin-pressure-panel',
     label: 'Margin Pressure',
     settingKey: 'showMarginPressurePanel',
     panelId: 'marginPressure',
+    kind: 'panel',
     linkPanel: 'marginPressure',
   },
   {
@@ -93,13 +171,14 @@ const PANEL_VISIBILITY_TOGGLES: PanelVisibilityToggle[] = [
     label: 'Factor Regression',
     settingKey: 'showFactorRegressionPanel',
     panelId: 'factorRegression',
+    kind: 'panel',
     linkPanel: 'factorRegression',
   },
 ];
 
 const PANEL_TOGGLE_BY_ID = Object.fromEntries(
   PANEL_VISIBILITY_TOGGLES.map((toggle) => [toggle.panelId, toggle])
-) as Record<FundamentalsPanelId, PanelVisibilityToggle>;
+) as Record<WorkbenchPanelId, PanelVisibilityToggle>;
 const FUNDAMENTAL_METRIC_LABEL_BY_ID = Object.fromEntries(
   FUNDAMENTAL_METRIC_DEFINITIONS.map((definition) => [definition.id, definition.label])
 ) as Record<FundamentalMetricId, string>;
@@ -205,6 +284,7 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
     [settings.signalOverlay?.signals, signalReferenceData?.signals]
   );
   const showSignalMeta = !!signalReferenceData && !signalReferenceError;
+  const workbenchPanelOrder = settings.workbenchPanelOrder ?? DEFAULT_WORKBENCH_PANEL_ORDER;
 
   const getPanelSignalMeta = useCallback(
     (panel: SignalLinkedPanel): string | undefined => {
@@ -243,8 +323,8 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
   );
 
   const movePanelOrder = useCallback(
-    (panelId: FundamentalsPanelId, direction: 'up' | 'down') => {
-      const currentOrder = settings.fundamentalsPanelOrder;
+    (panelId: WorkbenchPanelId, direction: 'up' | 'down') => {
+      const currentOrder = settings.workbenchPanelOrder ?? DEFAULT_WORKBENCH_PANEL_ORDER;
       const currentIndex = currentOrder.indexOf(panelId);
       if (currentIndex < 0) return;
 
@@ -257,9 +337,14 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
       if (!currentPanel || !targetPanel) return;
       nextOrder[currentIndex] = targetPanel;
       nextOrder[targetIndex] = currentPanel;
-      updateSettings({ fundamentalsPanelOrder: nextOrder });
+      updateSettings({
+        workbenchPanelOrder: nextOrder,
+        fundamentalsPanelOrder: nextOrder.filter(
+          (id): id is FundamentalsPanelId => PANEL_TOGGLE_BY_ID[id].kind === 'panel'
+        ),
+      });
     },
-    [settings.fundamentalsPanelOrder, updateSettings]
+    [settings.workbenchPanelOrder, updateSettings]
   );
 
   const updateFundamentalMetricVisibility = useCallback(
@@ -438,7 +523,12 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
       case 'panelLayout':
         return (
           <div className="space-y-2">
-            {settings.fundamentalsPanelOrder.map((panelId, index) => {
+            <div className="rounded-xl border border-border/60 bg-[var(--app-surface-muted)] p-2.5">
+              <p className="text-xs text-muted-foreground">
+                Sub-charts and fundamentals panels share one display order below the primary chart.
+              </p>
+            </div>
+            {workbenchPanelOrder.map((panelId, index) => {
               const toggle = PANEL_TOGGLE_BY_ID[panelId];
               const panelMeta = toggle.linkPanel ? getPanelSignalMeta(toggle.linkPanel) : undefined;
               const isVisible = settings[toggle.settingKey];
@@ -449,7 +539,9 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
-                      <p className="text-xs text-muted-foreground">Order {index + 1}</p>
+                      <p className="text-xs text-muted-foreground">
+                        Order {index + 1} · {toggle.kind === 'subChart' ? 'Sub-chart' : 'Panel'}
+                      </p>
                       <Label htmlFor={toggle.id} className="text-sm font-medium cursor-pointer">
                         {toggle.label}
                       </Label>
@@ -481,7 +573,7 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
                       size="sm"
                       className="h-7 px-2"
                       onClick={() => movePanelOrder(panelId, 'down')}
-                      disabled={index === settings.fundamentalsPanelOrder.length - 1}
+                      disabled={index === workbenchPanelOrder.length - 1}
                     >
                       <ArrowDown className="h-3.5 w-3.5 mr-1" />
                       Down

--- a/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
+++ b/apps/ts/packages/web/src/components/Chart/ChartControls.tsx
@@ -192,7 +192,6 @@ type SettingDialogId =
   | 'fundamentalMetrics'
   | 'fundamentalsHistoryMetrics'
   | 'overlayIndicators'
-  | 'subChartIndicators'
   | 'signalOverlay';
 
 interface SettingDialogDefinition {
@@ -232,12 +231,6 @@ const SETTING_DIALOGS: SettingDialogDefinition[] = [
     title: 'Overlay Indicators',
     description: 'Configure overlays rendered on the price chart.',
     icon: TrendingUp,
-  },
-  {
-    id: 'subChartIndicators',
-    title: 'Sub-Chart Indicators',
-    description: 'Configure additional panels rendered below the chart.',
-    icon: BarChart3,
   },
   {
     id: 'signalOverlay',
@@ -461,6 +454,184 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
     [settings.accumulationFlow, updateSettings]
   );
 
+  const renderSubChartPanelSettings = (panelId: WorkbenchPanelId) => {
+    switch (panelId) {
+      case 'riskAdjustedReturn':
+        return (
+          <div className="grid grid-cols-2 gap-1.5 border-t border-border/60 pt-2">
+            <NumberInput
+              label="Lookback"
+              value={settings.riskAdjustedReturn.lookbackPeriod}
+              onChange={(lookbackPeriod) => updateRiskAdjustedReturn({ lookbackPeriod })}
+              defaultValue={60}
+            />
+            <NumberInput
+              label="Threshold"
+              value={settings.riskAdjustedReturn.threshold}
+              onChange={(threshold) => updateRiskAdjustedReturn({ threshold })}
+              step="0.1"
+              defaultValue={1.0}
+            />
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Ratio Type</Label>
+              <Select
+                value={settings.riskAdjustedReturn.ratioType}
+                onValueChange={(ratioType) =>
+                  updateRiskAdjustedReturn({
+                    ratioType: ratioType as ChartSettings['riskAdjustedReturn']['ratioType'],
+                  })
+                }
+              >
+                <SelectTrigger className="h-7 border-border/50 bg-transparent text-xs focus:border-primary/50">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-background/95 backdrop-blur-md border-border shadow-xl">
+                  <SelectItem value="sortino" className="text-xs">
+                    sortino
+                  </SelectItem>
+                  <SelectItem value="sharpe" className="text-xs">
+                    sharpe
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Condition</Label>
+              <Select
+                value={settings.riskAdjustedReturn.condition}
+                onValueChange={(condition) =>
+                  updateRiskAdjustedReturn({
+                    condition: condition as ChartSettings['riskAdjustedReturn']['condition'],
+                  })
+                }
+              >
+                <SelectTrigger className="h-7 border-border/50 bg-transparent text-xs focus:border-primary/50">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-background/95 backdrop-blur-md border-border shadow-xl">
+                  <SelectItem value="above" className="text-xs">
+                    above
+                  </SelectItem>
+                  <SelectItem value="below" className="text-xs">
+                    below
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        );
+      case 'recentReturn':
+        return (
+          <div className="grid grid-cols-2 gap-1.5 border-t border-border/60 pt-2">
+            <NumberInput
+              label="Short Lookback"
+              value={settings.recentReturn.shortPeriod}
+              onChange={(shortPeriod) => updateRecentReturn({ shortPeriod })}
+              defaultValue={20}
+            />
+            <NumberInput
+              label="Long Lookback"
+              value={settings.recentReturn.longPeriod}
+              onChange={(longPeriod) => updateRecentReturn({ longPeriod })}
+              defaultValue={60}
+            />
+          </div>
+        );
+      case 'volumeComparison':
+        return (
+          <div className="grid grid-cols-2 gap-1.5 border-t border-border/60 pt-2">
+            <NumberInput
+              label="Short Period"
+              value={settings.volumeComparison.shortPeriod}
+              onChange={(shortPeriod) => updateVolumeComparison({ shortPeriod })}
+              defaultValue={20}
+            />
+            <NumberInput
+              label="Long Period"
+              value={settings.volumeComparison.longPeriod}
+              onChange={(longPeriod) => updateVolumeComparison({ longPeriod })}
+              defaultValue={100}
+            />
+            <NumberInput
+              label="Lower Mult."
+              value={settings.volumeComparison.lowerMultiplier}
+              onChange={(lowerMultiplier) => updateVolumeComparison({ lowerMultiplier })}
+              step="0.1"
+              defaultValue={1.0}
+            />
+            <NumberInput
+              label="Higher Mult."
+              value={settings.volumeComparison.higherMultiplier}
+              onChange={(higherMultiplier) => updateVolumeComparison({ higherMultiplier })}
+              step="0.1"
+              defaultValue={1.5}
+            />
+          </div>
+        );
+      case 'cmf':
+        return (
+          <div className="border-t border-border/60 pt-2">
+            <NumberInput
+              label="CMF Period"
+              value={settings.accumulationFlow.cmfPeriod}
+              onChange={(cmfPeriod) => updateAccumulationFlow({ cmfPeriod })}
+              defaultValue={20}
+            />
+          </div>
+        );
+      case 'chaikinOscillator':
+        return (
+          <div className="grid grid-cols-2 gap-2 border-t border-border/60 pt-2">
+            <NumberInput
+              label="Chaikin Fast"
+              value={settings.accumulationFlow.chaikinFastPeriod}
+              onChange={(chaikinFastPeriod) =>
+                updateAccumulationFlow({
+                  chaikinFastPeriod,
+                  chaikinSlowPeriod: Math.max(settings.accumulationFlow.chaikinSlowPeriod, chaikinFastPeriod + 1),
+                })
+              }
+              defaultValue={3}
+            />
+            <NumberInput
+              label="Chaikin Slow"
+              value={settings.accumulationFlow.chaikinSlowPeriod}
+              onChange={(chaikinSlowPeriod) =>
+                updateAccumulationFlow({
+                  chaikinSlowPeriod: Math.max(chaikinSlowPeriod, settings.accumulationFlow.chaikinFastPeriod + 1),
+                })
+              }
+              defaultValue={10}
+            />
+          </div>
+        );
+      case 'obvFlowScore':
+        return (
+          <div className="border-t border-border/60 pt-2">
+            <NumberInput
+              label="OBV Score Lookback"
+              value={settings.accumulationFlow.obvLookbackPeriod}
+              onChange={(obvLookbackPeriod) => updateAccumulationFlow({ obvLookbackPeriod })}
+              defaultValue={20}
+            />
+          </div>
+        );
+      case 'tradingValueMA':
+        return (
+          <div className="border-t border-border/60 pt-2">
+            <NumberInput
+              label="Period"
+              value={settings.tradingValueMA.period}
+              onChange={(period) => updateTradingValueMA({ period })}
+              defaultValue={15}
+            />
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
   const renderDialogBody = (dialogId: SettingDialogId) => {
     switch (dialogId) {
       case 'chartSettings':
@@ -579,6 +750,7 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
                       Down
                     </Button>
                   </div>
+                  {toggle.kind === 'subChart' && renderSubChartPanelSettings(panelId)}
                 </div>
               );
             })}
@@ -776,207 +948,6 @@ export function ChartControls({ selectedSymbol, onSelectSymbol }: ChartControlsP
                   defaultValue={2.0}
                 />
               </div>
-            </IndicatorToggle>
-          </div>
-        );
-
-      case 'subChartIndicators':
-        return (
-          <div className="space-y-2">
-            <IndicatorToggle
-              label="Risk Adjusted Return"
-              enabled={settings.showRiskAdjustedReturnChart}
-              onToggle={(checked) => updateSettings({ showRiskAdjustedReturnChart: checked })}
-              meta={getPanelSignalMeta('riskAdjustedReturn')}
-            >
-              <div className="grid grid-cols-2 gap-1.5">
-                <NumberInput
-                  label="Lookback"
-                  value={settings.riskAdjustedReturn.lookbackPeriod}
-                  onChange={(lookbackPeriod) => updateRiskAdjustedReturn({ lookbackPeriod })}
-                  defaultValue={60}
-                />
-                <NumberInput
-                  label="Threshold"
-                  value={settings.riskAdjustedReturn.threshold}
-                  onChange={(threshold) => updateRiskAdjustedReturn({ threshold })}
-                  step="0.1"
-                  defaultValue={1.0}
-                />
-                <div className="space-y-1">
-                  <Label className="text-xs text-muted-foreground">Ratio Type</Label>
-                  <Select
-                    value={settings.riskAdjustedReturn.ratioType}
-                    onValueChange={(ratioType) =>
-                      updateRiskAdjustedReturn({
-                        ratioType: ratioType as ChartSettings['riskAdjustedReturn']['ratioType'],
-                      })
-                    }
-                  >
-                    <SelectTrigger className="h-7 border-border/50 bg-transparent text-xs focus:border-primary/50">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="bg-background/95 backdrop-blur-md border-border shadow-xl">
-                      <SelectItem value="sortino" className="text-xs">
-                        sortino
-                      </SelectItem>
-                      <SelectItem value="sharpe" className="text-xs">
-                        sharpe
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs text-muted-foreground">Condition</Label>
-                  <Select
-                    value={settings.riskAdjustedReturn.condition}
-                    onValueChange={(condition) =>
-                      updateRiskAdjustedReturn({
-                        condition: condition as ChartSettings['riskAdjustedReturn']['condition'],
-                      })
-                    }
-                  >
-                    <SelectTrigger className="h-7 border-border/50 bg-transparent text-xs focus:border-primary/50">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="bg-background/95 backdrop-blur-md border-border shadow-xl">
-                      <SelectItem value="above" className="text-xs">
-                        above
-                      </SelectItem>
-                      <SelectItem value="below" className="text-xs">
-                        below
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </IndicatorToggle>
-
-            <IndicatorToggle
-              label="Recent Return"
-              enabled={settings.showRecentReturnChart}
-              onToggle={(checked) => updateSettings({ showRecentReturnChart: checked })}
-            >
-              <div className="grid grid-cols-2 gap-1.5">
-                <NumberInput
-                  label="Short Lookback"
-                  value={settings.recentReturn.shortPeriod}
-                  onChange={(shortPeriod) => updateRecentReturn({ shortPeriod })}
-                  defaultValue={20}
-                />
-                <NumberInput
-                  label="Long Lookback"
-                  value={settings.recentReturn.longPeriod}
-                  onChange={(longPeriod) => updateRecentReturn({ longPeriod })}
-                  defaultValue={60}
-                />
-              </div>
-            </IndicatorToggle>
-
-            <IndicatorToggle
-              label="Volume Comparison"
-              enabled={settings.showVolumeComparison}
-              onToggle={(checked) => updateSettings({ showVolumeComparison: checked })}
-              meta={getPanelSignalMeta('volumeComparison')}
-            >
-              <div className="grid grid-cols-2 gap-1.5">
-                <NumberInput
-                  label="Short Period"
-                  value={settings.volumeComparison.shortPeriod}
-                  onChange={(shortPeriod) => updateVolumeComparison({ shortPeriod })}
-                  defaultValue={20}
-                />
-                <NumberInput
-                  label="Long Period"
-                  value={settings.volumeComparison.longPeriod}
-                  onChange={(longPeriod) => updateVolumeComparison({ longPeriod })}
-                  defaultValue={100}
-                />
-                <NumberInput
-                  label="Lower Mult."
-                  value={settings.volumeComparison.lowerMultiplier}
-                  onChange={(lowerMultiplier) => updateVolumeComparison({ lowerMultiplier })}
-                  step="0.1"
-                  defaultValue={1.0}
-                />
-                <NumberInput
-                  label="Higher Mult."
-                  value={settings.volumeComparison.higherMultiplier}
-                  onChange={(higherMultiplier) => updateVolumeComparison({ higherMultiplier })}
-                  step="0.1"
-                  defaultValue={1.5}
-                />
-              </div>
-            </IndicatorToggle>
-
-            <IndicatorToggle
-              label="CMF"
-              enabled={settings.showCMF}
-              onToggle={(checked) => updateSettings({ showCMF: checked })}
-            >
-              <NumberInput
-                label="CMF Period"
-                value={settings.accumulationFlow.cmfPeriod}
-                onChange={(cmfPeriod) => updateAccumulationFlow({ cmfPeriod })}
-                defaultValue={20}
-              />
-            </IndicatorToggle>
-
-            <IndicatorToggle
-              label="Chaikin Oscillator"
-              enabled={settings.showChaikinOscillator}
-              onToggle={(checked) => updateSettings({ showChaikinOscillator: checked })}
-            >
-              <div className="grid grid-cols-2 gap-2">
-                <NumberInput
-                  label="Chaikin Fast"
-                  value={settings.accumulationFlow.chaikinFastPeriod}
-                  onChange={(chaikinFastPeriod) =>
-                    updateAccumulationFlow({
-                      chaikinFastPeriod,
-                      chaikinSlowPeriod: Math.max(settings.accumulationFlow.chaikinSlowPeriod, chaikinFastPeriod + 1),
-                    })
-                  }
-                  defaultValue={3}
-                />
-                <NumberInput
-                  label="Chaikin Slow"
-                  value={settings.accumulationFlow.chaikinSlowPeriod}
-                  onChange={(chaikinSlowPeriod) =>
-                    updateAccumulationFlow({
-                      chaikinSlowPeriod: Math.max(chaikinSlowPeriod, settings.accumulationFlow.chaikinFastPeriod + 1),
-                    })
-                  }
-                  defaultValue={10}
-                />
-              </div>
-            </IndicatorToggle>
-
-            <IndicatorToggle
-              label="OBV Flow Score"
-              enabled={settings.showOBVFlowScore}
-              onToggle={(checked) => updateSettings({ showOBVFlowScore: checked })}
-            >
-              <NumberInput
-                label="OBV Score Lookback"
-                value={settings.accumulationFlow.obvLookbackPeriod}
-                onChange={(obvLookbackPeriod) => updateAccumulationFlow({ obvLookbackPeriod })}
-                defaultValue={20}
-              />
-            </IndicatorToggle>
-
-            <IndicatorToggle
-              label="Trading Value MA"
-              enabled={settings.showTradingValueMA}
-              onToggle={(checked) => updateSettings({ showTradingValueMA: checked })}
-              meta={getPanelSignalMeta('tradingValueMA')}
-            >
-              <NumberInput
-                label="Period"
-                value={settings.tradingValueMA.period}
-                onChange={(period) => updateTradingValueMA({ period })}
-                defaultValue={15}
-              />
             </IndicatorToggle>
           </div>
         );

--- a/apps/ts/packages/web/src/components/Layout/Header.test.tsx
+++ b/apps/ts/packages/web/src/components/Layout/Header.test.tsx
@@ -39,9 +39,26 @@ vi.mock('@/components/ui/theme-toggle', () => ({
   ThemeToggle: () => <button type="button">ThemeToggle</button>,
 }));
 
+function mockHeaderMediaQuery(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+}
+
 describe('Header', () => {
   beforeEach(() => {
     pathname = '/symbol-workbench';
+    vi.unstubAllGlobals();
   });
 
   it('renders logo, primary navigation items, and overflow navigation trigger', () => {
@@ -67,6 +84,27 @@ describe('Header', () => {
 
     expect(screen.getByRole('link', { name: 'Research' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'N225 Options' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Market DB' })).toBeInTheDocument();
+  });
+
+  it('uses a current-page mobile navigation trigger and moves all destinations into the menu', async () => {
+    const user = userEvent.setup();
+    mockHeaderMediaQuery(true);
+
+    pathname = '/portfolio';
+    render(<Header />);
+
+    const mobileTrigger = screen.getByRole('button', { name: 'Portfolio' });
+    expect(mobileTrigger).toHaveAttribute('data-state', 'active');
+    expect(screen.queryByRole('button', { name: 'More' })).not.toBeInTheDocument();
+
+    await user.click(mobileTrigger);
+
+    expect(screen.getByText('Navigation')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Symbol Workbench' }).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('link', { name: 'Portfolio' }).some((link) => link.getAttribute('aria-current') === 'page')
+    ).toBe(true);
     expect(screen.getByRole('link', { name: 'Market DB' })).toBeInTheDocument();
   });
 

--- a/apps/ts/packages/web/src/components/Layout/Header.tsx
+++ b/apps/ts/packages/web/src/components/Layout/Header.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
 import {
   BarChart3,
@@ -12,6 +11,7 @@ import {
   MoreHorizontal,
   TrendingUp,
 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { cn } from '@/lib/utils';
 
@@ -46,6 +46,29 @@ const moreMenuId = 'global-header-overflow-nav';
 const primaryNavigationItems = navigationItems.filter((item) => primaryNavigationPaths.has(item.path));
 const overflowNavigationItems = navigationItems.filter((item) => !primaryNavigationPaths.has(item.path));
 
+function getIsMobileHeaderLayout(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px)').matches
+  );
+}
+
+function useIsMobileHeaderLayout(): boolean {
+  const [isMobileHeaderLayout, setIsMobileHeaderLayout] = useState(getIsMobileHeaderLayout);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia('(max-width: 1023px)');
+    const updateLayout = () => setIsMobileHeaderLayout(mediaQuery.matches);
+    updateLayout();
+    mediaQuery.addEventListener('change', updateLayout);
+    return () => mediaQuery.removeEventListener('change', updateLayout);
+  }, []);
+
+  return isMobileHeaderLayout;
+}
+
 function isNavigationItemActive(item: NavigationItem, pathname: string): boolean {
   return (
     pathname === item.path ||
@@ -63,14 +86,73 @@ function getNavigationItemClasses(isActive: boolean): string {
   );
 }
 
+function HeaderMenu({
+  id,
+  items,
+  pathname,
+  showMobileLabel,
+  onSelect,
+}: {
+  id: string;
+  items: NavigationItem[];
+  pathname: string;
+  showMobileLabel: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <div
+      id={id}
+      className="absolute right-0 top-full z-30 mt-2 w-64 rounded-2xl border border-border/70 bg-background/98 p-2 shadow-lg backdrop-blur-xl"
+    >
+      {showMobileLabel ? (
+        <p className="px-2 pb-2 pt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Navigation
+        </p>
+      ) : null}
+      {items.map((item) => {
+        const Icon = item.icon;
+        const isActive = isNavigationItemActive(item, pathname);
+
+        return (
+          <Link
+            key={item.path}
+            to={item.path}
+            aria-current={isActive ? 'page' : undefined}
+            data-state={isActive ? 'active' : 'inactive'}
+            onClick={onSelect}
+            className={cn(getNavigationItemClasses(isActive), 'w-full text-left')}
+          >
+            <Icon className="h-4 w-4 shrink-0" />
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
 export function Header() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const isMobileHeaderLayout = useIsMobileHeaderLayout();
   const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false);
   const moreMenuRef = useRef<HTMLDivElement | null>(null);
   const previousPathnameRef = useRef(pathname);
 
+  const activeNavigationItem = navigationItems.find((item) => isNavigationItemActive(item, pathname));
   const activeOverflowItem = overflowNavigationItems.find((item) => isNavigationItemActive(item, pathname));
-  const MoreMenuIcon = activeOverflowItem?.icon ?? MoreHorizontal;
+  const mobileMenuItems = navigationItems;
+  const menuItems = isMobileHeaderLayout ? mobileMenuItems : overflowNavigationItems;
+  const MenuIcon = (isMobileHeaderLayout ? activeNavigationItem?.icon : activeOverflowItem?.icon) ?? MoreHorizontal;
+  const menuLabel = isMobileHeaderLayout
+    ? (activeNavigationItem?.label ?? 'Navigation')
+    : (activeOverflowItem?.label ?? 'More');
+  const menuState = isMobileHeaderLayout
+    ? activeNavigationItem
+      ? 'active'
+      : 'inactive'
+    : activeOverflowItem
+      ? 'active'
+      : 'inactive';
 
   useEffect(() => {
     if (previousPathnameRef.current === pathname) {
@@ -109,7 +191,7 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-20 border-b border-border/70 bg-background/92 backdrop-blur-xl">
-      <div className="mx-auto flex h-16 w-full max-w-[1180px] items-center gap-2 px-3 sm:px-4 lg:px-5">
+      <div className="mx-auto flex h-14 w-full max-w-[1180px] items-center gap-2 px-3 sm:px-4 lg:h-16 lg:px-5">
         <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
           <Link
             to="/symbol-workbench"
@@ -126,8 +208,8 @@ export function Header() {
             </div>
           </Link>
 
-          <div className="flex min-w-0 flex-1 items-center gap-1.5 border-l border-border/70 pl-2 sm:pl-3">
-            <nav className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5 border-l border-border/70 pl-2 sm:pl-3 lg:justify-start">
+            <nav className="hidden min-w-0 flex-1 items-center gap-1 overflow-x-auto lg:flex">
               {primaryNavigationItems.map((item) => {
                 const Icon = item.icon;
                 const isActive = isNavigationItemActive(item, pathname);
@@ -153,53 +235,32 @@ export function Header() {
                 aria-controls={moreMenuId}
                 aria-expanded={isMoreMenuOpen}
                 aria-haspopup="true"
-                data-state={activeOverflowItem ? 'active' : 'inactive'}
+                data-state={menuState}
                 onClick={() => {
                   setIsMoreMenuOpen((current) => !current);
                 }}
                 className={cn(
-                  'app-interactive flex items-center gap-1.5 rounded-xl px-2.5 py-2 text-sm font-medium',
-                  activeOverflowItem
+                  'app-interactive flex max-w-[52vw] items-center gap-1.5 rounded-xl px-2.5 py-2 text-sm font-medium',
+                  menuState === 'active'
                     ? 'bg-[var(--app-surface-emphasis)] text-foreground shadow-sm'
                     : 'text-muted-foreground hover:bg-[var(--app-surface-muted)] hover:text-foreground'
                 )}
               >
-                <MoreMenuIcon className="h-4 w-4" />
-                <span>{activeOverflowItem?.label ?? 'More'}</span>
+                <MenuIcon className="h-4 w-4 shrink-0" />
+                <span className="truncate">{menuLabel}</span>
                 <ChevronDown
-                  className={cn('h-4 w-4 transition-transform duration-150', isMoreMenuOpen && 'rotate-180')}
+                  className={cn('h-4 w-4 shrink-0 transition-transform duration-150', isMoreMenuOpen && 'rotate-180')}
                 />
               </button>
 
               {isMoreMenuOpen ? (
-                <div
+                <HeaderMenu
                   id={moreMenuId}
-                  className="absolute right-0 top-full z-30 mt-2 w-56 rounded-2xl border border-border/70 bg-background/98 p-2 shadow-lg backdrop-blur-xl"
-                >
-                  {overflowNavigationItems.map((item) => {
-                    const Icon = item.icon;
-                    const isActive = isNavigationItemActive(item, pathname);
-
-                    return (
-                      <Link
-                        key={item.path}
-                        to={item.path}
-                        aria-current={isActive ? 'page' : undefined}
-                        data-state={isActive ? 'active' : 'inactive'}
-                        onClick={() => {
-                          setIsMoreMenuOpen(false);
-                        }}
-                        className={cn(
-                          getNavigationItemClasses(isActive),
-                          'w-full text-left',
-                        )}
-                      >
-                        <Icon className="h-4 w-4 shrink-0" />
-                        <span>{item.label}</span>
-                      </Link>
-                    );
-                  })}
-                </div>
+                  items={menuItems}
+                  pathname={pathname}
+                  showMobileLabel={isMobileHeaderLayout}
+                  onSelect={() => setIsMoreMenuOpen(false)}
+                />
               ) : null}
             </div>
           </div>

--- a/apps/ts/packages/web/src/components/Layout/Header.tsx
+++ b/apps/ts/packages/web/src/components/Layout/Header.tsx
@@ -102,7 +102,7 @@ function HeaderMenu({
   return (
     <div
       id={id}
-      className="absolute right-0 top-full z-30 mt-2 w-64 rounded-2xl border border-border/70 bg-background/98 p-2 shadow-lg backdrop-blur-xl"
+      className="absolute right-0 top-full z-30 mt-2 max-h-[calc(100dvh-4rem)] w-64 overflow-y-auto rounded-2xl border border-border/70 bg-background/98 p-2 shadow-lg backdrop-blur-xl"
     >
       {showMobileLabel ? (
         <p className="px-2 pb-2 pt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">

--- a/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.test.tsx
@@ -113,6 +113,33 @@ describe('IndexPerformanceTable', () => {
     expect(onIndexClick).toHaveBeenCalledWith('N225');
   });
 
+  it('keeps mobile virtualized index cards scrollable for long lists', () => {
+    mockIndexMediaQuery(true);
+    const items = Array.from({ length: 121 }, (_, index) =>
+      createItem({
+        code: `IDX${String(index).padStart(3, '0')}`,
+        name: `Index ${index}`,
+        category: index % 2 === 0 ? 'market' : 'style',
+        changePercentage: 121 - index,
+        currentClose: 1000 + index,
+        baseClose: 900 + index,
+      })
+    );
+    const { container } = render(
+      <IndexPerformanceTable items={items} isLoading={false} error={null} onIndexClick={vi.fn()} />
+    );
+    const scrollArea = container.querySelector('.overflow-auto');
+
+    expect(scrollArea).not.toBeNull();
+    expect(screen.getByText('IDX000')).toBeInTheDocument();
+    expect(screen.queryByText('IDX120')).not.toBeInTheDocument();
+    expect(container.querySelector('[aria-hidden="true"][style*="height"]')).not.toBeNull();
+
+    fireEvent.scroll(scrollArea as Element, { target: { scrollTop: 120 * 116 } });
+
+    expect(screen.getByText('IDX120')).toBeInTheDocument();
+  });
+
   it('virtualizes long lists', () => {
     const items = Array.from({ length: 121 }, (_, index) =>
       createItem({

--- a/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IndexPerformanceItem } from '@/types/ranking';
 import { IndexPerformanceTable } from './IndexPerformanceTable';
 
@@ -19,7 +19,26 @@ function createItem(overrides: Partial<IndexPerformanceItem>): IndexPerformanceI
   };
 }
 
+function mockIndexMediaQuery(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+}
+
 describe('IndexPerformanceTable', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
   it('renders empty state with selected lookback days', () => {
     render(
       <IndexPerformanceTable items={[]} isLoading={false} error={null} onIndexClick={vi.fn()} lookbackDays={10} />
@@ -74,6 +93,24 @@ describe('IndexPerformanceTable', () => {
 
     fireEvent.click(jpx400Row);
     expect(onIndexClick).toHaveBeenCalledWith('JPX400');
+  });
+
+  it('renders mobile index cards and keeps index navigation', () => {
+    const onIndexClick = vi.fn();
+    mockIndexMediaQuery(true);
+
+    render(
+      <IndexPerformanceTable
+        items={[createItem({ code: 'N225', name: 'Nikkei 225', category: 'market', changePercentage: 2.5 })]}
+        isLoading={false}
+        error={null}
+        onIndexClick={onIndexClick}
+      />
+    );
+
+    expect(screen.queryByRole('columnheader', { name: 'Code' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /N225/ }));
+    expect(onIndexClick).toHaveBeenCalledWith('N225');
   });
 
   it('virtualizes long lists', () => {

--- a/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.tsx
@@ -1,4 +1,5 @@
 import { TrendingUp } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { SectionEyebrow, Surface } from '@/components/Layout/Workspace';
 import { DataStateWrapper } from '@/components/ui/data-state-wrapper';
 import { useVirtualizedRows } from '@/hooks/useVirtualizedRows';
@@ -18,6 +19,29 @@ interface IndexPerformanceTableProps {
 const VIRTUALIZATION_THRESHOLD = 120;
 const INDEX_ROW_HEIGHT = 34;
 const INDEX_VIEWPORT_HEIGHT = 560;
+
+function getIsMobileIndexLayout(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px)').matches
+  );
+}
+
+function useIsMobileIndexLayout(): boolean {
+  const [isMobileIndexLayout, setIsMobileIndexLayout] = useState(getIsMobileIndexLayout);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia('(max-width: 1023px)');
+    const updateLayout = () => setIsMobileIndexLayout(mediaQuery.matches);
+    updateLayout();
+    mediaQuery.addEventListener('change', updateLayout);
+    return () => mediaQuery.removeEventListener('change', updateLayout);
+  }, []);
+
+  return isMobileIndexLayout;
+}
 
 function formatIndexLevel(value: number): string {
   return value.toLocaleString('ja-JP', {
@@ -61,6 +85,56 @@ function IndexPerformanceRow({
   );
 }
 
+function IndexPerformanceCard({
+  item,
+  onIndexClick,
+  lookbackDays,
+}: {
+  item: IndexPerformanceItem;
+  onIndexClick: (code: string) => void;
+  lookbackDays: number;
+}) {
+  const isPositive = item.changePercentage >= 0;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onIndexClick(item.code)}
+      className="w-full rounded-2xl border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:bg-[var(--app-surface-muted)]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-mono text-sm font-semibold text-primary">{item.code}</p>
+          <p className="mt-1 truncate text-sm font-semibold text-foreground">{item.name}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {INDEX_CATEGORY_LABELS[item.category] ?? item.category}
+          </p>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 text-sm font-semibold tabular-nums',
+            isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          )}
+        >
+          {formatPercentage(item.changePercentage)}
+        </span>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+        <div className="rounded-xl bg-[var(--app-surface-muted)] px-2.5 py-2">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Close</p>
+          <p className="mt-0.5 font-semibold tabular-nums text-foreground">{formatIndexLevel(item.currentClose)}</p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">{item.currentDate}</p>
+        </div>
+        <div className="rounded-xl bg-[var(--app-surface-muted)] px-2.5 py-2">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Base / {lookbackDays}D</p>
+          <p className="mt-0.5 font-semibold tabular-nums text-foreground">{formatIndexLevel(item.baseClose)}</p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">{item.baseDate}</p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
 export function IndexPerformanceTable({
   items,
   isLoading,
@@ -82,6 +156,7 @@ export function IndexPerformanceTable({
     return left.code.localeCompare(right.code);
   });
   const shouldVirtualize = rows.length >= VIRTUALIZATION_THRESHOLD;
+  const isMobileIndexLayout = useIsMobileIndexLayout();
   const virtual = useVirtualizedRows(rows, {
     enabled: shouldVirtualize,
     rowHeight: INDEX_ROW_HEIGHT,
@@ -117,34 +192,47 @@ export function IndexPerformanceTable({
           emptyIcon={<TrendingUp className="h-8 w-8" />}
           height="h-full min-h-[18rem]"
         >
-          <table className="w-full text-xs">
-            <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
-              <tr>
-                <th className="w-20 px-2 py-1.5 text-left">Code</th>
-                <th className="px-2 py-1.5 text-left">Index</th>
-                <th className="w-28 px-2 py-1.5 text-right">Close</th>
-                <th className="w-24 px-2 py-1.5 text-left">Date</th>
-                <th className="w-28 px-2 py-1.5 text-right">Base Close</th>
-                <th className="w-24 px-2 py-1.5 text-left">Base Date</th>
-                <th className="w-20 px-2 py-1.5 text-right">{lookbackDays}D</th>
-              </tr>
-            </thead>
-            <tbody>
-              {shouldVirtualize && virtual.paddingTop > 0 ? (
-                <tr>
-                  <td colSpan={7} className="p-0" style={{ height: virtual.paddingTop }} />
-                </tr>
-              ) : null}
+          {isMobileIndexLayout ? (
+            <div className="space-y-2 p-3">
               {virtual.visibleItems.map((item) => (
-                <IndexPerformanceRow key={item.code} item={item} onIndexClick={onIndexClick} />
+                <IndexPerformanceCard
+                  key={item.code}
+                  item={item}
+                  onIndexClick={onIndexClick}
+                  lookbackDays={lookbackDays}
+                />
               ))}
-              {shouldVirtualize && virtual.paddingBottom > 0 ? (
+            </div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
                 <tr>
-                  <td colSpan={7} className="p-0" style={{ height: virtual.paddingBottom }} />
+                  <th className="w-20 px-2 py-1.5 text-left">Code</th>
+                  <th className="px-2 py-1.5 text-left">Index</th>
+                  <th className="w-28 px-2 py-1.5 text-right">Close</th>
+                  <th className="w-24 px-2 py-1.5 text-left">Date</th>
+                  <th className="w-28 px-2 py-1.5 text-right">Base Close</th>
+                  <th className="w-24 px-2 py-1.5 text-left">Base Date</th>
+                  <th className="w-20 px-2 py-1.5 text-right">{lookbackDays}D</th>
                 </tr>
-              ) : null}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {shouldVirtualize && virtual.paddingTop > 0 ? (
+                  <tr>
+                    <td colSpan={7} className="p-0" style={{ height: virtual.paddingTop }} />
+                  </tr>
+                ) : null}
+                {virtual.visibleItems.map((item) => (
+                  <IndexPerformanceRow key={item.code} item={item} onIndexClick={onIndexClick} />
+                ))}
+                {shouldVirtualize && virtual.paddingBottom > 0 ? (
+                  <tr>
+                    <td colSpan={7} className="p-0" style={{ height: virtual.paddingBottom }} />
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          )}
         </DataStateWrapper>
       </div>
     </Surface>

--- a/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/IndexPerformanceTable.tsx
@@ -18,6 +18,7 @@ interface IndexPerformanceTableProps {
 
 const VIRTUALIZATION_THRESHOLD = 120;
 const INDEX_ROW_HEIGHT = 34;
+const INDEX_CARD_ROW_HEIGHT = 120;
 const INDEX_VIEWPORT_HEIGHT = 560;
 
 function getIsMobileIndexLayout(): boolean {
@@ -100,7 +101,7 @@ function IndexPerformanceCard({
     <button
       type="button"
       onClick={() => onIndexClick(item.code)}
-      className="w-full rounded-2xl border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:bg-[var(--app-surface-muted)]"
+      className="min-h-[7rem] w-full rounded-2xl border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:bg-[var(--app-surface-muted)]"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
@@ -135,6 +136,82 @@ function IndexPerformanceCard({
   );
 }
 
+interface IndexVirtualRows {
+  visibleItems: IndexPerformanceItem[];
+  paddingTop: number;
+  paddingBottom: number;
+}
+
+function VirtualSpacer({ height }: { height: number }) {
+  if (height <= 0) return null;
+  return <div aria-hidden="true" className="shrink-0" style={{ height }} />;
+}
+
+function IndexPerformanceCardList({
+  virtual,
+  shouldVirtualize,
+  onIndexClick,
+  lookbackDays,
+}: {
+  virtual: IndexVirtualRows;
+  shouldVirtualize: boolean;
+  onIndexClick: (code: string) => void;
+  lookbackDays: number;
+}) {
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      {shouldVirtualize ? <VirtualSpacer height={virtual.paddingTop} /> : null}
+      {virtual.visibleItems.map((item) => (
+        <IndexPerformanceCard key={item.code} item={item} onIndexClick={onIndexClick} lookbackDays={lookbackDays} />
+      ))}
+      {shouldVirtualize ? <VirtualSpacer height={virtual.paddingBottom} /> : null}
+    </div>
+  );
+}
+
+function IndexPerformanceRowsTable({
+  virtual,
+  shouldVirtualize,
+  onIndexClick,
+  lookbackDays,
+}: {
+  virtual: IndexVirtualRows;
+  shouldVirtualize: boolean;
+  onIndexClick: (code: string) => void;
+  lookbackDays: number;
+}) {
+  return (
+    <table className="w-full text-xs">
+      <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
+        <tr>
+          <th className="w-20 px-2 py-1.5 text-left">Code</th>
+          <th className="px-2 py-1.5 text-left">Index</th>
+          <th className="w-28 px-2 py-1.5 text-right">Close</th>
+          <th className="w-24 px-2 py-1.5 text-left">Date</th>
+          <th className="w-28 px-2 py-1.5 text-right">Base Close</th>
+          <th className="w-24 px-2 py-1.5 text-left">Base Date</th>
+          <th className="w-20 px-2 py-1.5 text-right">{lookbackDays}D</th>
+        </tr>
+      </thead>
+      <tbody>
+        {shouldVirtualize && virtual.paddingTop > 0 ? (
+          <tr>
+            <td colSpan={7} className="p-0" style={{ height: virtual.paddingTop }} />
+          </tr>
+        ) : null}
+        {virtual.visibleItems.map((item) => (
+          <IndexPerformanceRow key={item.code} item={item} onIndexClick={onIndexClick} />
+        ))}
+        {shouldVirtualize && virtual.paddingBottom > 0 ? (
+          <tr>
+            <td colSpan={7} className="p-0" style={{ height: virtual.paddingBottom }} />
+          </tr>
+        ) : null}
+      </tbody>
+    </table>
+  );
+}
+
 export function IndexPerformanceTable({
   items,
   isLoading,
@@ -159,7 +236,7 @@ export function IndexPerformanceTable({
   const isMobileIndexLayout = useIsMobileIndexLayout();
   const virtual = useVirtualizedRows(rows, {
     enabled: shouldVirtualize,
-    rowHeight: INDEX_ROW_HEIGHT,
+    rowHeight: isMobileIndexLayout ? INDEX_CARD_ROW_HEIGHT : INDEX_ROW_HEIGHT,
     viewportHeight: INDEX_VIEWPORT_HEIGHT,
   });
   const lookbackDays = rows[0]?.lookbackDays ?? selectedLookbackDays ?? 5;
@@ -193,45 +270,19 @@ export function IndexPerformanceTable({
           height="h-full min-h-[18rem]"
         >
           {isMobileIndexLayout ? (
-            <div className="space-y-2 p-3">
-              {virtual.visibleItems.map((item) => (
-                <IndexPerformanceCard
-                  key={item.code}
-                  item={item}
-                  onIndexClick={onIndexClick}
-                  lookbackDays={lookbackDays}
-                />
-              ))}
-            </div>
+            <IndexPerformanceCardList
+              virtual={virtual}
+              shouldVirtualize={shouldVirtualize}
+              onIndexClick={onIndexClick}
+              lookbackDays={lookbackDays}
+            />
           ) : (
-            <table className="w-full text-xs">
-              <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
-                <tr>
-                  <th className="w-20 px-2 py-1.5 text-left">Code</th>
-                  <th className="px-2 py-1.5 text-left">Index</th>
-                  <th className="w-28 px-2 py-1.5 text-right">Close</th>
-                  <th className="w-24 px-2 py-1.5 text-left">Date</th>
-                  <th className="w-28 px-2 py-1.5 text-right">Base Close</th>
-                  <th className="w-24 px-2 py-1.5 text-left">Base Date</th>
-                  <th className="w-20 px-2 py-1.5 text-right">{lookbackDays}D</th>
-                </tr>
-              </thead>
-              <tbody>
-                {shouldVirtualize && virtual.paddingTop > 0 ? (
-                  <tr>
-                    <td colSpan={7} className="p-0" style={{ height: virtual.paddingTop }} />
-                  </tr>
-                ) : null}
-                {virtual.visibleItems.map((item) => (
-                  <IndexPerformanceRow key={item.code} item={item} onIndexClick={onIndexClick} />
-                ))}
-                {shouldVirtualize && virtual.paddingBottom > 0 ? (
-                  <tr>
-                    <td colSpan={7} className="p-0" style={{ height: virtual.paddingBottom }} />
-                  </tr>
-                ) : null}
-              </tbody>
-            </table>
+            <IndexPerformanceRowsTable
+              virtual={virtual}
+              shouldVirtualize={shouldVirtualize}
+              onIndexClick={onIndexClick}
+              lookbackDays={lookbackDays}
+            />
           )}
         </DataStateWrapper>
       </div>

--- a/apps/ts/packages/web/src/components/Ranking/RankingTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/RankingTable.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Rankings } from '@/types/ranking';
 import { RankingTable } from './RankingTable';
 
@@ -34,7 +34,26 @@ function createRankings(count: number): Rankings {
   };
 }
 
+function mockRankingMediaQuery(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+}
+
 describe('RankingTable', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
   it('renders trading value rows by default', () => {
     render(<RankingTable rankings={createRankings(5)} isLoading={false} error={null} onStockClick={vi.fn()} />);
     expect(screen.getByText('Company 1')).toBeInTheDocument();
@@ -56,6 +75,20 @@ describe('RankingTable', () => {
     await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: '30D High' }));
     expect(screen.getByText('Break %')).toBeInTheDocument();
+  });
+
+  it('renders mobile ranking cards and keeps stock navigation', async () => {
+    const user = userEvent.setup();
+    const onStockClick = vi.fn();
+    mockRankingMediaQuery(true);
+
+    render(<RankingTable rankings={createRankings(5)} isLoading={false} error={null} onStockClick={onStockClick} />);
+
+    expect(screen.queryByRole('columnheader', { name: 'Code' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /7000/ })).toHaveTextContent('Company 1');
+
+    await user.click(screen.getByRole('button', { name: /7000/ }));
+    expect(onStockClick).toHaveBeenCalledWith('7000');
   });
 
   it('calls onStockClick when row is clicked', async () => {

--- a/apps/ts/packages/web/src/components/Ranking/RankingTable.test.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/RankingTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Rankings } from '@/types/ranking';
@@ -89,6 +89,23 @@ describe('RankingTable', () => {
 
     await user.click(screen.getByRole('button', { name: /7000/ }));
     expect(onStockClick).toHaveBeenCalledWith('7000');
+  });
+
+  it('keeps mobile virtualized ranking cards scrollable for long lists', () => {
+    mockRankingMediaQuery(true);
+    const { container } = render(
+      <RankingTable rankings={createRankings(130)} isLoading={false} error={null} onStockClick={vi.fn()} />
+    );
+    const scrollArea = container.querySelector('.overflow-auto');
+
+    expect(scrollArea).not.toBeNull();
+    expect(screen.getByText('Company 1')).toBeInTheDocument();
+    expect(screen.queryByText('Company 130')).not.toBeInTheDocument();
+    expect(container.querySelector('[aria-hidden="true"][style*="height"]')).not.toBeNull();
+
+    fireEvent.scroll(scrollArea as Element, { target: { scrollTop: 128 * 125 } });
+
+    expect(screen.getByText('Company 130')).toBeInTheDocument();
   });
 
   it('calls onStockClick when row is clicked', async () => {

--- a/apps/ts/packages/web/src/components/Ranking/RankingTable.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/RankingTable.tsx
@@ -26,6 +26,7 @@ const rankingTabs: { id: RankingType; label: string; icon: typeof DollarSign }[]
 
 const VIRTUALIZATION_THRESHOLD = 120;
 const RANKING_ROW_HEIGHT = 36;
+const RANKING_CARD_ROW_HEIGHT = 128;
 const RANKING_VIEWPORT_HEIGHT = 520;
 
 function getIsMobileRankingLayout(): boolean {
@@ -106,7 +107,7 @@ function RankingCard({
     <button
       type="button"
       onClick={() => onStockClick(item.code)}
-      className="w-full rounded-2xl border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:bg-[var(--app-surface-muted)]"
+      className="min-h-[7.5rem] w-full rounded-2xl border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:bg-[var(--app-surface-muted)]"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
@@ -155,6 +156,99 @@ function RankingCard({
   );
 }
 
+interface RankingVirtualRows {
+  visibleItems: RankingItem[];
+  paddingTop: number;
+  paddingBottom: number;
+}
+
+function VirtualSpacer({ height }: { height: number }) {
+  if (height <= 0) return null;
+  return <div aria-hidden="true" className="shrink-0" style={{ height }} />;
+}
+
+function RankingCardList({
+  virtual,
+  shouldVirtualize,
+  onStockClick,
+  showChange,
+  isPeriodType,
+}: {
+  virtual: RankingVirtualRows;
+  shouldVirtualize: boolean;
+  onStockClick: (code: string) => void;
+  showChange: boolean;
+  isPeriodType: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      {shouldVirtualize ? <VirtualSpacer height={virtual.paddingTop} /> : null}
+      {virtual.visibleItems.map((item) => (
+        <RankingCard
+          key={`${item.code}-${item.rank}`}
+          item={item}
+          onStockClick={onStockClick}
+          showChange={showChange}
+          isPeriodType={isPeriodType}
+        />
+      ))}
+      {shouldVirtualize ? <VirtualSpacer height={virtual.paddingBottom} /> : null}
+    </div>
+  );
+}
+
+function RankingRowsTable({
+  virtual,
+  shouldVirtualize,
+  onStockClick,
+  showChange,
+  isPeriodType,
+  columnCount,
+}: {
+  virtual: RankingVirtualRows;
+  shouldVirtualize: boolean;
+  onStockClick: (code: string) => void;
+  showChange: boolean;
+  isPeriodType: boolean;
+  columnCount: number;
+}) {
+  return (
+    <table className="w-full text-xs">
+      <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
+        <tr>
+          <th className="text-center px-2 py-1.5 w-12">#</th>
+          <th className="text-left px-2 py-1.5 w-16">Code</th>
+          <th className="text-left px-2 py-1.5">Company</th>
+          <th className="text-left px-2 py-1.5 w-24">Sector</th>
+          <th className="text-right px-2 py-1.5 w-24">Price</th>
+          {showChange && <th className="text-right px-2 py-1.5 w-20">{isPeriodType ? 'Break %' : 'Change'}</th>}
+          <th className="text-right px-2 py-1.5 w-24">Trading Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {shouldVirtualize && virtual.paddingTop > 0 && (
+          <tr>
+            <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingTop }} />
+          </tr>
+        )}
+        {virtual.visibleItems.map((item) => (
+          <RankingRow
+            key={`${item.code}-${item.rank}`}
+            item={item}
+            onStockClick={onStockClick}
+            showChange={showChange}
+          />
+        ))}
+        {shouldVirtualize && virtual.paddingBottom > 0 && (
+          <tr>
+            <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingBottom }} />
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}
+
 export function RankingTable({ rankings, isLoading, error, onStockClick, periodDays }: RankingTableProps) {
   const [activeRankingType, setActiveRankingType] = useState<RankingType>('tradingValue');
   const isMobileRankingLayout = useIsMobileRankingLayout();
@@ -165,7 +259,7 @@ export function RankingTable({ rankings, isLoading, error, onStockClick, periodD
   const shouldVirtualize = currentItems.length >= VIRTUALIZATION_THRESHOLD;
   const virtual = useVirtualizedRows(currentItems, {
     enabled: shouldVirtualize,
-    rowHeight: RANKING_ROW_HEIGHT,
+    rowHeight: isMobileRankingLayout ? RANKING_CARD_ROW_HEIGHT : RANKING_ROW_HEIGHT,
     viewportHeight: RANKING_VIEWPORT_HEIGHT,
   });
   const columnCount = showChange ? 7 : 6;
@@ -216,51 +310,22 @@ export function RankingTable({ rankings, isLoading, error, onStockClick, periodD
           height="h-full min-h-[18rem]"
         >
           {isMobileRankingLayout ? (
-            <div className="space-y-2 p-3">
-              {virtual.visibleItems.map((item) => (
-                <RankingCard
-                  key={`${item.code}-${item.rank}`}
-                  item={item}
-                  onStockClick={onStockClick}
-                  showChange={showChange}
-                  isPeriodType={isPeriodType}
-                />
-              ))}
-            </div>
+            <RankingCardList
+              virtual={virtual}
+              shouldVirtualize={shouldVirtualize}
+              onStockClick={onStockClick}
+              showChange={showChange}
+              isPeriodType={isPeriodType}
+            />
           ) : (
-            <table className="w-full text-xs">
-              <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
-                <tr>
-                  <th className="text-center px-2 py-1.5 w-12">#</th>
-                  <th className="text-left px-2 py-1.5 w-16">Code</th>
-                  <th className="text-left px-2 py-1.5">Company</th>
-                  <th className="text-left px-2 py-1.5 w-24">Sector</th>
-                  <th className="text-right px-2 py-1.5 w-24">Price</th>
-                  {showChange && <th className="text-right px-2 py-1.5 w-20">{isPeriodType ? 'Break %' : 'Change'}</th>}
-                  <th className="text-right px-2 py-1.5 w-24">Trading Value</th>
-                </tr>
-              </thead>
-              <tbody>
-                {shouldVirtualize && virtual.paddingTop > 0 && (
-                  <tr>
-                    <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingTop }} />
-                  </tr>
-                )}
-                {virtual.visibleItems.map((item) => (
-                  <RankingRow
-                    key={`${item.code}-${item.rank}`}
-                    item={item}
-                    onStockClick={onStockClick}
-                    showChange={showChange}
-                  />
-                ))}
-                {shouldVirtualize && virtual.paddingBottom > 0 && (
-                  <tr>
-                    <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingBottom }} />
-                  </tr>
-                )}
-              </tbody>
-            </table>
+            <RankingRowsTable
+              virtual={virtual}
+              shouldVirtualize={shouldVirtualize}
+              onStockClick={onStockClick}
+              showChange={showChange}
+              isPeriodType={isPeriodType}
+              columnCount={columnCount}
+            />
           )}
         </DataStateWrapper>
       </div>

--- a/apps/ts/packages/web/src/components/Ranking/RankingTable.tsx
+++ b/apps/ts/packages/web/src/components/Ranking/RankingTable.tsx
@@ -1,5 +1,5 @@
 import { ArrowDownCircle, ArrowUpCircle, DollarSign, TrendingDown, TrendingUp } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SectionEyebrow, Surface } from '@/components/Layout/Workspace';
 import { DataStateWrapper } from '@/components/ui/data-state-wrapper';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -27,6 +27,29 @@ const rankingTabs: { id: RankingType; label: string; icon: typeof DollarSign }[]
 const VIRTUALIZATION_THRESHOLD = 120;
 const RANKING_ROW_HEIGHT = 36;
 const RANKING_VIEWPORT_HEIGHT = 520;
+
+function getIsMobileRankingLayout(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px)').matches
+  );
+}
+
+function useIsMobileRankingLayout(): boolean {
+  const [isMobileRankingLayout, setIsMobileRankingLayout] = useState(getIsMobileRankingLayout);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia('(max-width: 1023px)');
+    const updateLayout = () => setIsMobileRankingLayout(mediaQuery.matches);
+    updateLayout();
+    mediaQuery.addEventListener('change', updateLayout);
+    return () => mediaQuery.removeEventListener('change', updateLayout);
+  }, []);
+
+  return isMobileRankingLayout;
+}
 
 function RankingRow({
   item,
@@ -66,8 +89,75 @@ function RankingRow({
   );
 }
 
+function RankingCard({
+  item,
+  onStockClick,
+  showChange,
+  isPeriodType,
+}: {
+  item: RankingItem;
+  onStockClick: (code: string) => void;
+  showChange: boolean;
+  isPeriodType: boolean;
+}) {
+  const isPositive = (item.changePercentage ?? 0) >= 0;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onStockClick(item.code)}
+      className="w-full rounded-2xl border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:bg-[var(--app-surface-muted)]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="rounded-full bg-[var(--app-surface-muted)] px-2 py-0.5 text-[11px] font-semibold tabular-nums text-muted-foreground">
+              #{item.rank}
+            </span>
+            <span className="font-mono text-sm font-semibold text-primary">{item.code}</span>
+          </div>
+          <p className="mt-1 truncate text-sm font-semibold text-foreground">{item.companyName}</p>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.sector33Name}</p>
+        </div>
+        {showChange ? (
+          <span
+            className={cn(
+              'shrink-0 text-sm font-semibold tabular-nums',
+              isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+            )}
+          >
+            {formatPercentage(item.changePercentage)}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+        <div className="rounded-xl bg-[var(--app-surface-muted)] px-2.5 py-2">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Price</p>
+          <p className="mt-0.5 font-semibold tabular-nums text-foreground">{formatPriceJPY(item.currentPrice)}</p>
+        </div>
+        <div className="rounded-xl bg-[var(--app-surface-muted)] px-2.5 py-2">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            {showChange ? (isPeriodType ? 'Break' : 'Change') : 'Trading Value'}
+          </p>
+          <p className="mt-0.5 font-semibold tabular-nums text-foreground">
+            {showChange
+              ? formatPercentage(item.changePercentage)
+              : formatTradingValue(item.tradingValue ?? item.tradingValueAverage)}
+          </p>
+        </div>
+      </div>
+      {showChange ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Trading Value: {formatTradingValue(item.tradingValue ?? item.tradingValueAverage)}
+        </p>
+      ) : null}
+    </button>
+  );
+}
+
 export function RankingTable({ rankings, isLoading, error, onStockClick, periodDays }: RankingTableProps) {
   const [activeRankingType, setActiveRankingType] = useState<RankingType>('tradingValue');
+  const isMobileRankingLayout = useIsMobileRankingLayout();
 
   const currentItems = rankings?.[activeRankingType] ?? [];
   const showChange = activeRankingType !== 'tradingValue';
@@ -125,39 +215,53 @@ export function RankingTable({ rankings, isLoading, error, onStockClick, periodD
           emptyIcon={<TrendingUp className="h-8 w-8" />}
           height="h-full min-h-[18rem]"
         >
-          <table className="w-full text-xs">
-            <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
-              <tr>
-                <th className="text-center px-2 py-1.5 w-12">#</th>
-                <th className="text-left px-2 py-1.5 w-16">Code</th>
-                <th className="text-left px-2 py-1.5">Company</th>
-                <th className="text-left px-2 py-1.5 w-24">Sector</th>
-                <th className="text-right px-2 py-1.5 w-24">Price</th>
-                {showChange && <th className="text-right px-2 py-1.5 w-20">{isPeriodType ? 'Break %' : 'Change'}</th>}
-                <th className="text-right px-2 py-1.5 w-24">Trading Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              {shouldVirtualize && virtual.paddingTop > 0 && (
-                <tr>
-                  <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingTop }} />
-                </tr>
-              )}
+          {isMobileRankingLayout ? (
+            <div className="space-y-2 p-3">
               {virtual.visibleItems.map((item) => (
-                <RankingRow
+                <RankingCard
                   key={`${item.code}-${item.rank}`}
                   item={item}
                   onStockClick={onStockClick}
                   showChange={showChange}
+                  isPeriodType={isPeriodType}
                 />
               ))}
-              {shouldVirtualize && virtual.paddingBottom > 0 && (
+            </div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 z-10 border-b bg-[var(--app-surface-muted)]">
                 <tr>
-                  <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingBottom }} />
+                  <th className="text-center px-2 py-1.5 w-12">#</th>
+                  <th className="text-left px-2 py-1.5 w-16">Code</th>
+                  <th className="text-left px-2 py-1.5">Company</th>
+                  <th className="text-left px-2 py-1.5 w-24">Sector</th>
+                  <th className="text-right px-2 py-1.5 w-24">Price</th>
+                  {showChange && <th className="text-right px-2 py-1.5 w-20">{isPeriodType ? 'Break %' : 'Change'}</th>}
+                  <th className="text-right px-2 py-1.5 w-24">Trading Value</th>
                 </tr>
-              )}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {shouldVirtualize && virtual.paddingTop > 0 && (
+                  <tr>
+                    <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingTop }} />
+                  </tr>
+                )}
+                {virtual.visibleItems.map((item) => (
+                  <RankingRow
+                    key={`${item.code}-${item.rank}`}
+                    item={item}
+                    onStockClick={onStockClick}
+                    showChange={showChange}
+                  />
+                ))}
+                {shouldVirtualize && virtual.paddingBottom > 0 && (
+                  <tr>
+                    <td colSpan={columnCount} className="p-0" style={{ height: virtual.paddingBottom }} />
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          )}
         </DataStateWrapper>
       </div>
     </Surface>

--- a/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.test.tsx
+++ b/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.test.tsx
@@ -40,7 +40,7 @@ describe('ValueCompositeRankingFilters', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'FY EPS' }));
+    await user.click(screen.getByRole('button', { name: 'FY-only EPS' }));
 
     expect(onChange).toHaveBeenCalledWith({
       markets: 'standard',

--- a/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.test.tsx
+++ b/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.test.tsx
@@ -23,4 +23,30 @@ describe('ValueCompositeRankingFilters', () => {
       scoreMethod: 'equal_weight',
     });
   });
+
+  it('changes forward EPS basis with the segmented toggle', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <ValueCompositeRankingFilters
+        params={{
+          markets: 'standard',
+          limit: 50,
+          scoreMethod: 'walkforward_regression_weight',
+          forwardEpsMode: 'latest',
+        }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'FY EPS' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      markets: 'standard',
+      limit: 50,
+      scoreMethod: 'walkforward_regression_weight',
+      forwardEpsMode: 'fy',
+    });
+  });
 });

--- a/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.tsx
+++ b/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.tsx
@@ -1,6 +1,10 @@
 import { SectionEyebrow, SegmentedTabs, Surface } from '@/components/Layout/Workspace';
 import { DateInput, MarketsSelect, NumberSelect } from '@/components/shared/filters';
-import type { ValueCompositeRankingParams, ValueCompositeScoreMethod } from '@/types/valueCompositeRanking';
+import type {
+  ValueCompositeForwardEpsMode,
+  ValueCompositeRankingParams,
+  ValueCompositeScoreMethod,
+} from '@/types/valueCompositeRanking';
 
 const VALUE_COMPOSITE_MARKET_OPTIONS = [
   { value: 'standard', label: 'Standard' },
@@ -18,6 +22,11 @@ const LIMIT_OPTIONS = [
 const SCORE_METHOD_OPTIONS = [
   { value: 'walkforward_regression_weight' as ValueCompositeScoreMethod, label: 'Walk-forward' },
   { value: 'equal_weight' as ValueCompositeScoreMethod, label: 'Equal weight' },
+];
+
+const FORWARD_EPS_MODE_OPTIONS = [
+  { value: 'latest' as ValueCompositeForwardEpsMode, label: 'Latest EPS' },
+  { value: 'fy' as ValueCompositeForwardEpsMode, label: 'FY EPS' },
 ];
 
 interface ValueCompositeRankingFiltersProps {
@@ -47,6 +56,19 @@ export function ValueCompositeRankingFilters({ params, onChange }: ValueComposit
             className="grid grid-cols-2 gap-1"
             itemClassName="h-8 justify-center rounded-lg px-2 py-1.5 text-xs"
           />
+        </div>
+        <div className="space-y-2">
+          <SectionEyebrow className="mb-0">Forward EPS Basis</SectionEyebrow>
+          <SegmentedTabs
+            items={FORWARD_EPS_MODE_OPTIONS}
+            value={params.forwardEpsMode ?? 'latest'}
+            onChange={(forwardEpsMode) => updateParam('forwardEpsMode', forwardEpsMode)}
+            className="grid grid-cols-2 gap-1"
+            itemClassName="h-8 justify-center rounded-lg px-2 py-1.5 text-xs"
+          />
+          <p className="text-xs text-muted-foreground">
+            Latest EPS uses revised quarterly forecasts when available; FY EPS pins the latest FY forecast.
+          </p>
         </div>
         <MarketsSelect
           value={params.markets || 'standard'}

--- a/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.tsx
+++ b/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingFilters.tsx
@@ -25,8 +25,8 @@ const SCORE_METHOD_OPTIONS = [
 ];
 
 const FORWARD_EPS_MODE_OPTIONS = [
-  { value: 'latest' as ValueCompositeForwardEpsMode, label: 'Latest EPS' },
-  { value: 'fy' as ValueCompositeForwardEpsMode, label: 'FY EPS' },
+  { value: 'latest' as ValueCompositeForwardEpsMode, label: 'Latest revised EPS' },
+  { value: 'fy' as ValueCompositeForwardEpsMode, label: 'FY-only EPS' },
 ];
 
 interface ValueCompositeRankingFiltersProps {
@@ -67,7 +67,8 @@ export function ValueCompositeRankingFilters({ params, onChange }: ValueComposit
             itemClassName="h-8 justify-center rounded-lg px-2 py-1.5 text-xs"
           />
           <p className="text-xs text-muted-foreground">
-            Latest EPS uses revised quarterly forecasts when available; FY EPS pins the latest FY forecast.
+            Latest revised EPS matches the previous default: revised quarterly forecasts when available, otherwise FY.
+            FY-only pins the latest FY forecast.
           </p>
         </div>
         <MarketsSelect

--- a/apps/ts/packages/web/src/hooks/useValueCompositeRanking.ts
+++ b/apps/ts/packages/web/src/hooks/useValueCompositeRanking.ts
@@ -1,9 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { analyticsClient } from '@/lib/analytics-client';
-import type {
-  ValueCompositeRankingParams,
-  ValueCompositeRankingResponse,
-} from '@/types/valueCompositeRanking';
+import type { ValueCompositeRankingParams, ValueCompositeRankingResponse } from '@/types/valueCompositeRanking';
 import { logger } from '@/utils/logger';
 
 function fetchValueCompositeRanking(params: ValueCompositeRankingParams): Promise<ValueCompositeRankingResponse> {
@@ -12,6 +9,7 @@ function fetchValueCompositeRanking(params: ValueCompositeRankingParams): Promis
     limit: params.limit,
     markets: params.markets,
     scoreMethod: params.scoreMethod,
+    forwardEpsMode: params.forwardEpsMode,
   };
 
   logger.debug('Fetching value composite ranking data', { query });

--- a/apps/ts/packages/web/src/lib/routeSearch.test.ts
+++ b/apps/ts/packages/web/src/lib/routeSearch.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractLegacyBacktestSearch,
-  extractLegacySymbolWorkbenchSearch,
   extractLegacyIndicesSearch,
   extractLegacyPortfolioSearch,
   extractLegacyScreeningSearch,
+  extractLegacySymbolWorkbenchSearch,
   getRankingStateFromScreeningSearch,
   getRankingStateFromSearch,
   getScreeningStateFromSearch,
@@ -14,17 +14,17 @@ import {
   serializeIndicesSearch,
   serializeOptions225Search,
   serializePortfolioSearch,
-  serializeResearchSearch,
   serializeRankingSearch,
+  serializeResearchSearch,
   serializeScreeningSearch,
   validateBacktestSearch,
-  validateSymbolWorkbenchSearch,
   validateIndicesSearch,
   validateOptions225Search,
   validatePortfolioSearch,
-  validateResearchSearch,
   validateRankingSearch,
+  validateResearchSearch,
   validateScreeningSearch,
+  validateSymbolWorkbenchSearch,
 } from './routeSearch';
 
 function createMemoryStorage(initial: Record<string, string> = {}): Storage {
@@ -281,6 +281,7 @@ describe('routeSearch', () => {
       valueMarkets: 'standard',
       valueLimit: '100',
       valueScoreMethod: 'equal_weight',
+      valueForwardEpsMode: 'fy',
     });
 
     const rankingState = getRankingStateFromSearch(rankingSearch);
@@ -291,12 +292,14 @@ describe('routeSearch', () => {
       markets: 'standard',
       limit: 100,
       scoreMethod: 'equal_weight',
+      forwardEpsMode: 'fy',
     });
     expect(serializeRankingSearch(rankingState)).toEqual({
       tab: 'valueComposite',
       valueDate: '2026-04-24',
       valueLimit: 100,
       valueScoreMethod: 'equal_weight',
+      valueForwardEpsMode: 'fy',
     });
   });
 

--- a/apps/ts/packages/web/src/lib/routeSearch.ts
+++ b/apps/ts/packages/web/src/lib/routeSearch.ts
@@ -18,14 +18,18 @@ import type {
   RankingDailyView,
   RankingPageTab,
   RankingParams,
-  Topix100PriceSmaWindow,
-  Topix100RankingSortKey,
-  Topix100RankingMetric,
-  Topix100StudyMode,
   Topix100PriceBucketFilter,
+  Topix100PriceSmaWindow,
+  Topix100RankingMetric,
+  Topix100RankingSortKey,
+  Topix100StudyMode,
 } from '@/types/ranking';
 import type { ScreeningParams } from '@/types/screening';
-import type { ValueCompositeRankingParams, ValueCompositeScoreMethod } from '@/types/valueCompositeRanking';
+import type {
+  ValueCompositeForwardEpsMode,
+  ValueCompositeRankingParams,
+  ValueCompositeScoreMethod,
+} from '@/types/valueCompositeRanking';
 
 export type PortfolioSubTab = 'portfolios' | 'watchlists';
 
@@ -115,6 +119,7 @@ export interface RankingRouteSearch {
   valueLimit?: number;
   valueMarkets?: string;
   valueScoreMethod?: ValueCompositeScoreMethod;
+  valueForwardEpsMode?: ValueCompositeForwardEpsMode;
 }
 
 export interface BacktestRouteSearch {
@@ -141,6 +146,7 @@ const VALUE_COMPOSITE_SCORE_METHOD_VALUES: ValueCompositeScoreMethod[] = [
   'equal_weight',
   'walkforward_regression_weight',
 ];
+const VALUE_COMPOSITE_FORWARD_EPS_MODE_VALUES: ValueCompositeForwardEpsMode[] = ['latest', 'fy'];
 const RANKING_DAILY_VIEWS: RankingDailyView[] = ['stocks', 'indices', 'topix100'];
 const LEGACY_TOPIX100_RANKING_METRIC = 'price_vs_sma20_gap';
 const TOPIX100_STUDY_MODE_VALUES: Topix100StudyMode[] = ['intraday', 'swing_5d'];
@@ -268,6 +274,10 @@ function normalizeRankingDailyView(value: unknown): RankingDailyView | undefined
 
 function normalizeValueCompositeScoreMethod(value: unknown): ValueCompositeScoreMethod | undefined {
   return normalizeEnum(normalizeString(value), VALUE_COMPOSITE_SCORE_METHOD_VALUES);
+}
+
+function normalizeValueCompositeForwardEpsMode(value: unknown): ValueCompositeForwardEpsMode | undefined {
+  return normalizeEnum(normalizeString(value), VALUE_COMPOSITE_FORWARD_EPS_MODE_VALUES);
 }
 
 function normalizeTopix100PriceBucketFilter(value: unknown): Topix100PriceBucketFilter | undefined {
@@ -707,6 +717,7 @@ export function getRankingStateFromSearch(search: RankingRouteSearch): {
       ['limit', search.valueLimit],
       ['markets', search.valueMarkets],
       ['scoreMethod', search.valueScoreMethod],
+      ['forwardEpsMode', search.valueForwardEpsMode],
     ]),
   };
 }
@@ -927,6 +938,7 @@ export function validateRankingSearch(search: Record<string, unknown>): RankingR
   assignIfDefined(next, 'valueLimit', normalizePositiveInt(search.valueLimit));
   assignIfDefined(next, 'valueMarkets', normalizeString(search.valueMarkets));
   assignIfDefined(next, 'valueScoreMethod', normalizeValueCompositeScoreMethod(search.valueScoreMethod));
+  assignIfDefined(next, 'valueForwardEpsMode', normalizeValueCompositeForwardEpsMode(search.valueForwardEpsMode));
   return next;
 }
 
@@ -1047,6 +1059,12 @@ export function serializeRankingSearch(state: {
     'valueScoreMethod',
     state.valueCompositeRankingParams.scoreMethod,
     DEFAULT_VALUE_COMPOSITE_RANKING_PARAMS.scoreMethod
+  );
+  assignIfDefinedAndNotDefault(
+    next,
+    'valueForwardEpsMode',
+    state.valueCompositeRankingParams.forwardEpsMode,
+    DEFAULT_VALUE_COMPOSITE_RANKING_PARAMS.forwardEpsMode
   );
 
   return next;

--- a/apps/ts/packages/web/src/pages/RankingPage.tsx
+++ b/apps/ts/packages/web/src/pages/RankingPage.tsx
@@ -60,6 +60,10 @@ function getValueCompositeScoreMethodLabel(method: ValueCompositeScoreMethod | u
   return method === 'equal_weight' ? 'Equal-weight value score' : 'Walk-forward value score';
 }
 
+function getValueCompositeForwardEpsModeLabel(mode: ValueCompositeRankingParams['forwardEpsMode']): string {
+  return mode === 'fy' ? 'FY forecast EPS' : 'Latest revised forward EPS';
+}
+
 interface RankingSidebarProps {
   activeSubTab: RankingPageTab;
   activeDailyView: RankingDailyView;
@@ -201,6 +205,7 @@ function buildIntroMetaItems(
   if (activeSubTab === 'valueComposite') {
     return [
       { label: 'Mode', value: getValueCompositeScoreMethodLabel(valueCompositeRankingParams.scoreMethod) },
+      { label: 'EPS Basis', value: getValueCompositeForwardEpsModeLabel(valueCompositeRankingParams.forwardEpsMode) },
       { label: 'Markets', value: formatMarketsLabel((valueCompositeRankingParams.markets ?? 'standard').split(',')) },
     ];
   }

--- a/apps/ts/packages/web/src/pages/RankingPage.tsx
+++ b/apps/ts/packages/web/src/pages/RankingPage.tsx
@@ -61,7 +61,7 @@ function getValueCompositeScoreMethodLabel(method: ValueCompositeScoreMethod | u
 }
 
 function getValueCompositeForwardEpsModeLabel(mode: ValueCompositeRankingParams['forwardEpsMode']): string {
-  return mode === 'fy' ? 'FY forecast EPS' : 'Latest revised forward EPS';
+  return mode === 'fy' ? 'FY-only forecast EPS' : 'Latest revised EPS (previous default)';
 }
 
 interface RankingSidebarProps {

--- a/apps/ts/packages/web/src/pages/RankingPage.tsx
+++ b/apps/ts/packages/web/src/pages/RankingPage.tsx
@@ -28,12 +28,12 @@ import {
   resolveTopix100PriceSmaWindow,
   resolveTopix100RankingMetric,
 } from '@/components/Ranking/topix100RankingMetric';
+import { DateInput, NumberSelect } from '@/components/shared/filters';
 import {
   ValueCompositeRankingFilters,
   ValueCompositeRankingSummary,
   ValueCompositeRankingTable,
 } from '@/components/ValueCompositeRanking';
-import { DateInput, NumberSelect } from '@/components/shared/filters';
 import { useFundamentalRanking } from '@/hooks/useFundamentalRanking';
 import { useRankingRouteState } from '@/hooks/usePageRouteState';
 import { useRanking } from '@/hooks/useRanking';
@@ -150,8 +150,8 @@ function RankingSidebar({
             items={subTabs}
             value={activeSubTab}
             onChange={setActiveSubTab}
-            className="flex-col"
-            itemClassName="h-8 justify-start rounded-lg px-3 py-1.5 text-xs"
+            className="overflow-x-auto lg:flex-col"
+            itemClassName="h-8 shrink-0 justify-start rounded-lg px-3 py-1.5 text-xs"
           />
           {activeSubTab === 'ranking' ? (
             <div className="space-y-2 border-t border-border/60 pt-3">
@@ -160,8 +160,8 @@ function RankingSidebar({
                 items={dailyViewTabs}
                 value={activeDailyView}
                 onChange={setActiveDailyView}
-                className="flex-col"
-                itemClassName="h-8 justify-start rounded-lg px-3 py-1.5 text-xs"
+                className="overflow-x-auto lg:flex-col"
+                itemClassName="h-8 shrink-0 justify-start rounded-lg px-3 py-1.5 text-xs"
               />
             </div>
           ) : null}
@@ -177,10 +177,7 @@ function RankingSidebar({
           <RankingFilters params={rankingParams} onChange={setRankingParams} />
         )
       ) : activeSubTab === 'valueComposite' ? (
-        <ValueCompositeRankingFilters
-          params={valueCompositeRankingParams}
-          onChange={setValueCompositeRankingParams}
-        />
+        <ValueCompositeRankingFilters params={valueCompositeRankingParams} onChange={setValueCompositeRankingParams} />
       ) : (
         <FundamentalRankingFilters params={fundamentalRankingParams} onChange={setFundamentalRankingParams} />
       )}
@@ -399,7 +396,7 @@ export function RankingPage() {
         </div>
       </Surface>
 
-      <SplitLayout className="min-h-0 flex-1 flex-col gap-3 lg:flex-row lg:items-stretch">
+      <SplitLayout className="min-h-0 flex-1 flex-col gap-3 lg:flex-row lg:items-stretch lg:overflow-hidden">
         <SplitSidebar className="w-full lg:h-full lg:w-40 lg:overflow-auto xl:w-44 2xl:w-48">
           <RankingSidebar
             activeSubTab={activeSubTab}

--- a/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.test.tsx
@@ -120,6 +120,21 @@ const mockSettings = {
     'marginPressure',
     'factorRegression',
   ],
+  workbenchPanelOrder: [
+    'ppo',
+    'riskAdjustedReturn',
+    'recentReturn',
+    'volumeComparison',
+    'cmf',
+    'chaikinOscillator',
+    'obvFlowScore',
+    'tradingValueMA',
+    'fundamentals',
+    'fundamentalsHistory',
+    'costStructure',
+    'marginPressure',
+    'factorRegression',
+  ],
   fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
   fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
   fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
@@ -299,6 +314,21 @@ describe('SymbolWorkbenchPage', () => {
     mockSettings.showMarginPressurePanel = true;
     mockSettings.showFactorRegressionPanel = true;
     mockSettings.fundamentalsPanelOrder = [
+      'fundamentals',
+      'fundamentalsHistory',
+      'costStructure',
+      'marginPressure',
+      'factorRegression',
+    ];
+    mockSettings.workbenchPanelOrder = [
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
       'fundamentals',
       'fundamentalsHistory',
       'costStructure',
@@ -748,6 +778,21 @@ describe('SymbolWorkbenchPage', () => {
 
   it('renders panel sections based on configured order', () => {
     mockSettings.fundamentalsPanelOrder = [
+      'marginPressure',
+      'fundamentalsHistory',
+      'factorRegression',
+      'costStructure',
+      'fundamentals',
+    ];
+    mockSettings.workbenchPanelOrder = [
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
       'marginPressure',
       'fundamentalsHistory',
       'factorRegression',

--- a/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.test.tsx
+++ b/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.test.tsx
@@ -526,7 +526,7 @@ describe('SymbolWorkbenchPage', () => {
     renderSymbolWorkbenchPage();
 
     expect(screen.getByRole('button', { name: /Stock Refresh/i })).toBeInTheDocument();
-    expect(screen.getByText('Stock Chart')).toBeInTheDocument();
+    expect(screen.getAllByText('Stock Chart').length).toBeGreaterThan(0);
     expect(screen.getByText('PPO Chart')).toBeInTheDocument();
     expect(screen.getByText('Recent Return Chart')).toBeInTheDocument();
     expect(screen.getByText('Risk Adjusted Return Chart')).toBeInTheDocument();
@@ -555,6 +555,30 @@ describe('SymbolWorkbenchPage', () => {
       symbol: '7203',
       enabled: false,
     });
+  });
+
+  it('opens chart controls from the mobile settings action', () => {
+    mockUseMultiTimeframeChart.mockReturnValue({
+      chartData: {
+        daily: {
+          candlestickData: [{ time: '2024-01-01', open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }],
+          indicators: { atrSupport: [], nBarSupport: [], ppo: [] },
+          bollingerBands: [],
+          volumeComparison: [],
+          tradingValueMA: [],
+        },
+      },
+      isLoading: false,
+      error: null,
+      selectedSymbol: '7203',
+    });
+
+    renderSymbolWorkbenchPage();
+
+    fireEvent.click(screen.getByRole('button', { name: '設定' }));
+
+    expect(screen.getByRole('dialog', { name: 'Symbol Workbench Settings' })).toBeInTheDocument();
+    expect(screen.getAllByText('Chart Controls').length).toBeGreaterThan(1);
   });
 
   it('passes screening verification context into chart rendering and symbol changes', async () => {
@@ -589,8 +613,8 @@ describe('SymbolWorkbenchPage', () => {
     renderSymbolWorkbenchPage();
 
     expect(mockUseMultiTimeframeChart).toHaveBeenCalledWith('7203', 'production/demo');
-    expect(screen.getByText('production/demo (strategy)')).toBeInTheDocument();
-    expect(screen.getByText('2026-03-14')).toBeInTheDocument();
+    expect(screen.getAllByText('production/demo (strategy)').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('2026-03-14').length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole('button', { name: 'Select 6758' }));
 

--- a/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
+++ b/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
@@ -21,6 +21,7 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { SectionEyebrow, SplitLayout, SplitMain, SplitSidebar, Surface } from '@/components/Layout/Workspace';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { countVisibleFundamentalMetrics, resolveFundamentalsPanelHeightPx } from '@/constants/fundamentalMetrics';
 import { useBtMarginIndicators } from '@/hooks/useBtMarginIndicators';
 import { useRefreshStocks } from '@/hooks/useDbSync';
@@ -1184,25 +1185,21 @@ function SymbolWorkbenchPanelsContent({
                 {activeMobilePanel?.kind ?? 'Primary'}
               </p>
             </div>
-            <fieldset className="flex snap-x gap-2 overflow-x-auto pb-1">
-              <legend className="sr-only">Workbench panels</legend>
-              {panelOptions.map((option) => {
-                const isActive = option.id === activeMobilePanelId;
-                return (
-                  <Button
-                    key={option.id}
-                    type="button"
-                    variant={isActive ? 'default' : 'outline'}
-                    size="sm"
-                    className="shrink-0 snap-start"
-                    aria-pressed={isActive}
-                    onClick={() => setActiveMobilePanelId(option.id)}
-                  >
-                    {option.label}
-                  </Button>
-                );
-              })}
-            </fieldset>
+            <Select
+              value={activeMobilePanel?.id ?? 'primary'}
+              onValueChange={(value) => setActiveMobilePanelId(value as WorkbenchDisplayPanelId)}
+            >
+              <SelectTrigger aria-label="Workbench panel">
+                <SelectValue placeholder="Select panel" />
+              </SelectTrigger>
+              <SelectContent>
+                {panelOptions.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.label} · {option.kind}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </Surface>
 
           {!activeMobilePanel || activeMobilePanel.id === 'primary'

--- a/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
+++ b/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
@@ -174,9 +174,9 @@ function ChartHeaderInfoField({ label, value }: { label: string; value: string }
 
 function ChartHeaderMetaChip({ label, value }: { label: string; value: string }) {
   return (
-    <div className="inline-flex items-center gap-2 text-xs">
-      <span className="uppercase tracking-[0.14em] text-muted-foreground">{label}</span>
-      <span className="font-medium text-foreground">{value}</span>
+    <div className="flex min-w-0 items-center gap-2 text-xs">
+      <span className="shrink-0 uppercase tracking-[0.14em] text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate font-medium text-foreground">{value}</span>
     </div>
   );
 }
@@ -1316,12 +1316,12 @@ export function SymbolWorkbenchPage() {
       ) : null}
 
       <Dialog open={isMobileSettingsOpen} onOpenChange={setIsMobileSettingsOpen}>
-        <DialogContent className="h-[calc(100dvh-1.5rem)] max-h-none max-w-none translate-y-[-50%] overflow-hidden p-0 sm:max-w-lg sm:rounded-lg lg:hidden">
+        <DialogContent className="flex h-[calc(100dvh-1.5rem)] max-h-none max-w-none translate-y-[-50%] flex-col overflow-hidden p-0 sm:max-w-lg sm:rounded-lg lg:hidden">
           <DialogHeader className="border-b border-border/60 px-4 py-3 text-left">
             <DialogTitle>Symbol Workbench Settings</DialogTitle>
             <DialogDescription>Search, chart settings, panel order, and signal controls.</DialogDescription>
           </DialogHeader>
-          <div className="min-h-0 overflow-y-auto">
+          <div className="min-h-0 flex-1 overflow-y-auto">
             <ChartControls selectedSymbol={selectedSymbol} onSelectSymbol={(symbol) => setSelectedSymbol(symbol)} />
           </div>
         </DialogContent>

--- a/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
+++ b/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import type { DataProvenance, ResponseDiagnostics } from '@trading25/contracts/types/api-types';
-import { AlertCircle, BookOpen, Loader2, RotateCcw, TrendingUp, Wallet } from 'lucide-react';
+import { AlertCircle, BookOpen, Loader2, RotateCcw, SettingsIcon, TrendingUp, Wallet } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChartControls } from '@/components/Chart/ChartControls';
 import { CostStructurePanel } from '@/components/Chart/CostStructurePanel';
@@ -20,6 +20,7 @@ import { VolumeComparisonChart } from '@/components/Chart/VolumeComparisonChart'
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { SectionEyebrow, SplitLayout, SplitMain, SplitSidebar, Surface } from '@/components/Layout/Workspace';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { countVisibleFundamentalMetrics, resolveFundamentalsPanelHeightPx } from '@/constants/fundamentalMetrics';
 import { useBtMarginIndicators } from '@/hooks/useBtMarginIndicators';
 import { useRefreshStocks } from '@/hooks/useDbSync';
@@ -49,6 +50,7 @@ import { formatMarketCap } from '@/utils/formatters';
 import { logger } from '@/utils/logger';
 
 type ChartSettings = ReturnType<typeof useChartStore.getState>['settings'];
+type WorkbenchDisplayPanelId = 'primary' | WorkbenchPanelId;
 
 interface LazySectionState {
   sectionRef: (node: HTMLDivElement | null) => void;
@@ -73,6 +75,64 @@ interface ChartRefreshFeedback {
 interface ChartHeaderMarketCaps {
   freeFloat: number | null;
   issuedShares: number | null;
+}
+
+interface WorkbenchPanelOption {
+  id: WorkbenchDisplayPanelId;
+  label: string;
+  kind: 'Primary' | 'Sub-chart' | 'Panel';
+}
+
+const WORKBENCH_PANEL_LABELS: Record<WorkbenchPanelId, string> = {
+  ppo: 'PPO',
+  riskAdjustedReturn: 'Risk',
+  recentReturn: 'Recent',
+  volumeComparison: 'Volume',
+  cmf: 'CMF',
+  chaikinOscillator: 'Chaikin',
+  obvFlowScore: 'OBV',
+  tradingValueMA: 'Trading Value',
+  fundamentals: 'Fundamentals',
+  fundamentalsHistory: 'FY History',
+  costStructure: 'Cost',
+  marginPressure: 'Margin',
+  factorRegression: 'Factor',
+};
+
+function isSubChartPanel(panelId: WorkbenchPanelId): boolean {
+  return (
+    panelId === 'ppo' ||
+    panelId === 'riskAdjustedReturn' ||
+    panelId === 'recentReturn' ||
+    panelId === 'volumeComparison' ||
+    panelId === 'cmf' ||
+    panelId === 'chaikinOscillator' ||
+    panelId === 'obvFlowScore' ||
+    panelId === 'tradingValueMA'
+  );
+}
+
+function getIsMobileWorkbenchLayout(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px)').matches
+  );
+}
+
+function useIsMobileWorkbenchLayout(): boolean {
+  const [isMobileWorkbenchLayout, setIsMobileWorkbenchLayout] = useState(getIsMobileWorkbenchLayout);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia('(max-width: 1023px)');
+    const updateLayout = () => setIsMobileWorkbenchLayout(mediaQuery.matches);
+    updateLayout();
+    mediaQuery.addEventListener('change', updateLayout);
+    return () => mediaQuery.removeEventListener('change', updateLayout);
+  }, []);
+
+  return isMobileWorkbenchLayout;
 }
 
 function formatDisplayTimeframeLabel(timeframe: ChartSettings['displayTimeframe']): string {
@@ -362,6 +422,52 @@ function resolveFundamentalPanelVisibility(settings: ChartSettings): Record<Fund
   };
 }
 
+function isWorkbenchPanelVisible(
+  panelId: WorkbenchPanelId,
+  settings: ChartSettings,
+  panelVisibilityById: Record<FundamentalsPanelId, boolean>
+): boolean {
+  switch (panelId) {
+    case 'ppo':
+      return settings.showPPOChart;
+    case 'riskAdjustedReturn':
+      return settings.showRiskAdjustedReturnChart;
+    case 'recentReturn':
+      return settings.showRecentReturnChart;
+    case 'volumeComparison':
+      return settings.showVolumeComparison;
+    case 'cmf':
+      return settings.showCMF;
+    case 'chaikinOscillator':
+      return settings.showChaikinOscillator;
+    case 'obvFlowScore':
+      return settings.showOBVFlowScore;
+    case 'tradingValueMA':
+      return settings.showTradingValueMA;
+    default:
+      return panelVisibilityById[panelId];
+  }
+}
+
+function buildWorkbenchPanelOptions(
+  settings: ChartSettings,
+  panelVisibilityById: Record<FundamentalsPanelId, boolean>
+): WorkbenchPanelOption[] {
+  const workbenchPanelOrder = settings.workbenchPanelOrder ?? DEFAULT_WORKBENCH_PANEL_ORDER;
+  return [
+    { id: 'primary', label: 'Primary', kind: 'Primary' },
+    ...workbenchPanelOrder
+      .filter((panelId) => isWorkbenchPanelVisible(panelId, settings, panelVisibilityById))
+      .map(
+        (panelId): WorkbenchPanelOption => ({
+          id: panelId,
+          label: WORKBENCH_PANEL_LABELS[panelId],
+          kind: isSubChartPanel(panelId) ? 'Sub-chart' : 'Panel',
+        })
+      ),
+  ];
+}
+
 function renderOrderedPanelSection({
   panelId,
   selectedSymbol,
@@ -627,6 +733,7 @@ function ChartHeader({
   refreshFeedback,
   isRefreshing,
   onRefresh,
+  onOpenMobileSettings,
 }: {
   settings: ChartSettings;
   selectedSymbol: string;
@@ -640,6 +747,7 @@ function ChartHeader({
   refreshFeedback: ChartRefreshFeedback | null;
   isRefreshing: boolean;
   onRefresh: () => void;
+  onOpenMobileSettings: () => void;
 }) {
   const mergedLoadedDomains = mergeUniqueStrings(
     signalProvenance?.loaded_domains,
@@ -656,16 +764,16 @@ function ChartHeader({
 
   return (
     <div className="space-y-3">
-      <Surface className="px-5 py-4">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+      <Surface className="px-3 py-3 sm:px-5 sm:py-4">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
           <div className="min-w-0 space-y-3">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[var(--app-surface-muted)] text-primary">
+            <div className="flex items-center gap-2 sm:gap-3">
+              <div className="hidden h-10 w-10 items-center justify-center rounded-2xl bg-[var(--app-surface-muted)] text-primary sm:flex">
                 <TrendingUp className="h-5 w-5" />
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 flex-1">
                 <SectionEyebrow>Symbol Workbench</SectionEyebrow>
-                <h2 className="truncate text-2xl font-semibold tracking-tight text-foreground">
+                <h2 className="truncate text-lg font-semibold tracking-tight text-foreground sm:text-2xl">
                   {selectedSymbol}
                   {stockInfo?.companyName && (
                     <span className="ml-2 font-medium text-foreground">{stockInfo.companyName}</span>
@@ -673,13 +781,27 @@ function ChartHeader({
                   {settings.relativeMode && <span className="font-medium text-muted-foreground"> / TOPIX</span>}
                 </h2>
               </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 lg:hidden"
+                onClick={onOpenMobileSettings}
+              >
+                <SettingsIcon className="mr-1 h-4 w-4" />
+                設定
+              </Button>
             </div>
 
-            <div className="flex flex-wrap gap-x-5 gap-y-2">
+            <div className="hidden flex-wrap gap-x-5 gap-y-2 sm:flex">
               <ChartHeaderMetaChip label="Overlay" value={overlayLabel} />
               <ChartHeaderMetaChip label="Matched Date" value={formatOptionalDate(matchedDate)} />
               <ChartHeaderMetaChip label="Market Snapshot" value={marketSnapshotId} />
               <ChartHeaderMetaChip label="Signal Domains" value={formatList(mergedLoadedDomains)} />
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-xs sm:hidden">
+              <ChartHeaderMetaChip label="Overlay" value={overlayLabel} />
+              <ChartHeaderMetaChip label="Date" value={formatOptionalDate(matchedDate)} />
             </div>
           </div>
 
@@ -687,6 +809,7 @@ function ChartHeader({
             <Button
               variant="outline"
               size="sm"
+              className="hidden sm:inline-flex"
               onClick={() => openCompanyPage('https://shikiho.toyokeizai.net/stocks/', selectedSymbol)}
               title="四季報を開く"
             >
@@ -696,13 +819,20 @@ function ChartHeader({
             <Button
               variant="outline"
               size="sm"
+              className="hidden sm:inline-flex"
               onClick={() => openCompanyPage('https://www.buffett-code.com/company/', selectedSymbol, '/')}
               title="Buffett Codeを開く"
             >
               <Wallet className="mr-1 h-4 w-4" />
               B.C.
             </Button>
-            <Button variant="outline" size="sm" onClick={onRefresh} disabled={isRefreshing}>
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1 sm:flex-none"
+              onClick={onRefresh}
+              disabled={isRefreshing}
+            >
               {isRefreshing ? (
                 <>
                   <Loader2 className="mr-1 h-4 w-4 animate-spin" />
@@ -719,7 +849,7 @@ function ChartHeader({
           </div>
         </div>
 
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:mt-4 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3 xl:grid-cols-6">
           <ChartHeaderInfoField label="市場" value={formatMarketLabel(stockInfo)} />
           <ChartHeaderInfoField label="指数採用" value={formatScaleCategoryLabel(stockInfo?.scaleCategory)} />
           <ChartHeaderInfoField label="セクター17" value={stockInfo?.sector17Name || '-'} />
@@ -932,6 +1062,46 @@ function renderOrderedWorkbenchSection({
   }
 }
 
+function renderPrimaryChartSection({
+  settings,
+  chartData,
+  signalMarkers,
+  mobile = false,
+}: {
+  settings: ChartSettings;
+  chartData: ReturnType<typeof useMultiTimeframeChart>['chartData'];
+  signalMarkers: ReturnType<typeof useMultiTimeframeChart>['signalMarkers'];
+  mobile?: boolean;
+}) {
+  return (
+    <Surface
+      className={cn(
+        'overflow-hidden',
+        mobile ? 'h-[min(58dvh,34rem)] min-h-[26rem]' : 'min-h-[34rem] lg:min-h-[40rem]'
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-border/60 px-4 py-3">
+        <div>
+          <SectionEyebrow>Primary</SectionEyebrow>
+          <h3 className="text-base font-semibold capitalize text-foreground">{settings.displayTimeframe} Chart</h3>
+        </div>
+      </div>
+      <div className="h-[calc(100%-4.25rem)]">
+        <ErrorBoundary>
+          <StockChart
+            data={chartData[settings.displayTimeframe]?.candlestickData || []}
+            atrSupport={chartData[settings.displayTimeframe]?.indicators.atrSupport as IndicatorValue[] | undefined}
+            nBarSupport={chartData[settings.displayTimeframe]?.indicators.nBarSupport as IndicatorValue[] | undefined}
+            bollingerBands={chartData[settings.displayTimeframe]?.bollingerBands as BollingerBandsData[] | undefined}
+            vwema={chartData[settings.displayTimeframe]?.indicators.vwema as IndicatorValue[] | undefined}
+            signalMarkers={signalMarkers?.[settings.displayTimeframe]}
+          />
+        </ErrorBoundary>
+      </div>
+    </Surface>
+  );
+}
+
 function SymbolWorkbenchPanelsContent({
   settings,
   selectedSymbol,
@@ -965,49 +1135,85 @@ function SymbolWorkbenchPanelsContent({
   marginPressureLoading: boolean;
   marginPressureError: Error | null;
 }) {
+  const isMobileWorkbenchLayout = useIsMobileWorkbenchLayout();
   const workbenchPanelOrder = settings.workbenchPanelOrder ?? DEFAULT_WORKBENCH_PANEL_ORDER;
+  const panelOptions = useMemo(
+    () => buildWorkbenchPanelOptions(settings, panelVisibilityById),
+    [settings, panelVisibilityById]
+  );
+  const [activeMobilePanelId, setActiveMobilePanelId] = useState<WorkbenchDisplayPanelId>('primary');
+
+  useEffect(() => {
+    if (!panelOptions.some((option) => option.id === activeMobilePanelId)) {
+      setActiveMobilePanelId('primary');
+    }
+  }, [activeMobilePanelId, panelOptions]);
+
+  const activeMobilePanel = panelOptions.find((option) => option.id === activeMobilePanelId) ?? panelOptions[0];
+
+  const renderWorkbenchPanel = (panelId: WorkbenchPanelId) =>
+    renderOrderedWorkbenchSection({
+      panelId,
+      selectedSymbol,
+      settings,
+      chartData,
+      panelVisibilityById,
+      fundamentalsPanelHeight,
+      tradingValuePeriod,
+      fundamentalsPanelSection,
+      fundamentalsHistorySection,
+      costStructureSection,
+      marginSection,
+      factorSection,
+      marginPressureData,
+      marginPressureLoading,
+      marginPressureError,
+    });
 
   return (
     <div className="flex h-full flex-col gap-3">
-      <Surface className="min-h-[34rem] overflow-hidden lg:min-h-[40rem]">
-        <div className="flex items-center justify-between border-b border-border/60 px-4 py-3">
-          <div>
-            <SectionEyebrow>Primary</SectionEyebrow>
-            <h3 className="text-base font-semibold capitalize text-foreground">{settings.displayTimeframe} Chart</h3>
-          </div>
-        </div>
-        <div className="h-[calc(100%-4.25rem)]">
-          <ErrorBoundary>
-            <StockChart
-              data={chartData[settings.displayTimeframe]?.candlestickData || []}
-              atrSupport={chartData[settings.displayTimeframe]?.indicators.atrSupport as IndicatorValue[] | undefined}
-              nBarSupport={chartData[settings.displayTimeframe]?.indicators.nBarSupport as IndicatorValue[] | undefined}
-              bollingerBands={chartData[settings.displayTimeframe]?.bollingerBands as BollingerBandsData[] | undefined}
-              vwema={chartData[settings.displayTimeframe]?.indicators.vwema as IndicatorValue[] | undefined}
-              signalMarkers={signalMarkers?.[settings.displayTimeframe]}
-            />
-          </ErrorBoundary>
-        </div>
-      </Surface>
+      {isMobileWorkbenchLayout ? (
+        <div className="flex flex-col gap-3">
+          <Surface className="px-3 py-3">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div>
+                <SectionEyebrow>Panel</SectionEyebrow>
+                <p className="text-sm font-semibold text-foreground">{activeMobilePanel?.label ?? 'Primary'}</p>
+              </div>
+              <p className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                {activeMobilePanel?.kind ?? 'Primary'}
+              </p>
+            </div>
+            <fieldset className="flex snap-x gap-2 overflow-x-auto pb-1">
+              <legend className="sr-only">Workbench panels</legend>
+              {panelOptions.map((option) => {
+                const isActive = option.id === activeMobilePanelId;
+                return (
+                  <Button
+                    key={option.id}
+                    type="button"
+                    variant={isActive ? 'default' : 'outline'}
+                    size="sm"
+                    className="shrink-0 snap-start"
+                    aria-pressed={isActive}
+                    onClick={() => setActiveMobilePanelId(option.id)}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </fieldset>
+          </Surface>
 
-      {workbenchPanelOrder.map((panelId) =>
-        renderOrderedWorkbenchSection({
-          panelId,
-          selectedSymbol,
-          settings,
-          chartData,
-          panelVisibilityById,
-          fundamentalsPanelHeight,
-          tradingValuePeriod,
-          fundamentalsPanelSection,
-          fundamentalsHistorySection,
-          costStructureSection,
-          marginSection,
-          factorSection,
-          marginPressureData,
-          marginPressureLoading,
-          marginPressureError,
-        })
+          {!activeMobilePanel || activeMobilePanel.id === 'primary'
+            ? renderPrimaryChartSection({ settings, chartData, signalMarkers, mobile: true })
+            : renderWorkbenchPanel(activeMobilePanel.id)}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {renderPrimaryChartSection({ settings, chartData, signalMarkers })}
+          {workbenchPanelOrder.map((panelId) => renderWorkbenchPanel(panelId))}
+        </div>
       )}
     </div>
   );
@@ -1028,8 +1234,10 @@ export function SymbolWorkbenchPage() {
     strategyName
   );
   const { settings } = useChartStore();
+  const isMobileWorkbenchLayout = useIsMobileWorkbenchLayout();
   const refreshStocks = useRefreshStocks();
   const [refreshFeedback, setRefreshFeedback] = useState<ChartRefreshFeedback | null>(null);
+  const [isMobileSettingsOpen, setIsMobileSettingsOpen] = useState(false);
   const shouldFetchMarginPressure = settings.showMarginPressurePanel && marginSection.isVisible;
   const shouldFetchFundamentals = selectedSymbol != null;
   const {
@@ -1098,15 +1306,29 @@ export function SymbolWorkbenchPage() {
   }, [queryClient, refreshStocks, selectedSymbol]);
 
   return (
-    <SplitLayout className="min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4 lg:flex-row lg:items-stretch lg:overflow-hidden">
+    <SplitLayout className="min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 sm:p-4 lg:flex-row lg:items-stretch lg:overflow-hidden">
       <h1 className="sr-only">Symbol Workbench</h1>
-      <SplitSidebar className="w-full lg:w-[18rem]">
-        <Surface className="h-full min-h-0 overflow-hidden">
-          <ErrorBoundary>
+      {!isMobileWorkbenchLayout || !selectedSymbol ? (
+        <SplitSidebar className="w-full lg:w-[18rem]">
+          <Surface className="h-full min-h-0 overflow-hidden">
+            <ErrorBoundary>
+              <ChartControls selectedSymbol={selectedSymbol} onSelectSymbol={(symbol) => setSelectedSymbol(symbol)} />
+            </ErrorBoundary>
+          </Surface>
+        </SplitSidebar>
+      ) : null}
+
+      <Dialog open={isMobileSettingsOpen} onOpenChange={setIsMobileSettingsOpen}>
+        <DialogContent className="h-[calc(100dvh-1.5rem)] max-h-none max-w-none translate-y-[-50%] overflow-hidden p-0 sm:max-w-lg sm:rounded-lg lg:hidden">
+          <DialogHeader className="border-b border-border/60 px-4 py-3 text-left">
+            <DialogTitle>Symbol Workbench Settings</DialogTitle>
+            <DialogDescription>Search, chart settings, panel order, and signal controls.</DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 overflow-y-auto">
             <ChartControls selectedSymbol={selectedSymbol} onSelectSymbol={(symbol) => setSelectedSymbol(symbol)} />
-          </ErrorBoundary>
-        </Surface>
-      </SplitSidebar>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <SplitMain className="min-h-0 gap-3 lg:overflow-y-auto lg:pr-1">
         {selectedSymbol && (
@@ -1123,6 +1345,7 @@ export function SymbolWorkbenchPage() {
             refreshFeedback={refreshFeedback}
             isRefreshing={refreshStocks.isPending}
             onRefresh={handleRefresh}
+            onOpenMobileSettings={() => setIsMobileSettingsOpen(true)}
           />
         )}
         {error && <ErrorState error={error} />}

--- a/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
+++ b/apps/ts/packages/web/src/pages/SymbolWorkbenchPage.tsx
@@ -28,7 +28,12 @@ import { useMigrateSymbolWorkbenchRouteState, useSymbolWorkbenchRouteState } fro
 import { type StockInfoResponse, stockInfoKeys, useStockInfo } from '@/hooks/useStockInfo';
 import { ApiError } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
-import { type FundamentalsPanelId, useChartStore } from '@/stores/chartStore';
+import {
+  DEFAULT_WORKBENCH_PANEL_ORDER,
+  type FundamentalsPanelId,
+  useChartStore,
+  type WorkbenchPanelId,
+} from '@/stores/chartStore';
 import type {
   BollingerBandsData,
   IndicatorValue,
@@ -748,19 +753,49 @@ function ChartHeader({
   );
 }
 
-type TimeframeChartData = ReturnType<typeof useMultiTimeframeChart>['chartData'][ChartSettings['displayTimeframe']];
-
-interface WorkbenchSubChartGroupProps {
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: keeps each persisted workbench panel id mapped in one renderer.
+function renderOrderedWorkbenchSection({
+  panelId,
+  selectedSymbol,
+  settings,
+  chartData,
+  panelVisibilityById,
+  fundamentalsPanelHeight,
+  tradingValuePeriod,
+  fundamentalsPanelSection,
+  fundamentalsHistorySection,
+  costStructureSection,
+  marginSection,
+  factorSection,
+  marginPressureData,
+  marginPressureLoading,
+  marginPressureError,
+}: {
+  panelId: WorkbenchPanelId;
+  selectedSymbol: string | null;
   settings: ChartSettings;
-  currentChartData: TimeframeChartData;
-  timeframeLabel: string;
-}
+  chartData: ReturnType<typeof useMultiTimeframeChart>['chartData'];
+  panelVisibilityById: Record<FundamentalsPanelId, boolean>;
+  fundamentalsPanelHeight: number;
+  tradingValuePeriod: number;
+  fundamentalsPanelSection: LazySectionState;
+  fundamentalsHistorySection: LazySectionState;
+  costStructureSection: LazySectionState;
+  marginSection: LazySectionState;
+  factorSection: LazySectionState;
+  marginPressureData: MarginPressureIndicatorsResponse | undefined;
+  marginPressureLoading: boolean;
+  marginPressureError: Error | null;
+}) {
+  const timeframe = settings.displayTimeframe;
+  const timeframeLabel = formatDisplayTimeframeLabel(timeframe);
+  const currentChartData = chartData[timeframe];
 
-function ReturnSubCharts({ settings, currentChartData, timeframeLabel }: WorkbenchSubChartGroupProps) {
-  return (
-    <>
-      {settings.showPPOChart && (
-        <Surface className="h-96 shrink-0 overflow-hidden">
+  switch (panelId) {
+    case 'ppo':
+      if (!settings.showPPOChart) return null;
+      return (
+        <Surface key={panelId} className="h-96 shrink-0 overflow-hidden">
           <ErrorBoundary>
             <PPOChart
               data={(currentChartData?.indicators.ppo as PPOIndicatorData[]) || []}
@@ -768,10 +803,11 @@ function ReturnSubCharts({ settings, currentChartData, timeframeLabel }: Workben
             />
           </ErrorBoundary>
         </Surface>
-      )}
-
-      {settings.showRiskAdjustedReturnChart && (
-        <Surface className="h-[240px] shrink-0 overflow-hidden">
+      );
+    case 'riskAdjustedReturn':
+      if (!settings.showRiskAdjustedReturnChart) return null;
+      return (
+        <Surface key={panelId} className="h-[240px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <RiskAdjustedReturnChart
               data={(currentChartData?.indicators.riskAdjustedReturn as RiskAdjustedReturnData[]) || []}
@@ -783,10 +819,11 @@ function ReturnSubCharts({ settings, currentChartData, timeframeLabel }: Workben
             />
           </ErrorBoundary>
         </Surface>
-      )}
-
-      {settings.showRecentReturnChart && (
-        <Surface className="h-[240px] shrink-0 overflow-hidden">
+      );
+    case 'recentReturn':
+      if (!settings.showRecentReturnChart) return null;
+      return (
+        <Surface key={panelId} className="h-[240px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <RecentReturnChart
               shortData={
@@ -805,16 +842,11 @@ function ReturnSubCharts({ settings, currentChartData, timeframeLabel }: Workben
             />
           </ErrorBoundary>
         </Surface>
-      )}
-    </>
-  );
-}
-
-function VolumeFlowSubCharts({ settings, currentChartData, timeframeLabel }: WorkbenchSubChartGroupProps) {
-  return (
-    <>
-      {settings.showVolumeComparison && (
-        <Surface className="h-[240px] shrink-0 overflow-hidden">
+      );
+    case 'volumeComparison':
+      if (!settings.showVolumeComparison) return null;
+      return (
+        <Surface key={panelId} className="h-[240px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <VolumeComparisonChart
               data={(currentChartData?.volumeComparison as VolumeComparisonData[]) || []}
@@ -825,10 +857,11 @@ function VolumeFlowSubCharts({ settings, currentChartData, timeframeLabel }: Wor
             />
           </ErrorBoundary>
         </Surface>
-      )}
-
-      {settings.showCMF && (
-        <Surface className="h-[220px] shrink-0 overflow-hidden">
+      );
+    case 'cmf':
+      if (!settings.showCMF) return null;
+      return (
+        <Surface key={panelId} className="h-[220px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <SingleValueIndicatorChart
               data={(currentChartData?.indicators.cmf as IndicatorValue[]) || []}
@@ -838,10 +871,11 @@ function VolumeFlowSubCharts({ settings, currentChartData, timeframeLabel }: Wor
             />
           </ErrorBoundary>
         </Surface>
-      )}
-
-      {settings.showChaikinOscillator && (
-        <Surface className="h-[220px] shrink-0 overflow-hidden">
+      );
+    case 'chaikinOscillator':
+      if (!settings.showChaikinOscillator) return null;
+      return (
+        <Surface key={panelId} className="h-[220px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <SingleValueIndicatorChart
               data={(currentChartData?.indicators.chaikinOscillator as IndicatorValue[]) || []}
@@ -851,10 +885,11 @@ function VolumeFlowSubCharts({ settings, currentChartData, timeframeLabel }: Wor
             />
           </ErrorBoundary>
         </Surface>
-      )}
-
-      {settings.showOBVFlowScore && (
-        <Surface className="h-[220px] shrink-0 overflow-hidden">
+      );
+    case 'obvFlowScore':
+      if (!settings.showOBVFlowScore) return null;
+      return (
+        <Surface key={panelId} className="h-[220px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <SingleValueIndicatorChart
               data={(currentChartData?.indicators.obvFlowScore as IndicatorValue[]) || []}
@@ -864,10 +899,11 @@ function VolumeFlowSubCharts({ settings, currentChartData, timeframeLabel }: Wor
             />
           </ErrorBoundary>
         </Surface>
-      )}
-
-      {settings.showTradingValueMA && (
-        <Surface className="h-[200px] shrink-0 overflow-hidden">
+      );
+    case 'tradingValueMA':
+      if (!settings.showTradingValueMA) return null;
+      return (
+        <Surface key={panelId} className="h-[200px] shrink-0 overflow-hidden">
           <ErrorBoundary>
             <TradingValueMAChart
               data={(currentChartData?.tradingValueMA as TradingValueMAData[]) || []}
@@ -875,28 +911,25 @@ function VolumeFlowSubCharts({ settings, currentChartData, timeframeLabel }: Wor
             />
           </ErrorBoundary>
         </Surface>
-      )}
-    </>
-  );
-}
-
-function WorkbenchSubCharts({
-  settings,
-  chartData,
-}: {
-  settings: ChartSettings;
-  chartData: ReturnType<typeof useMultiTimeframeChart>['chartData'];
-}) {
-  const timeframe = settings.displayTimeframe;
-  const timeframeLabel = formatDisplayTimeframeLabel(timeframe);
-  const currentChartData = chartData[timeframe];
-
-  return (
-    <>
-      <ReturnSubCharts settings={settings} currentChartData={currentChartData} timeframeLabel={timeframeLabel} />
-      <VolumeFlowSubCharts settings={settings} currentChartData={currentChartData} timeframeLabel={timeframeLabel} />
-    </>
-  );
+      );
+    default:
+      if (!panelVisibilityById[panelId]) return null;
+      return renderOrderedPanelSection({
+        panelId,
+        selectedSymbol,
+        settings,
+        fundamentalsPanelHeight,
+        tradingValuePeriod,
+        fundamentalsPanelSection,
+        fundamentalsHistorySection,
+        costStructureSection,
+        marginSection,
+        factorSection,
+        marginPressureData,
+        marginPressureLoading,
+        marginPressureError,
+      });
+  }
 }
 
 function SymbolWorkbenchPanelsContent({
@@ -932,6 +965,8 @@ function SymbolWorkbenchPanelsContent({
   marginPressureLoading: boolean;
   marginPressureError: Error | null;
 }) {
+  const workbenchPanelOrder = settings.workbenchPanelOrder ?? DEFAULT_WORKBENCH_PANEL_ORDER;
+
   return (
     <div className="flex h-full flex-col gap-3">
       <Surface className="min-h-[34rem] overflow-hidden lg:min-h-[40rem]">
@@ -955,27 +990,25 @@ function SymbolWorkbenchPanelsContent({
         </div>
       </Surface>
 
-      <WorkbenchSubCharts settings={settings} chartData={chartData} />
-
-      {settings.fundamentalsPanelOrder
-        .filter((panelId) => panelVisibilityById[panelId])
-        .map((panelId) =>
-          renderOrderedPanelSection({
-            panelId,
-            selectedSymbol,
-            settings,
-            fundamentalsPanelHeight,
-            tradingValuePeriod,
-            fundamentalsPanelSection,
-            fundamentalsHistorySection,
-            costStructureSection,
-            marginSection,
-            factorSection,
-            marginPressureData,
-            marginPressureLoading,
-            marginPressureError,
-          })
-        )}
+      {workbenchPanelOrder.map((panelId) =>
+        renderOrderedWorkbenchSection({
+          panelId,
+          selectedSymbol,
+          settings,
+          chartData,
+          panelVisibilityById,
+          fundamentalsPanelHeight,
+          tradingValuePeriod,
+          fundamentalsPanelSection,
+          fundamentalsHistorySection,
+          costStructureSection,
+          marginSection,
+          factorSection,
+          marginPressureData,
+          marginPressureLoading,
+          marginPressureError,
+        })
+      )}
     </div>
   );
 }

--- a/apps/ts/packages/web/src/stores/chartStore.test.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.test.ts
@@ -390,6 +390,21 @@ describe('chartStore', () => {
       'marginPressure',
       'factorRegression',
     ]);
+    expect(settings.workbenchPanelOrder).toEqual([
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
+      'fundamentals',
+      'fundamentalsHistory',
+      'costStructure',
+      'marginPressure',
+      'factorRegression',
+    ]);
     expect(settings.fundamentalsMetricOrder).toEqual(defaultSettings.fundamentalsMetricOrder);
     expect(settings.fundamentalsMetricVisibility).toEqual(defaultSettings.fundamentalsMetricVisibility);
     expect(settings.fundamentalsHistoryMetricOrder).toEqual(defaultSettings.fundamentalsHistoryMetricOrder);
@@ -544,6 +559,21 @@ describe('chartStore', () => {
 
     const settings = useChartStore.getState().settings;
     expect(settings.fundamentalsPanelOrder).toEqual([
+      'marginPressure',
+      'fundamentals',
+      'fundamentalsHistory',
+      'costStructure',
+      'factorRegression',
+    ]);
+    expect(settings.workbenchPanelOrder).toEqual([
+      'ppo',
+      'riskAdjustedReturn',
+      'recentReturn',
+      'volumeComparison',
+      'cmf',
+      'chaikinOscillator',
+      'obvFlowScore',
+      'tradingValueMA',
       'marginPressure',
       'fundamentals',
       'fundamentalsHistory',

--- a/apps/ts/packages/web/src/stores/chartStore.ts
+++ b/apps/ts/packages/web/src/stores/chartStore.ts
@@ -25,6 +25,16 @@ export type FundamentalsPanelId =
   | 'costStructure'
   | 'marginPressure'
   | 'factorRegression';
+export type SubChartPanelId =
+  | 'ppo'
+  | 'riskAdjustedReturn'
+  | 'recentReturn'
+  | 'volumeComparison'
+  | 'cmf'
+  | 'chaikinOscillator'
+  | 'obvFlowScore'
+  | 'tradingValueMA';
+export type WorkbenchPanelId = SubChartPanelId | FundamentalsPanelId;
 
 export const DEFAULT_FUNDAMENTALS_PANEL_ORDER: FundamentalsPanelId[] = [
   'fundamentals',
@@ -32,6 +42,22 @@ export const DEFAULT_FUNDAMENTALS_PANEL_ORDER: FundamentalsPanelId[] = [
   'costStructure',
   'marginPressure',
   'factorRegression',
+];
+
+export const DEFAULT_SUB_CHART_PANEL_ORDER: SubChartPanelId[] = [
+  'ppo',
+  'riskAdjustedReturn',
+  'recentReturn',
+  'volumeComparison',
+  'cmf',
+  'chaikinOscillator',
+  'obvFlowScore',
+  'tradingValueMA',
+];
+
+export const DEFAULT_WORKBENCH_PANEL_ORDER: WorkbenchPanelId[] = [
+  ...DEFAULT_SUB_CHART_PANEL_ORDER,
+  ...DEFAULT_FUNDAMENTALS_PANEL_ORDER,
 ];
 
 // Signal Overlay Types
@@ -101,6 +127,7 @@ export interface ChartSettings {
   showMarginPressurePanel: boolean;
   showFactorRegressionPanel: boolean;
   fundamentalsPanelOrder: FundamentalsPanelId[];
+  workbenchPanelOrder?: WorkbenchPanelId[];
   fundamentalsMetricOrder: FundamentalMetricId[];
   fundamentalsMetricVisibility: Record<FundamentalMetricId, boolean>;
   fundamentalsHistoryMetricOrder: FundamentalsHistoryMetricId[];
@@ -212,6 +239,7 @@ export const defaultSettings: ChartSettings = {
   showMarginPressurePanel: true,
   showFactorRegressionPanel: true,
   fundamentalsPanelOrder: [...DEFAULT_FUNDAMENTALS_PANEL_ORDER],
+  workbenchPanelOrder: [...DEFAULT_WORKBENCH_PANEL_ORDER],
   fundamentalsMetricOrder: [...DEFAULT_FUNDAMENTAL_METRIC_ORDER],
   fundamentalsMetricVisibility: { ...DEFAULT_FUNDAMENTAL_METRIC_VISIBILITY },
   fundamentalsHistoryMetricOrder: [...DEFAULT_FUNDAMENTALS_HISTORY_METRIC_ORDER],
@@ -306,6 +334,23 @@ function isValidFundamentalsPanelId(value: unknown): value is FundamentalsPanelI
   );
 }
 
+function isValidSubChartPanelId(value: unknown): value is SubChartPanelId {
+  return (
+    value === 'ppo' ||
+    value === 'riskAdjustedReturn' ||
+    value === 'recentReturn' ||
+    value === 'volumeComparison' ||
+    value === 'cmf' ||
+    value === 'chaikinOscillator' ||
+    value === 'obvFlowScore' ||
+    value === 'tradingValueMA'
+  );
+}
+
+function isValidWorkbenchPanelId(value: unknown): value is WorkbenchPanelId {
+  return isValidSubChartPanelId(value) || isValidFundamentalsPanelId(value);
+}
+
 function normalizeFundamentalsPanelOrder(value: unknown): FundamentalsPanelId[] {
   const normalizedOrder: FundamentalsPanelId[] = [];
   const seen = new Set<FundamentalsPanelId>();
@@ -320,6 +365,31 @@ function normalizeFundamentalsPanelOrder(value: unknown): FundamentalsPanelId[] 
 
   for (const panelId of DEFAULT_FUNDAMENTALS_PANEL_ORDER) {
     if (seen.has(panelId)) continue;
+    normalizedOrder.push(panelId);
+  }
+
+  return normalizedOrder;
+}
+
+function normalizeWorkbenchPanelOrder(value: unknown, legacyFundamentalsOrder: unknown): WorkbenchPanelId[] {
+  const normalizedOrder: WorkbenchPanelId[] = [];
+  const seen = new Set<WorkbenchPanelId>();
+
+  if (Array.isArray(value)) {
+    for (const panelId of value) {
+      if (!isValidWorkbenchPanelId(panelId) || seen.has(panelId)) continue;
+      seen.add(panelId);
+      normalizedOrder.push(panelId);
+    }
+  }
+
+  const fallbackOrder = Array.isArray(value)
+    ? DEFAULT_WORKBENCH_PANEL_ORDER
+    : [...DEFAULT_SUB_CHART_PANEL_ORDER, ...normalizeFundamentalsPanelOrder(legacyFundamentalsOrder)];
+
+  for (const panelId of fallbackOrder) {
+    if (seen.has(panelId)) continue;
+    seen.add(panelId);
     normalizedOrder.push(panelId);
   }
 
@@ -481,6 +551,7 @@ function normalizeSettings(settings: unknown): ChartSettings {
       defaultSettings.showFactorRegressionPanel
     ),
     fundamentalsPanelOrder: normalizeFundamentalsPanelOrder(partial.fundamentalsPanelOrder),
+    workbenchPanelOrder: normalizeWorkbenchPanelOrder(partial.workbenchPanelOrder, partial.fundamentalsPanelOrder),
     fundamentalsMetricOrder: normalizeFundamentalMetricOrder(partial.fundamentalsMetricOrder),
     fundamentalsMetricVisibility: normalizeFundamentalMetricVisibility(partial.fundamentalsMetricVisibility),
     fundamentalsHistoryMetricOrder: normalizeFundamentalsHistoryMetricOrder(partial.fundamentalsHistoryMetricOrder),

--- a/apps/ts/packages/web/src/stores/screeningStore.ts
+++ b/apps/ts/packages/web/src/stores/screeningStore.ts
@@ -48,6 +48,7 @@ export const DEFAULT_VALUE_COMPOSITE_RANKING_PARAMS: ValueCompositeRankingParams
   markets: 'standard',
   limit: 50,
   scoreMethod: 'walkforward_regression_weight',
+  forwardEpsMode: 'latest',
 };
 
 interface ScreeningState {

--- a/apps/ts/packages/web/src/types/valueCompositeRanking.ts
+++ b/apps/ts/packages/web/src/types/valueCompositeRanking.ts
@@ -2,12 +2,16 @@
  * Value-composite ranking types for frontend.
  */
 
-import type { ValueCompositeScoreMethod } from '@trading25/contracts/types/api-response-types';
+import type {
+  ValueCompositeForwardEpsMode,
+  ValueCompositeScoreMethod,
+} from '@trading25/contracts/types/api-response-types';
 
 export type {
-  ValueCompositeScoreMethod,
+  ValueCompositeForwardEpsMode,
   ValueCompositeRankingItem,
   ValueCompositeRankingResponse,
+  ValueCompositeScoreMethod,
 } from '@trading25/contracts/types/api-response-types';
 
 export interface ValueCompositeRankingParams {
@@ -15,4 +19,5 @@ export interface ValueCompositeRankingParams {
   limit?: number;
   markets?: string;
   scoreMethod?: ValueCompositeScoreMethod;
+  forwardEpsMode?: ValueCompositeForwardEpsMode;
 }

--- a/apps/ts/packages/web/vite.config.ts
+++ b/apps/ts/packages/web/vite.config.ts
@@ -94,7 +94,7 @@ export default defineConfig(({ mode }) => {
 		},
 		server: {
 			host: '0.0.0.0',
-			allowedHosts: ['mba-m4', 'hx90'],
+			allowedHosts: ['mba-m4', 'hx90', 'hx90.tailb95be2.ts.net', 'mba-m4.tailb95be2.ts.net'],
 			port: WEB_PORT,
 			strictPort: true,
 			proxy: {

--- a/docs/frontend-mobile-galaxy-s26-ultra-design.md
+++ b/docs/frontend-mobile-galaxy-s26-ultra-design.md
@@ -33,6 +33,7 @@ Observed patterns in `apps/ts/packages/web/src`:
 - On mobile, many pages collapse to `flex-col`, but the sidebar remains a full-width block above the content.
 - Tables and virtualized lists are central to Ranking / Screening / Portfolio / Watchlist flows.
 - Symbol Workbench has a large primary chart (`min-h-[34rem]`) plus many sub-panels; this is expensive in vertical space.
+- The global/page header can become hard to read on phone widths: titles, nav items, action buttons, status text, and current context compete for one narrow row.
 - Settings and control panels often use desktop-like density and long dialogs.
 
 This means the first mobile problem is not simply breakpoint support. It is **task prioritization**: on a phone, the user needs one active task surface at a time.
@@ -84,7 +85,31 @@ Instead:
 - Keep primary decision data visible: symbol, latest price/date, key signal state, selected timeframe.
 - Use progressive disclosure for API diagnostics, provenance, warnings, and advanced settings.
 
-### 4. Charts need mobile-specific interaction contracts
+### 4. Header readability must be treated as a first-class mobile problem
+
+On a 412 px-wide phone, the header cannot carry the same amount of information as desktop. The failure mode is usually not complete breakage; it is **low readability**: compressed titles, wrapped controls, hidden context, and action buttons that visually compete with the page title.
+
+Recommended header contract:
+
+- Use a two-tier mobile header instead of one overloaded row:
+  - Tier 1: app/page identity and primary navigation/menu affordance.
+  - Tier 2: page-specific context such as selected symbol, timeframe, refresh status, or active filter count.
+- Keep the visible title short. Move long route names, descriptions, and diagnostics into a details sheet or page body.
+- Collapse secondary actions behind a `More`/kebab menu or bottom sheet.
+- Use icon+label only for the most important action; use icon-only with accessible labels for secondary actions if space is tight.
+- Make sticky headers compact and translucent/solid enough to preserve chart/table readability beneath them.
+- Test text scaling and Japanese labels; Japanese route/action labels can be wider than expected even when character count is low.
+
+For Symbol Workbench, the mobile header should prioritize:
+
+1. selected symbol / company name,
+2. timeframe,
+3. refresh/data status,
+4. settings/panel picker access.
+
+Everything else should be demoted below the chart or into a sheet.
+
+### 5. Charts need mobile-specific interaction contracts
 
 For chart panels:
 
@@ -103,7 +128,7 @@ For Galaxy S26 Ultra portrait, a good chart target is:
 
 The current `min-h-[34rem]` primary chart is close to a full screen by itself on mobile; that is acceptable only if the page intentionally becomes a chart-first screen.
 
-### 5. Tables need card or hybrid views
+### 6. Tables need card or hybrid views
 
 Dense financial tables are the hardest mobile surface.
 
@@ -122,7 +147,7 @@ Recommended approach:
 
 Avoid forcing users to horizontally scan 10+ columns on a 412 px viewport.
 
-### 6. Dialogs should become sheets on mobile
+### 7. Dialogs should become sheets on mobile
 
 Current dialogs are fine on desktop, but on phone:
 
@@ -133,7 +158,7 @@ Current dialogs are fine on desktop, but on phone:
 
 For Symbol Workbench settings, the recent unification of panel/sub-chart settings into Panel Layout is a good direction. On mobile, make that layout a bottom sheet with per-panel accordions.
 
-### 7. Use safe-area and browser chrome aware spacing
+### 8. Use safe-area and browser chrome aware spacing
 
 Add mobile shell spacing with modern viewport units:
 
@@ -141,13 +166,14 @@ Add mobile shell spacing with modern viewport units:
 - Add `env(safe-area-inset-bottom)` to bottom nav/sheets.
 - Keep primary bottom actions above the gesture navigation area.
 
-### 8. Maintain desktop behavior by introducing mobile-only components gradually
+### 9. Maintain desktop behavior by introducing mobile-only components gradually
 
 Do not rewrite every page at once. Add reusable primitives and migrate page by page.
 
 Candidate primitives:
 
 - `MobilePageShell`
+- `MobileHeader` / `MobileContextBar`
 - `MobileControlSheet`
 - `MobileSegmentedSurface`
 - `ResponsiveDataView` (`table` desktop, `cards` mobile)
@@ -278,6 +304,7 @@ Useful patterns:
 A page is S26 Ultra-ready when:
 
 - It works at `412 × 892` without unintended horizontal page scroll.
+- Header content remains readable: no cramped title/action row, no important context hidden behind wrapping, and no accidental overlap with browser safe areas.
 - Primary task content appears above or near the first fold.
 - Touch targets are at least ~44 px where practical.
 - Dialogs/sheets can be completed with one thumb and do not trap nested scroll awkwardly.

--- a/docs/frontend-mobile-galaxy-s26-ultra-design.md
+++ b/docs/frontend-mobile-galaxy-s26-ultra-design.md
@@ -1,0 +1,290 @@
+# Frontend mobile design note: Galaxy S26 Ultra
+
+Date: 2026-04-26
+
+## Why this note exists
+
+The current web frontend is usable on narrow viewports, but most primary workflows are still desktop-first: split panes, sticky sidebars, dense tables, and large fixed-height chart panels. The Galaxy S26 Ultra is large for a phone, but it is still a one-column touch device in portrait. Treating it like a small desktop will make symbol analysis and backtest operations feel cramped.
+
+This note defines a mobile target and design direction for optimizing `apps/ts/packages/web` without losing the desktop analyst workflow.
+
+## Device target
+
+Primary reference device: **Samsung Galaxy S26 Ultra**.
+
+Public specs checked:
+
+- Samsung official product page exists for Galaxy S26 Ultra: <https://www.samsung.com/us/smartphones/galaxy-s26-ultra/>
+- GSMArena review reports a **6.9-inch LTPO OLED** panel with **1440 × 3120 px** resolution and up to **120 Hz** refresh: <https://www.gsmarena.com/samsung_galaxy_s26_ultra-review-2939p3.php>
+- Other spec-index/search sources consistently report **6.9 in / 3120 × 1440 / 19.5:9**.
+
+Practical CSS target:
+
+- Physical pixels: `1440 × 3120` portrait.
+- Expected Android/Chrome CSS viewport: roughly **411–412 CSS px wide** at high DPR.
+- Height varies with browser chrome and install mode; design for **~840–915 CSS px visible height**.
+- Do not hard-code to one phone. Use S26 Ultra as the high-end Android portrait benchmark and keep the range **360–430 CSS px width** healthy.
+
+## Current frontend constraints
+
+Observed patterns in `apps/ts/packages/web/src`:
+
+- Main pages use `SplitLayout`, `SplitSidebar`, and `SplitMain` with `lg:flex-row` desktop layouts.
+- On mobile, many pages collapse to `flex-col`, but the sidebar remains a full-width block above the content.
+- Tables and virtualized lists are central to Ranking / Screening / Portfolio / Watchlist flows.
+- Symbol Workbench has a large primary chart (`min-h-[34rem]`) plus many sub-panels; this is expensive in vertical space.
+- Settings and control panels often use desktop-like density and long dialogs.
+
+This means the first mobile problem is not simply breakpoint support. It is **task prioritization**: on a phone, the user needs one active task surface at a time.
+
+## Design principles for S26 Ultra optimization
+
+### 1. Mobile is a dedicated shell, not only `flex-col`
+
+At `max-width: 430px`, use a mobile shell that separates:
+
+1. top app/navigation affordance,
+2. current page controls,
+3. main content,
+4. optional secondary panels.
+
+Avoid rendering desktop sidebars as large full-width cards above the main result. They push the actual chart/table below the fold.
+
+Recommended pattern:
+
+- Desktop: keep `SplitSidebar + SplitMain`.
+- Mobile: transform sidebars into one of:
+  - a sticky compact filter bar,
+  - a bottom sheet / drawer,
+  - segmented tabs for page modes,
+  - an inline collapsed accordion only when controls are rarely used.
+
+### 2. Optimize for 412 px width first
+
+Use `412px` as the primary QA viewport.
+
+Suggested viewport set:
+
+- `360 × 800`: small Android baseline.
+- `390 × 844`: common iPhone-like baseline.
+- `412 × 892`: Galaxy S26 Ultra CSS-width approximation.
+- `430 × 932`: large Android/iPhone Max class.
+- `915 × 412`: S26 Ultra landscape approximation for chart-heavy flows.
+
+Acceptance goal: no horizontal page scroll outside intentionally scrollable tables/charts.
+
+### 3. Preserve analyst density, but make disclosure explicit
+
+Trading/analysis UIs need dense information. Do not simply make everything huge.
+
+Instead:
+
+- Use compact metric cards in 2 columns where values are short.
+- Collapse secondary metadata under `Details` / `Diagnostics` accordions.
+- Keep primary decision data visible: symbol, latest price/date, key signal state, selected timeframe.
+- Use progressive disclosure for API diagnostics, provenance, warnings, and advanced settings.
+
+### 4. Charts need mobile-specific interaction contracts
+
+For chart panels:
+
+- Reserve most vertical space for the active chart; controls should be compact and sticky above it.
+- Prefer one visible chart/panel at a time on portrait mobile.
+- Provide a chart/panel picker instead of stacking every enabled sub-chart vertically.
+- Use horizontal swipe or segmented tabs for `Primary`, `PPO`, `Risk`, `Volume`, `Fundamentals`, etc.
+- Keep tooltips finger-friendly and avoid hover-only interactions.
+- Use `touch-action` intentionally: chart pan/zoom must not fight page scroll.
+
+For Galaxy S26 Ultra portrait, a good chart target is:
+
+- Header/controls: 80–120 px.
+- Active chart viewport: 420–560 px.
+- Below-chart summary/actions: remaining space.
+
+The current `min-h-[34rem]` primary chart is close to a full screen by itself on mobile; that is acceptable only if the page intentionally becomes a chart-first screen.
+
+### 5. Tables need card or hybrid views
+
+Dense financial tables are the hardest mobile surface.
+
+Recommended approach:
+
+- Keep table semantics on desktop.
+- On mobile, use either:
+  - card rows with top 3–5 fields, expandable details, or
+  - a horizontal-scroll table with sticky first column and obvious scroll affordance.
+- For Ranking / Screening, default mobile row content should include:
+  - symbol/code and company name,
+  - primary score/rank,
+  - latest return/performance metric,
+  - one risk or liquidity metric,
+  - action affordance to open details/workbench.
+
+Avoid forcing users to horizontally scan 10+ columns on a 412 px viewport.
+
+### 6. Dialogs should become sheets on mobile
+
+Current dialogs are fine on desktop, but on phone:
+
+- Use full-screen or near-full-screen sheets for settings/editors.
+- Keep action buttons sticky at the bottom.
+- Ensure form fields are at least 44 px touch targets.
+- Avoid nested scrolling inside a dialog unless the outer page is locked.
+
+For Symbol Workbench settings, the recent unification of panel/sub-chart settings into Panel Layout is a good direction. On mobile, make that layout a bottom sheet with per-panel accordions.
+
+### 7. Use safe-area and browser chrome aware spacing
+
+Add mobile shell spacing with modern viewport units:
+
+- Prefer `100dvh` over `100vh` for full-height mobile panels.
+- Add `env(safe-area-inset-bottom)` to bottom nav/sheets.
+- Keep primary bottom actions above the gesture navigation area.
+
+### 8. Maintain desktop behavior by introducing mobile-only components gradually
+
+Do not rewrite every page at once. Add reusable primitives and migrate page by page.
+
+Candidate primitives:
+
+- `MobilePageShell`
+- `MobileControlSheet`
+- `MobileSegmentedSurface`
+- `ResponsiveDataView` (`table` desktop, `cards` mobile)
+- `ChartPanelPager`
+- `StickyMobileActionBar`
+
+## Page-specific recommendations
+
+### Symbol Workbench
+
+Highest priority. It is the most likely mobile verification page for the current workflow.
+
+Recommended mobile layout:
+
+1. Sticky compact header:
+   - selected symbol,
+   - timeframe selector,
+   - refresh/status action,
+   - settings button.
+2. Active panel pager:
+   - `Primary`, enabled sub-charts, fundamentals panels.
+   - One panel visible at a time in portrait.
+3. Bottom sheet for settings:
+   - symbol search,
+   - chart settings,
+   - panel layout/order,
+   - signal overlay.
+4. Convert chart/panel stack into an ordered tab/pager using existing `workbenchPanelOrder`.
+
+Important: keep `workbenchPanelOrder` as the source of truth. Mobile should change presentation, not duplicate settings state.
+
+### Ranking / Screening
+
+Recommended mobile layout:
+
+- Top sticky summary + filter button.
+- Filter/sidebar as full-screen sheet.
+- Results as mobile cards by default.
+- Keep a “table mode” toggle for power users.
+- Sticky sort selector for common ranking dimensions.
+
+### Backtest
+
+Recommended mobile layout:
+
+- Split the workflow into steps: `Strategy`, `Config`, `Run`, `Results`, `Artifacts`.
+- Use tabs/stepper instead of multi-column panels.
+- YAML/editor surfaces should open full-screen and use monospace with a minimum 14 px font.
+
+### Portfolio / Watchlist
+
+Recommended mobile layout:
+
+- List/detail as separate screens or nested route state.
+- Summary metric cards first.
+- Holdings/positions as cards with expandable metrics.
+
+### Settings
+
+Recommended mobile layout:
+
+- Group settings into accordions.
+- Avoid 2–3 column grids below `sm`; keep one column with compact vertical rhythm.
+- Put destructive/admin actions behind confirmation sheets.
+
+## Implementation plan
+
+### Phase 1: Baseline and guardrails
+
+- Add Playwright/mobile viewport presets for `412 × 892` and `360 × 800`.
+- Add visual smoke checks for main routes: Symbol Workbench, Ranking, Screening, Backtest, Portfolio.
+- Add a “no unintended body horizontal scroll” assertion.
+- Audit fixed heights above `400px` on mobile.
+
+### Phase 2: Mobile shell primitives
+
+- Introduce reusable mobile shell/sheet primitives in `components/Layout`.
+- Make `SplitLayout` consumers opt into a mobile sidebar mode.
+- Convert dialogs to full-screen sheets at `max-width: 430px`.
+
+### Phase 3: Symbol Workbench mobile rewrite
+
+- Add mobile-only `ChartPanelPager` using `workbenchPanelOrder`.
+- Move ChartControls into a sheet on mobile.
+- Keep primary chart/panel height dynamic with `dvh`.
+- Verify FastAPI/Vite restart after code changes before mobile QA.
+
+### Phase 4: Data-heavy pages
+
+- Add `ResponsiveDataView` and migrate Ranking/Screening tables.
+- Preserve desktop tables and power-user density.
+- Add mobile card snapshots/tests.
+
+## CSS/Tailwind guidance
+
+Suggested breakpoint semantics:
+
+- Default styles should work at 360–430 px.
+- `sm` is still phone/large-phone adjacent; do not assume tablet.
+- Use `md` for wider phone landscape / small tablet improvements.
+- Use `lg` for desktop split layouts.
+
+Useful patterns:
+
+```tsx
+// mobile-first full-height shell
+<div className="flex min-h-[100dvh] flex-col overflow-hidden lg:min-h-0">
+  <header className="shrink-0" />
+  <main className="min-h-0 flex-1 overflow-y-auto" />
+</div>
+```
+
+```tsx
+// mobile sheet padding safe for gesture nav
+<div className="pb-[calc(env(safe-area-inset-bottom)+1rem)]">
+  ...
+</div>
+```
+
+```tsx
+// desktop split, mobile control sheet trigger
+<aside className="hidden lg:block lg:w-[18rem]">...</aside>
+<Button className="lg:hidden">Filters / Settings</Button>
+```
+
+## Definition of done for S26 Ultra mobile support
+
+A page is S26 Ultra-ready when:
+
+- It works at `412 × 892` without unintended horizontal page scroll.
+- Primary task content appears above or near the first fold.
+- Touch targets are at least ~44 px where practical.
+- Dialogs/sheets can be completed with one thumb and do not trap nested scroll awkwardly.
+- Tables either become cards or have an explicit horizontal-scroll design.
+- Charts support touch interaction without breaking vertical page scroll.
+- Desktop `lg+` layout remains unchanged unless intentionally improved.
+
+## Recommendation
+
+Start with **Symbol Workbench**. It already has the strongest need for phone verification, and the recent panel/sub-chart unification gives a clean state model for a mobile panel pager. After that, apply the same shell/sheet patterns to Ranking and Screening.


### PR DESCRIPTION
## Summary
- optimize Symbol Workbench for Galaxy S26 Ultra / phone-sized viewports
- unify Symbol Workbench panel ordering and fold sub-chart configuration into Panel Layout
- add mobile-specific Symbol Workbench shell with settings dialog, compact page header, single active panel selector, and emphasized Symbol Search
- improve the global app header on mobile by showing the current page trigger and moving all destinations into a navigation menu
- improve Ranking mobile UX with card-based Daily Ranking and Index Performance results while preserving desktop tables
- add a Value Scores Forward EPS Basis selector: latest revised quarterly forecast EPS when available, or FY forecast EPS
- document the mobile design target and QA expectations
- add minimal OpenClaw repo guardrails to `AGENTS.md` for branch naming, push/PR permissions, and author identity

## Validation
- `uv run pytest tests/unit/server/services/test_ranking_service.py::TestGetValueCompositeRanking tests/unit/server/routes/test_analytics_complex.py::TestValueCompositeRanking`
- `uv run ruff check src/application/services/ranking_service.py src/entrypoints/http/routes/analytics_complex.py src/entrypoints/http/schemas/ranking.py tests/unit/server/services/test_ranking_service.py tests/unit/server/routes/test_analytics_complex.py`
- `bunx biome check --write ...`
- `bun run typecheck`
- `bun run test src/stores/chartStore.test.ts src/components/Chart/ChartControls.test.tsx src/pages/SymbolWorkbenchPage.test.tsx`
- `bun run test src/components/Layout/Header.test.tsx src/pages/SymbolWorkbenchPage.test.tsx`
- `bun run test src/pages/RankingPage.test.tsx src/components/Ranking/RankingTable.test.tsx src/components/Ranking/IndexPerformanceTable.test.tsx`
- `bun run --filter @trading25/api-clients typecheck && bun run --filter @trading25/api-clients test && bun run --filter @trading25/web typecheck`
- `bun run --filter @trading25/web test src/components/ValueCompositeRanking/ValueCompositeRankingFilters.test.tsx src/lib/routeSearch.test.ts src/pages/RankingPage.test.tsx`
- `bunx tsc -p packages/contracts/tsconfig.typecheck.json --noEmit`
- Playwright-style viewport checks at `412x892` confirmed no horizontal overflow and no console errors for Symbol Workbench, global header navigation, Ranking, and the Value Scores EPS basis controls
- Dev servers verified locally: Vite `:5173` and FastAPI `/doc` on `:3002` returned `200`; `/api/analytics/value-composite-ranking?limit=1&forwardEpsMode=fy` returned `forwardEpsMode: fy`

## Notes
- Desktop `lg+` layout is preserved where applicable; mobile behavior is viewport-width based, not UA based.
- OpenClaw/moltbook unrelated personal docs were moved outside the repo and are intentionally excluded from this PR.
- OpenClaw remote branch naming now uses `openclaw/*` per the added guardrail.