### PR TITLE
feat(bt): add optional VectorBT Rust engine

### DIFF
--- a/apps/bt/README.md
+++ b/apps/bt/README.md
@@ -96,6 +96,15 @@ uv run pytest tests
 - pydantic / typer / loguru
 - pytest / ruff / pyright
 
+Optional VectorBT Rust dispatch:
+
+```bash
+uv sync --group rust
+BT_VECTORBT_ENGINE=rust uv run bt backtest <strategy>
+```
+
+`BT_VECTORBT_ENGINE` は `auto` / `numba` / `rust` を受け付けます。Rust dispatch は `Portfolio.from_signals` path のみ対象です。
+
 ## Documentation
 
 - `AGENTS.md` - 運用ルールと責務

--- a/apps/bt/README.md
+++ b/apps/bt/README.md
@@ -103,7 +103,7 @@ uv sync --group rust
 BT_VECTORBT_ENGINE=rust uv run bt backtest <strategy>
 ```
 
-`BT_VECTORBT_ENGINE` は `auto` / `numba` / `rust` を受け付けます。Rust dispatch は `Portfolio.from_signals` path のみ対象です。
+`BT_VECTORBT_ENGINE` は `numba`（default） / `auto` / `rust` を受け付けます。Rust dispatch は `Portfolio.from_signals` path のみ対象で、`rust` または `auto` を明示した場合だけ利用します。round-trip execution policy は `Portfolio.from_order_func` を使うため `numba` のみ対応です。
 
 ## Documentation
 

--- a/apps/bt/pyproject.toml
+++ b/apps/bt/pyproject.toml
@@ -52,6 +52,9 @@ research = [
 nautilus = [
     "nautilus-trader>=1.225.0",
 ]
+rust = [
+    "vectorbt-rust>=1.0.0",
+]
 
 [tool.pyright]
 include = ["src"]

--- a/apps/bt/src/domains/backtest/vectorbt_adapter.py
+++ b/apps/bt/src/domains/backtest/vectorbt_adapter.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -14,12 +15,29 @@ from vectorbt.portfolio.enums import Direction, SizeType
 
 from src.domains.backtest.contracts import CanonicalExecutionMetrics
 
+VectorbtEngine = Literal["auto", "numba", "rust"]
+VECTORBT_ENGINE_ENV = "BT_VECTORBT_ENGINE"
+_VALID_VECTORBT_ENGINES: set[str] = {"auto", "numba", "rust"}
+
 ROUND_TRIP_DIRECTION_MAP = {
     "longonly": int(Direction.LongOnly),
     "shortonly": int(Direction.ShortOnly),
     "both": int(Direction.Both),
 }
 PERCENT_SIZE_TYPE = int(SizeType.Percent)
+
+
+def resolve_vectorbt_engine(engine: str | None = None) -> VectorbtEngine:
+    """Resolve the VectorBT portfolio dispatch engine."""
+
+    raw_engine = engine if engine is not None else os.getenv(VECTORBT_ENGINE_ENV, "auto")
+    resolved = raw_engine.strip().lower()
+    if resolved not in _VALID_VECTORBT_ENGINES:
+        raise ValueError(
+            f"Invalid VectorBT engine {raw_engine!r}. "
+            "Expected one of: auto, numba, rust."
+        )
+    return cast(VectorbtEngine, resolved)
 
 
 def _is_mock_value(value: Any) -> bool:
@@ -355,6 +373,9 @@ class VectorbtPortfolioAdapter:
 class VectorbtAdapter:
     """Execute and normalize portfolios through vectorbt."""
 
+    def __init__(self, engine: str | None = None) -> None:
+        self.engine = resolve_vectorbt_engine(engine)
+
     def create_signal_portfolio(
         self,
         *,
@@ -386,6 +407,7 @@ class VectorbtAdapter:
             "group_by": group_by,
             "accumulate": accumulate,
             "freq": freq,
+            "engine": self.engine,
         }
         if size is not None:
             portfolio_kwargs["size"] = size

--- a/apps/bt/src/domains/backtest/vectorbt_adapter.py
+++ b/apps/bt/src/domains/backtest/vectorbt_adapter.py
@@ -17,6 +17,7 @@ from src.domains.backtest.contracts import CanonicalExecutionMetrics
 
 VectorbtEngine = Literal["auto", "numba", "rust"]
 VECTORBT_ENGINE_ENV = "BT_VECTORBT_ENGINE"
+DEFAULT_VECTORBT_ENGINE: VectorbtEngine = "numba"
 _VALID_VECTORBT_ENGINES: set[str] = {"auto", "numba", "rust"}
 
 ROUND_TRIP_DIRECTION_MAP = {
@@ -30,7 +31,7 @@ PERCENT_SIZE_TYPE = int(SizeType.Percent)
 def resolve_vectorbt_engine(engine: str | None = None) -> VectorbtEngine:
     """Resolve the VectorBT portfolio dispatch engine."""
 
-    raw_engine = engine if engine is not None else os.getenv(VECTORBT_ENGINE_ENV, "auto")
+    raw_engine = engine if engine is not None else os.getenv(VECTORBT_ENGINE_ENV, DEFAULT_VECTORBT_ENGINE)
     resolved = raw_engine.strip().lower()
     if resolved not in _VALID_VECTORBT_ENGINES:
         raise ValueError(
@@ -38,6 +39,16 @@ def resolve_vectorbt_engine(engine: str | None = None) -> VectorbtEngine:
             "Expected one of: auto, numba, rust."
         )
     return cast(VectorbtEngine, resolved)
+
+
+def _ensure_round_trip_engine_supported(engine: VectorbtEngine) -> None:
+    if engine == "numba":
+        return
+    raise ValueError(
+        f"VectorBT engine {engine!r} is only supported for signal portfolios. "
+        f"Round-trip execution uses Portfolio.from_order_func and requires "
+        f"{VECTORBT_ENGINE_ENV}=numba."
+    )
 
 
 def _is_mock_value(value: Any) -> bool:
@@ -374,7 +385,7 @@ class VectorbtAdapter:
     """Execute and normalize portfolios through vectorbt."""
 
     def __init__(self, engine: str | None = None) -> None:
-        self.engine = resolve_vectorbt_engine(engine)
+        self.engine: VectorbtEngine = resolve_vectorbt_engine(engine)
 
     def create_signal_portfolio(
         self,
@@ -438,6 +449,7 @@ class VectorbtAdapter:
         group_by: bool | None,
         freq: str = "D",
     ) -> ExecutionPortfolioProtocol:
+        _ensure_round_trip_engine_supported(self.engine)
         normalized_entries = entries_data.fillna(False).infer_objects(copy=False).astype(bool)
         order_func = _round_trip_order_func_nb
         if execution_mode == "overnight_round_trip":

--- a/apps/bt/tests/smoke/test_nautilus_runtime_smoke.py
+++ b/apps/bt/tests/smoke/test_nautilus_runtime_smoke.py
@@ -34,7 +34,7 @@ def _build_prepared_inputs() -> _PreparedPortfolioInputs:
         strategy_name="demo",
         dataset_name="sample",
         shared_config=SharedConfig(
-            dataset="sample",
+            universe_preset="sample",
             stock_codes=["1301"],
             initial_cash=1_000_000,
             timeframe="daily",
@@ -73,7 +73,7 @@ def test_nautilus_real_runtime_smoke(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         runner._vectorbt_runner,
         "build_parameters_for_strategy",
         lambda strategy, config_override=None: {
-            "shared_config": {"dataset": "sample", "timeframe": "daily"},
+            "shared_config": {"universe_preset": "sample", "timeframe": "daily"},
             "entry_filter_params": {},
         },
     )

--- a/apps/bt/tests/unit/backtest/test_vectorbt_adapter.py
+++ b/apps/bt/tests/unit/backtest/test_vectorbt_adapter.py
@@ -1,0 +1,68 @@
+"""Tests for the VectorBT execution adapter."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.domains.backtest.vectorbt_adapter import (
+    VECTORBT_ENGINE_ENV,
+    VectorbtAdapter,
+    resolve_vectorbt_engine,
+)
+
+
+def test_resolve_vectorbt_engine_defaults_to_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(VECTORBT_ENGINE_ENV, raising=False)
+
+    assert resolve_vectorbt_engine() == "auto"
+
+
+def test_resolve_vectorbt_engine_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VECTORBT_ENGINE_ENV, " RuSt ")
+
+    assert resolve_vectorbt_engine() == "rust"
+
+
+def test_resolve_vectorbt_engine_rejects_invalid_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(VECTORBT_ENGINE_ENV, "python")
+
+    with pytest.raises(ValueError, match="Invalid VectorBT engine"):
+        resolve_vectorbt_engine()
+
+
+def test_create_signal_portfolio_passes_selected_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_from_signals(**kwargs):
+        captured.update(kwargs)
+        return "portfolio"
+
+    monkeypatch.setattr(
+        "vectorbt.Portfolio.from_signals",
+        _fake_from_signals,
+        raising=False,
+    )
+
+    index = pd.date_range("2024-01-01", periods=2)
+    close = pd.DataFrame({"7203": [100.0, 101.0]}, index=index)
+    entries = pd.DataFrame({"7203": [True, False]}, index=index)
+    exits = pd.DataFrame({"7203": [False, True]}, index=index)
+
+    portfolio = VectorbtAdapter(engine="rust").create_signal_portfolio(
+        close=close,
+        entries=entries,
+        exits=exits,
+        direction="longonly",
+        init_cash=1_000_000,
+        fees=0.001,
+        slippage=0.0,
+    )
+
+    assert portfolio == "portfolio"
+    assert captured["engine"] == "rust"
+

--- a/apps/bt/tests/unit/backtest/test_vectorbt_adapter.py
+++ b/apps/bt/tests/unit/backtest/test_vectorbt_adapter.py
@@ -6,16 +6,19 @@ import pandas as pd
 import pytest
 
 from src.domains.backtest.vectorbt_adapter import (
+    DEFAULT_VECTORBT_ENGINE,
+    PERCENT_SIZE_TYPE,
+    ROUND_TRIP_DIRECTION_MAP,
     VECTORBT_ENGINE_ENV,
     VectorbtAdapter,
     resolve_vectorbt_engine,
 )
 
 
-def test_resolve_vectorbt_engine_defaults_to_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_vectorbt_engine_defaults_to_numba(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(VECTORBT_ENGINE_ENV, raising=False)
 
-    assert resolve_vectorbt_engine() == "auto"
+    assert resolve_vectorbt_engine() == DEFAULT_VECTORBT_ENGINE
 
 
 def test_resolve_vectorbt_engine_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,3 +69,84 @@ def test_create_signal_portfolio_passes_selected_engine(
     assert portfolio == "portfolio"
     assert captured["engine"] == "rust"
 
+
+def test_create_signal_portfolio_default_engine_runs_vectorbt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(VECTORBT_ENGINE_ENV, raising=False)
+
+    index = pd.date_range("2024-01-01", periods=2)
+    close = pd.DataFrame({"7203": [100.0, 101.0]}, index=index)
+    entries = pd.DataFrame({"7203": [True, False]}, index=index)
+    exits = pd.DataFrame({"7203": [False, True]}, index=index)
+
+    portfolio = VectorbtAdapter().create_signal_portfolio(
+        close=close,
+        entries=entries,
+        exits=exits,
+        direction="longonly",
+        init_cash=1_000_000,
+        fees=0.001,
+        slippage=0.0,
+    )
+
+    assert portfolio.total_return() is not None
+
+
+def test_create_signal_portfolio_rust_matches_numba_when_optional_engine_installed() -> None:
+    pytest.importorskip("vectorbt_rust")
+
+    index = pd.date_range("2024-01-01", periods=3)
+    close = pd.DataFrame({"7203": [100.0, 102.0, 101.0]}, index=index)
+    entries = pd.DataFrame({"7203": [True, False, False]}, index=index)
+    exits = pd.DataFrame({"7203": [False, False, True]}, index=index)
+
+    numba_portfolio = VectorbtAdapter(engine="numba").create_signal_portfolio(
+        close=close,
+        entries=entries,
+        exits=exits,
+        direction="longonly",
+        init_cash=1_000_000,
+        fees=0.001,
+        slippage=0.0,
+    )
+    rust_portfolio = VectorbtAdapter(engine="rust").create_signal_portfolio(
+        close=close,
+        entries=entries,
+        exits=exits,
+        direction="longonly",
+        init_cash=1_000_000,
+        fees=0.001,
+        slippage=0.0,
+    )
+
+    pd.testing.assert_series_equal(
+        rust_portfolio.total_return(),
+        numba_portfolio.total_return(),
+        check_names=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ["auto", "rust"])
+def test_round_trip_portfolio_rejects_non_numba_engine(engine: str) -> None:
+    index = pd.date_range("2024-01-01", periods=2)
+    open_data = pd.DataFrame({"7203": [100.0, 101.0]}, index=index)
+    close_data = pd.DataFrame({"7203": [101.0, 102.0]}, index=index)
+    entries = pd.DataFrame({"7203": [True, False]}, index=index)
+
+    with pytest.raises(ValueError, match="only supported for signal portfolios"):
+        VectorbtAdapter(engine=engine).create_round_trip_portfolio(
+            open_data=open_data,
+            close_data=close_data,
+            entries_data=entries,
+            execution_mode="next_session_round_trip",
+            entry_size=1.0,
+            entry_size_type=PERCENT_SIZE_TYPE,
+            direction=ROUND_TRIP_DIRECTION_MAP["longonly"],
+            fees=0.001,
+            slippage=0.0,
+            init_cash=1_000_000,
+            max_size=float("inf"),
+            cash_sharing=False,
+            group_by=None,
+        )

--- a/apps/bt/uv.lock
+++ b/apps/bt/uv.lock
@@ -1451,6 +1451,9 @@ dev = [
 nautilus = [
     { name = "nautilus-trader" },
 ]
+rust = [
+    { name = "vectorbt-rust" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1487,6 +1490,7 @@ dev = [
 ]
 nautilus = [{ name = "nautilus-trader", specifier = ">=1.225.0" }]
 research = []
+rust = [{ name = "vectorbt-rust", specifier = ">=1.0.0" }]
 
 [[package]]
 name = "traitlets"
@@ -1636,6 +1640,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/55/257d9217301d0817b4b0b2ed74e8949d1084d6457ad032c13ab81e652c3a/vectorbt-1.0.0.tar.gz", hash = "sha256:e42cd61ecdabb165bf7a482516f15f48b0173ad17629c875916dacfdc39b8fb0", size = 546226, upload-time = "2026-04-22T13:30:02.032Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/08/c15c7ade057b0633ac39fe6f5fffa37c306304745538c4f9187a05e9aa69/vectorbt-1.0.0-py3-none-any.whl", hash = "sha256:c596e11bdad985181150f3b3c8db0a7322c738fbb64c7a919a0418e99326cc13", size = 451657, upload-time = "2026-04-22T13:29:59.982Z" },
+]
+
+[[package]]
+name = "vectorbt-rust"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/32/a5b7193cfaaa4485e6b3c0156e15701b21bb505b66e035f01594675d1242/vectorbt_rust-1.0.0.tar.gz", hash = "sha256:d9ef94a24f970be4d566d5c41d20c436cb1593ae2e960ee2ae9851ce5042b9aa", size = 74476, upload-time = "2026-04-22T13:29:36.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/62/3df4be3717f3c2df07f51d380f9beae7100e78656b1879710e62c2d36f28/vectorbt_rust-1.0.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ceceb76bb1f485dc66eb3aa4ee2e4934b704c8753884a4c2eebf156427ecf374", size = 845019, upload-time = "2026-04-22T13:29:22.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5f/b96d327002901177fc05c64d9a99bbff5673a20081bb1a3a2e35e02a8707/vectorbt_rust-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:689794e3f3a91c0b8cfc3565076b01864a51a95a8a003410c972942a424a8014", size = 766156, upload-time = "2026-04-22T13:29:24.034Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fc/2ef2905a752f17329c768ddbfdff3cd14deab932e1010ca140bde9ab32b4/vectorbt_rust-1.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a204323805b5cc721ce4706f8d117886d0e860a2c74758aad965c65912aabc8f", size = 781441, upload-time = "2026-04-22T13:29:25.418Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c6/708752ae698161575fe949ba659341e24ebd6341ed683e1f2b66b7a84a35/vectorbt_rust-1.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a379f7ae66ef5733d5de6ae1f23f8434d4411918d04b9b2baf7e8db105ca759", size = 873255, upload-time = "2026-04-22T13:29:27.081Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/fe1b7b07520fbb1559187ea5a962db0246b5c3f6e24ace2f7cd6a5346fab/vectorbt_rust-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:f6adbd831d1615eca9e6499296345d092f670d668440d2b5043523f3753c62fc", size = 885340, upload-time = "2026-04-22T13:29:28.381Z" },
 ]
 
 [[package]]

--- a/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingTable.tsx
+++ b/apps/ts/packages/web/src/components/ValueCompositeRanking/ValueCompositeRankingTable.tsx
@@ -34,20 +34,20 @@ function formatMarketCapBil(value: number): string {
 type TechnicalMetricKey = Exclude<keyof NonNullable<ValueCompositeRankingItem['technicalMetrics']>, 'featureDate'>;
 
 interface TechnicalMetricColumn {
-  key: TechnicalMetricKey;
+  metric: TechnicalMetricKey;
   label: string;
   signed: boolean;
 }
 
 const STANDARD_TECHNICAL_COLUMNS: TechnicalMetricColumn[] = [
-  { key: 'reboundFrom252dLowPct', label: '252d Low Reb', signed: true },
-  { key: 'return252dPct', label: '252d Ret', signed: true },
+  { metric: 'reboundFrom252dLowPct', label: '252d Low Reb', signed: true },
+  { metric: 'return252dPct', label: '252d Ret', signed: true },
 ];
 
 const PRIME_TECHNICAL_COLUMNS: TechnicalMetricColumn[] = [
-  { key: 'volatility20dPct', label: 'Vol 20d', signed: false },
-  { key: 'volatility60dPct', label: 'Vol 60d', signed: false },
-  { key: 'downsideVolatility60dPct', label: 'Down Vol 60d', signed: false },
+  { metric: 'volatility20dPct', label: 'Vol 20d', signed: false },
+  { metric: 'volatility60dPct', label: 'Vol 60d', signed: false },
+  { metric: 'downsideVolatility60dPct', label: 'Down Vol 60d', signed: false },
 ];
 
 function normalizeMarket(value: string | null | undefined): 'prime' | 'standard' | 'other' {
@@ -97,8 +97,8 @@ function ValueCompositeRankingRow({
       <td className="px-2 py-1.5 truncate max-w-[100px] text-muted-foreground">{item.sector33Name}</td>
       <td className="px-2 py-1.5 text-right font-medium tabular-nums">{formatScore(item.score)}</td>
       {technicalColumns.map((column) => (
-        <td key={column.key} className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
-          {formatTechnicalPercent(item.technicalMetrics?.[column.key], column.signed)}
+        <td key={column.metric} className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
+          {formatTechnicalPercent(item.technicalMetrics?.[column.metric], column.signed)}
         </td>
       ))}
       <td className="px-2 py-1.5 text-right tabular-nums">{formatRatio(item.pbr)}</td>
@@ -148,7 +148,7 @@ export function ValueCompositeRankingTable({ data, isLoading, error, onStockClic
                 <th className="text-left px-2 py-1.5 w-24">Sector</th>
                 <th className="text-right px-2 py-1.5 w-20">Score</th>
                 {technicalColumns.map((column) => (
-                  <th key={column.key} className="text-right px-2 py-1.5 w-24">
+                  <th key={column.metric} className="text-right px-2 py-1.5 w-24">
                     {column.label}
                   </th>
                 ))}

--- a/scripts/test-packages.sh
+++ b/scripts/test-packages.sh
@@ -34,7 +34,6 @@ run_bt_unit_shards() {
   )
   local -a shard_core=(
     tests/unit/agent
-    tests/unit/analysis
     tests/unit/api
     tests/unit/application
     tests/unit/architecture


### PR DESCRIPTION
## Summary
- add optional `vectorbt-rust` dependency group for `apps/bt`
- add `BT_VECTORBT_ENGINE=auto|numba|rust` selector in the VectorBT adapter
- pass the selected engine to `Portfolio.from_signals` while keeping round-trip `from_order_func` on the existing Numba path
- document the short-term Rust dispatch usage and add adapter unit tests

## Verification
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt pytest apps/bt/tests/unit/backtest/test_vectorbt_adapter.py apps/bt/tests/unit/strategies/test_costs.py apps/bt/tests/unit/strategies/test_position_limits.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt ruff check apps/bt/src/domains/backtest/vectorbt_adapter.py apps/bt/tests/unit/backtest/test_vectorbt_adapter.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/bt --group rust python -c ...` smoke confirmed `Portfolio rust`

## Notes
- This is intentionally scoped to the short-term path: Rust dispatch applies to `Portfolio.from_signals` only.
- Current round-trip execution semantics continue to use the existing custom Numba order function.