### PR TITLE
feat(bt): add daily market sync scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ LOG_LEVEL=info
 # Optional runtime environment label
 NODE_ENV=development
 
+# Optional FastAPI background scheduler for market DB incremental sync.
+# When enabled, FastAPI checks J-Quants TOPIX data at 16:30 JST and only syncs on actual trading days.
+# MARKET_SYNC_SCHEDULER_ENABLED=false
+# MARKET_SYNC_SCHEDULER_TIME_JST=16:30
+# MARKET_SYNC_SCHEDULER_ENFORCE_BULK_FOR_STOCK_DATA=false
+
 # --- bt data plane (Phase 2) ---
 # MARKET_TIMESERIES_BACKEND=duckdb-parquet
 # MARKET_TIMESERIES_DIR=$HOME/.local/share/trading25/market-timeseries

--- a/apps/bt/src/application/services/daily_market_sync_scheduler.py
+++ b/apps/bt/src/application/services/daily_market_sync_scheduler.py
@@ -1,0 +1,187 @@
+"""Daily market DB incremental sync scheduler.
+
+Runs inside the FastAPI process when enabled. The scheduler wakes at a
+configured JST wall-clock time, checks whether J-Quants has TOPIX data for the
+current date, and starts the existing incremental market DB sync job only on
+actual trading days.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime, time, timedelta
+from types import SimpleNamespace
+from typing import Any, Protocol, cast
+from zoneinfo import ZoneInfo
+
+from fastapi import FastAPI, Request
+from loguru import logger
+
+from src.application.services.sync_service import SyncMode, start_sync
+
+_JST = ZoneInfo("Asia/Tokyo")
+_DEFAULT_CHECK_ENDPOINT = "/indices/bars/daily/topix"
+
+
+class ScheduledSyncJQuantsClientLike(Protocol):
+    @property
+    def has_api_key(self) -> bool: ...
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]: ...
+
+    async def get_paginated(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        max_pages: int = 10,
+    ) -> list[dict[str, Any]]: ...
+
+
+class DailyMarketSyncSchedulerSettingsLike(Protocol):
+    market_sync_scheduler_enabled: bool
+    market_sync_scheduler_time_jst: str
+    market_sync_scheduler_enforce_bulk_for_stock_data: bool
+
+
+def _to_jst(now: datetime | None = None) -> datetime:
+    resolved = now or datetime.now(_JST)
+    if resolved.tzinfo is None:
+        return resolved.replace(tzinfo=_JST)
+    return resolved.astimezone(_JST)
+
+
+def parse_schedule_time_jst(value: str) -> time:
+    text = value.strip()
+    try:
+        hour_text, minute_text = text.split(":", maxsplit=1)
+        parsed = time(int(hour_text), int(minute_text))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("MARKET_SYNC_SCHEDULER_TIME_JST must be HH:MM") from exc
+    return parsed
+
+
+def seconds_until_next_schedule(
+    *,
+    now: datetime | None = None,
+    schedule_time: time,
+) -> float:
+    current = _to_jst(now)
+    target = datetime.combine(current.date(), schedule_time, tzinfo=_JST)
+    if target <= current:
+        target += timedelta(days=1)
+    return (target - current).total_seconds()
+
+
+def _jquants_date_param(target_date: date) -> str:
+    return target_date.strftime("%Y%m%d")
+
+
+def _row_matches_date(row: dict[str, Any], target_date: date) -> bool:
+    expected_compact = target_date.strftime("%Y%m%d")
+    expected_iso = target_date.isoformat()
+    raw_value = row.get("Date", row.get("date"))
+    if raw_value is None:
+        return False
+    text = str(raw_value).strip()
+    return text in {expected_compact, expected_iso}
+
+
+async def is_jquants_trading_day(
+    jquants_client: ScheduledSyncJQuantsClientLike,
+    *,
+    target_date: date,
+    endpoint: str = _DEFAULT_CHECK_ENDPOINT,
+) -> bool:
+    """Return True when J-Quants exposes TOPIX data for target_date."""
+    if target_date.weekday() >= 5:
+        return False
+
+    rows = await jquants_client.get_paginated(
+        endpoint,
+        params={"date": _jquants_date_param(target_date)},
+        max_pages=1,
+    )
+    return any(_row_matches_date(row, target_date) for row in rows)
+
+
+async def trigger_scheduled_incremental_sync(
+    app: FastAPI,
+    *,
+    jquants_client: ScheduledSyncJQuantsClientLike,
+    target_date: date | None = None,
+    enforce_bulk_for_stock_data: bool = False,
+) -> str:
+    """Check trading day and start an incremental sync job.
+
+    Returns a small status string for logs/tests:
+    - no_api_key
+    - non_trading_day
+    - already_running
+    - started:<job_id>
+    - setup_error:<message>
+    """
+    if not jquants_client.has_api_key:
+        logger.info("Scheduled market sync skipped: JQuants API key is not configured")
+        return "no_api_key"
+
+    current_date = target_date or _to_jst().date()
+    if not await is_jquants_trading_day(jquants_client, target_date=current_date):
+        logger.info("Scheduled market sync skipped: {} is not a J-Quants trading day", current_date.isoformat())
+        return "non_trading_day"
+
+    # Reuse the HTTP route resource choreography so scheduled sync has the same
+    # read-only reader close/restore behavior as POST /api/db/sync.
+    from src.entrypoints.http.routes import db as db_routes
+
+    request_like = cast(Request, SimpleNamespace(app=app))
+    try:
+        market_db, time_series_store = db_routes._prepare_market_write_resources(request_like)  # noqa: SLF001
+    except RuntimeError as exc:
+        logger.warning("Scheduled market sync setup failed: {}", exc)
+        return f"setup_error:{exc}"
+
+    try:
+        job = await start_sync(
+            SyncMode.INCREMENTAL,
+            market_db,
+            jquants_client,
+            time_series_store=time_series_store,
+            close_time_series_store=True,
+            close_market_db=True,
+            on_finish=lambda: db_routes._restore_read_only_market_resources(request_like),  # noqa: SLF001
+            enforce_bulk_for_stock_data=enforce_bulk_for_stock_data,
+        )
+    except Exception:
+        db_routes._restore_read_only_market_resources(request_like)  # noqa: SLF001
+        raise
+
+    if job is None:
+        db_routes._restore_read_only_market_resources(request_like)  # noqa: SLF001
+        logger.info("Scheduled market sync skipped: another sync job is already running")
+        return "already_running"
+
+    logger.info("Scheduled market sync started: jobId={} date={}", job.job_id, current_date.isoformat())
+    return f"started:{job.job_id}"
+
+
+async def run_daily_market_sync_scheduler(
+    app: FastAPI,
+    *,
+    settings: DailyMarketSyncSchedulerSettingsLike,
+    jquants_client: ScheduledSyncJQuantsClientLike,
+) -> None:
+    schedule_time = parse_schedule_time_jst(settings.market_sync_scheduler_time_jst)
+    logger.info("Scheduled market sync enabled: daily at {} JST", schedule_time.strftime("%H:%M"))
+
+    while True:
+        await asyncio.sleep(seconds_until_next_schedule(schedule_time=schedule_time))
+        try:
+            await trigger_scheduled_incremental_sync(
+                app,
+                jquants_client=jquants_client,
+                enforce_bulk_for_stock_data=settings.market_sync_scheduler_enforce_bulk_for_stock_data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - scheduler should survive one failed wake
+            logger.exception("Scheduled market sync failed: {}", exc)

--- a/apps/bt/src/entrypoints/http/app.py
+++ b/apps/bt/src/entrypoints/http/app.py
@@ -46,6 +46,7 @@ from src.application.services.margin_analytics_service import create_market_marg
 from src.application.services.market_data_service import MarketDataService
 from src.application.services.optimization_service import optimization_service
 from src.application.services.dataset_resolver import DatasetResolver
+from src.application.services.daily_market_sync_scheduler import run_daily_market_sync_scheduler
 from src.application.services.roe_service import create_market_roe_service
 from src.application.services.screening_job_service import (
     screening_job_manager,
@@ -194,6 +195,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.dataset_resolver = dataset_resolver
 
     cleanup_task = asyncio.create_task(_periodic_cleanup())
+    daily_market_sync_task: asyncio.Task[None] | None = None
+    if settings.market_sync_scheduler_enabled:
+        daily_market_sync_task = asyncio.create_task(
+            run_daily_market_sync_scheduler(
+                app,
+                settings=settings,
+                jquants_client=jquants_client,
+            )
+        )
 
     yield
 
@@ -201,6 +211,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     cleanup_task.cancel()
     with suppress(asyncio.CancelledError):
         await cleanup_task
+    if daily_market_sync_task is not None:
+        daily_market_sync_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await daily_market_sync_task
 
     # Phase 3D: Job manager shutdown（DB close 前に durable write を済ませる）
     from src.application.services.sync_service import sync_job_manager

--- a/apps/bt/src/shared/config/settings.py
+++ b/apps/bt/src/shared/config/settings.py
@@ -54,6 +54,20 @@ class Settings(BaseModel):
         alias="BT_LAB_JOB_TIMEOUT_SECONDS",
     )
 
+    # Market DB daily incremental sync scheduler (FastAPI background task)
+    market_sync_scheduler_enabled: bool = Field(
+        default=False,
+        alias="MARKET_SYNC_SCHEDULER_ENABLED",
+    )
+    market_sync_scheduler_time_jst: str = Field(
+        default="16:30",
+        alias="MARKET_SYNC_SCHEDULER_TIME_JST",
+    )
+    market_sync_scheduler_enforce_bulk_for_stock_data: bool = Field(
+        default=False,
+        alias="MARKET_SYNC_SCHEDULER_ENFORCE_BULK_FOR_STOCK_DATA",
+    )
+
     # JQuants API
     jquants_api_key: str = Field(default="", alias="JQUANTS_API_KEY")
     jquants_plan: str = Field(default="free", alias="JQUANTS_PLAN")

--- a/apps/bt/tests/unit/application/test_daily_market_sync_scheduler.py
+++ b/apps/bt/tests/unit/application/test_daily_market_sync_scheduler.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.application.services.daily_market_sync_scheduler import (
+    is_jquants_trading_day,
+    parse_schedule_time_jst,
+    seconds_until_next_schedule,
+)
+
+
+class FakeJQuantsClient:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+        self.calls: list[tuple[str, dict[str, object] | None, int]] = []
+
+    @property
+    def has_api_key(self) -> bool:
+        return True
+
+    async def get_paginated(
+        self,
+        path: str,
+        params: dict[str, object] | None = None,
+        max_pages: int = 10,
+    ) -> list[dict[str, object]]:
+        self.calls.append((path, params, max_pages))
+        return self.rows
+
+
+def test_parse_schedule_time_jst_accepts_hh_mm() -> None:
+    assert parse_schedule_time_jst("16:30") == time(16, 30)
+
+
+@pytest.mark.parametrize("value", ["1630", "24:00", "aa:bb"])
+def test_parse_schedule_time_jst_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        parse_schedule_time_jst(value)
+
+
+def test_seconds_until_next_schedule_same_day() -> None:
+    now = datetime(2026, 5, 1, 15, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    assert seconds_until_next_schedule(now=now, schedule_time=time(16, 30)) == 90 * 60
+
+
+def test_seconds_until_next_schedule_rolls_to_next_day() -> None:
+    now = datetime(2026, 5, 1, 17, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    assert seconds_until_next_schedule(now=now, schedule_time=time(16, 30)) == (23 * 60 + 30) * 60
+
+
+@pytest.mark.asyncio
+async def test_is_jquants_trading_day_skips_weekends_without_api_call() -> None:
+    client = FakeJQuantsClient(rows=[{"Date": "20260502"}])
+
+    assert await is_jquants_trading_day(client, target_date=date(2026, 5, 2)) is False
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_is_jquants_trading_day_uses_topix_date_row() -> None:
+    client = FakeJQuantsClient(rows=[{"Date": "20260501"}])
+
+    assert await is_jquants_trading_day(client, target_date=date(2026, 5, 1)) is True
+    assert client.calls == [
+        (
+            "/indices/bars/daily/topix",
+            {"date": "20260501"},
+            1,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_is_jquants_trading_day_requires_matching_date() -> None:
+    client = FakeJQuantsClient(rows=[{"Date": "20260430"}])
+
+    assert await is_jquants_trading_day(client, target_date=date(2026, 5, 1)) is False

--- a/apps/bt/tests/unit/config/test_settings.py
+++ b/apps/bt/tests/unit/config/test_settings.py
@@ -15,6 +15,9 @@ def test_settings_defaults(monkeypatch):
     monkeypatch.delenv("BT_BACKTEST_JOB_TIMEOUT_SECONDS", raising=False)
     monkeypatch.delenv("BT_OPTIMIZATION_JOB_TIMEOUT_SECONDS", raising=False)
     monkeypatch.delenv("BT_LAB_JOB_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("MARKET_SYNC_SCHEDULER_ENABLED", raising=False)
+    monkeypatch.delenv("MARKET_SYNC_SCHEDULER_TIME_JST", raising=False)
+    monkeypatch.delenv("MARKET_SYNC_SCHEDULER_ENFORCE_BULK_FOR_STOCK_DATA", raising=False)
 
     settings = reload_settings()
 
@@ -24,6 +27,9 @@ def test_settings_defaults(monkeypatch):
     assert settings.backtest_job_timeout_seconds == 3600
     assert settings.optimization_job_timeout_seconds == 3600
     assert settings.lab_job_timeout_seconds == 3600
+    assert settings.market_sync_scheduler_enabled is False
+    assert settings.market_sync_scheduler_time_jst == "16:30"
+    assert settings.market_sync_scheduler_enforce_bulk_for_stock_data is False
 
 
 def test_settings_env_override(monkeypatch):
@@ -33,6 +39,9 @@ def test_settings_env_override(monkeypatch):
     monkeypatch.setenv("BT_BACKTEST_JOB_TIMEOUT_SECONDS", "1800")
     monkeypatch.setenv("BT_OPTIMIZATION_JOB_TIMEOUT_SECONDS", "2400")
     monkeypatch.setenv("BT_LAB_JOB_TIMEOUT_SECONDS", "3000")
+    monkeypatch.setenv("MARKET_SYNC_SCHEDULER_ENABLED", "true")
+    monkeypatch.setenv("MARKET_SYNC_SCHEDULER_TIME_JST", "17:05")
+    monkeypatch.setenv("MARKET_SYNC_SCHEDULER_ENFORCE_BULK_FOR_STOCK_DATA", "true")
 
     settings = reload_settings()
 
@@ -42,6 +51,9 @@ def test_settings_env_override(monkeypatch):
     assert settings.backtest_job_timeout_seconds == 1800
     assert settings.optimization_job_timeout_seconds == 2400
     assert settings.lab_job_timeout_seconds == 3000
+    assert settings.market_sync_scheduler_enabled is True
+    assert settings.market_sync_scheduler_time_jst == "17:05"
+    assert settings.market_sync_scheduler_enforce_bulk_for_stock_data is True
 
 
 def test_settings_cache(monkeypatch):
@@ -72,11 +84,12 @@ def test_settings_module_loads_dotenv():
     assert settings_mod._dotenv_path == expected
 
 
-def test_find_repo_root_raises_when_git_not_found(tmp_path):
+def test_find_repo_root_raises_when_git_not_found():
+    from pathlib import Path
+
     from src.shared.config.settings import _find_repo_root
 
-    start = tmp_path / "nested" / "path"
-    start.mkdir(parents=True)
+    start = Path("/__trading25_missing_git_root__/nested/path")
 
     with pytest.raises(RuntimeError):
         _find_repo_root(start)


### PR DESCRIPTION
## Summary
- add an optional FastAPI lifespan background scheduler for daily market DB incremental sync
- check J-Quants TOPIX data for the target date before syncing, so holidays/non-trading days are skipped
- add env settings and .env.example documentation

## Test
- uv run pytest tests/unit/application/test_daily_market_sync_scheduler.py tests/unit/config/test_settings.py
- uv run pyright src/application/services/daily_market_sync_scheduler.py src/entrypoints/http/app.py src/shared/config/settings.py
- uv run ruff check src/application/services/daily_market_sync_scheduler.py src/entrypoints/http/app.py src/shared/config/settings.py tests/unit/application/test_daily_market_sync_scheduler.py tests/unit/config/test_settings.py