### PR TITLE
Refactor bt research common primitives into internal core

### DIFF
--- a/apps/bt/docs/research-core.md
+++ b/apps/bt/docs/research-core.md
@@ -1,0 +1,71 @@
+# bt Internal Research Core
+
+## Purpose
+
+`src.domains.analytics.research_core` is a thin internal layer for runner-first
+research primitives that are repeated across Trading25 analytics studies. It is
+not an external library, a product API, or a generic research DSL. The core keeps
+Trading25-specific Data Plane assumptions close to the research modules while
+removing low-value duplication from individual studies.
+
+## Current Scope
+
+- `research_core.universe`
+  - Market-behavior universe labels and order: `topix500`, `prime_ex_topix500`,
+    `standard`, `growth`.
+  - Current market-code aliases through `expand_market_codes`.
+  - Static SQL fragments for the `stock_master_daily` as-of universe join.
+- `research_core.parameters`
+  - Positive integer sequence normalization for window and horizon parameters.
+  - Rolling-window warmup start-date estimation with explicit session/calendar
+    multiplier and available-start clamp.
+- `research_core.tables`
+  - Stable output-table ordering with universe order and optional local ordering
+    maps.
+
+The initial migration covers these representative market-behavior studies:
+
+- `classical_momentum_research`
+- `new_high_momentum_research`
+- `turtle_like_momentum_research`
+
+These were chosen because they share the same market universe, output ordering,
+and warmup/parameter patterns while still exercising different research shapes:
+event selection, condition bucket summaries, and trade-ledger portfolio output.
+
+## Boundaries
+
+- `research_bundle.py` remains the bundle/output SoT for
+  `manifest.json + results.duckdb + summary.md`.
+- `readonly_duckdb_support.py` remains the local DuckDB read/snapshot support.
+- `shared/utils/pit_guard.py` remains the preferred helper for PIT-safe
+  dataframe joins.
+- `scripts/research/common.py` remains runner CLI glue for output arguments and
+  bundle payload printing.
+- Individual research modules still own study-specific SQL, features, buckets,
+  portfolio construction, interpretation, and Published Readout content.
+
+## Candidate Backlog
+
+Keep future additions small and proven by at least two real research modules
+before moving them into the core.
+
+- `event_panel`: canonical stock price + `stock_master_daily` as-of panel CTE,
+  including 4-digit/5-digit dedupe and current market universe scoping.
+- `asof_features`: PIT-safe latest fundamentals or valuation feature joins when
+  dataframe helpers are not enough and the SQL pattern is repeated.
+- `bucket_analysis`: repeated quantile/condition bucket summaries, baseline
+  lift, and same-universe-day lift calculations.
+- `research_outputs`: output table shape checks and bundle table naming helpers.
+- `validation`: horizon coverage checks, event/date leakage assertions, and
+  minimum sample-size diagnostics.
+
+## Guardrails
+
+- Do not move one-off strategy logic into the core.
+- Do not make the core a new execution engine or replace vectorbt/Nautilus roles.
+- Do not change runner-first, bundle-first, or Published Readout SoT behavior.
+- Preserve PIT filtering order: as-of filtering must happen before latest-row
+  selection.
+- Keep migrations incremental; each core primitive should have focused tests and
+  at least one representative runner migration.

--- a/apps/bt/src/domains/analytics/classical_momentum_research.py
+++ b/apps/bt/src/domains/analytics/classical_momentum_research.py
@@ -16,13 +16,21 @@ from src.domains.analytics.readonly_duckdb_support import (
     normalize_code_sql,
     open_readonly_analysis_connection,
 )
+from src.domains.analytics.research_core import (
+    UNIVERSE_LABELS,
+    build_market_universe_case_sql,
+    normalize_positive_int_sequence,
+    research_universe_market_codes,
+    sort_research_table,
+    sql_string_list,
+    warmup_start_date,
+)
 from src.domains.analytics.research_bundle import (
     ResearchBundleInfo,
     load_dataclass_research_bundle,
     write_dataclass_research_bundle,
 )
 from src.domains.analytics.topix_rank_future_close_core import _default_start_date
-from src.shared.utils.market_code_alias import expand_market_codes
 
 CLASSICAL_MOMENTUM_RESEARCH_EXPERIMENT_ID = "market-behavior/classical-momentum-research"
 
@@ -37,26 +45,6 @@ DEFAULT_SELECTION_FRACTIONS: tuple[float, ...] = (0.05, 0.10)
 DEFAULT_REBALANCE_INTERVAL_SESSIONS = 20
 DEFAULT_MIN_AVG_TRADING_VALUE_MIL_JPY = 10.0
 
-PRIME_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["prime"]))
-STANDARD_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["standard"]))
-GROWTH_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["growth"]))
-TOPIX500_SCALE_CATEGORIES: tuple[str, ...] = (
-    "TOPIX Core30",
-    "TOPIX Large70",
-    "TOPIX Mid400",
-)
-UNIVERSE_ORDER: tuple[str, ...] = (
-    "topix500",
-    "prime_ex_topix500",
-    "standard",
-    "growth",
-)
-UNIVERSE_LABELS: dict[str, str] = {
-    "topix500": "TOPIX500",
-    "prime_ex_topix500": "Prime ex TOPIX500",
-    "standard": "Standard",
-    "growth": "Growth",
-}
 TABLE_FIELD_NAMES: tuple[str, ...] = (
     "universe_summary_df",
     "selected_event_df",
@@ -87,22 +75,10 @@ class ClassicalMomentumResearchResult:
     portfolio_summary_df: pd.DataFrame
 
 
-def _sql_string_list(values: tuple[str, ...]) -> str:
-    return ", ".join(f"'{value}'" for value in values)
-
-
 def _sort_table(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    result = df.copy()
-    if "universe_key" in result.columns:
-        result["_universe_order"] = result["universe_key"].map(
-            {key: index for index, key in enumerate(UNIVERSE_ORDER)}
-        )
-    sort_columns = [
-        column
-        for column in (
-            "_universe_order",
+    return sort_research_table(
+        df,
+        sort_columns=(
             "lookback_sessions",
             "skip_sessions",
             "hold_sessions",
@@ -111,12 +87,8 @@ def _sort_table(df: pd.DataFrame) -> pd.DataFrame:
             "date",
             "selection_rank",
             "code",
-        )
-        if column in result.columns
-    ]
-    if sort_columns:
-        result = result.sort_values(sort_columns, kind="stable").reset_index(drop=True)
-    return result.drop(columns=[column for column in result.columns if column.startswith("_")])
+        ),
+    )
 
 
 def _normalize_lookback_specs(
@@ -138,25 +110,6 @@ def _normalize_lookback_specs(
             normalized.append(spec)
     if not normalized:
         raise ValueError("at least one lookback spec is required")
-    return tuple(sorted(normalized))
-
-
-def _normalize_positive_int_sequence(
-    values: tuple[int, ...] | list[int] | None,
-    *,
-    fallback: tuple[int, ...],
-    name: str,
-) -> tuple[int, ...]:
-    raw_values = fallback if values is None else tuple(values)
-    normalized: list[int] = []
-    for raw_value in raw_values:
-        value = int(raw_value)
-        if value <= 0:
-            raise ValueError(f"{name} values must be positive")
-        if value not in normalized:
-            normalized.append(value)
-    if not normalized:
-        raise ValueError(f"at least one {name} value is required")
     return tuple(sorted(normalized))
 
 
@@ -182,16 +135,12 @@ def _warmup_start_date(
     *,
     lookback_specs: tuple[tuple[int, int], ...],
 ) -> str | None:
-    if analysis_start_date is None:
-        return available_start_date
-    max_lookback = max(lookback for lookback, _ in lookback_specs)
-    warmup_days = int(max_lookback * 2.1) + 30
-    candidate = (pd.Timestamp(analysis_start_date) - pd.Timedelta(days=warmup_days)).strftime(
-        "%Y-%m-%d"
+    return warmup_start_date(
+        analysis_start_date,
+        available_start_date,
+        warmup_sessions=max(lookback for lookback, _ in lookback_specs),
+        session_to_calendar_multiplier=2.1,
     )
-    if available_start_date is None:
-        return candidate
-    return max(available_start_date, candidate)
 
 
 def _create_panel_table(
@@ -205,9 +154,7 @@ def _create_panel_table(
 ) -> None:
     price_code = normalize_code_sql("sd.code")
     master_code = normalize_code_sql("smd.code")
-    all_market_codes = tuple(
-        dict.fromkeys([*PRIME_MARKET_CODES, *STANDARD_MARKET_CODES, *GROWTH_MARKET_CODES])
-    )
+    all_market_codes = research_universe_market_codes()
     raw_date_filter = ""
     raw_params: list[str] = []
     if raw_start_date is not None:
@@ -287,22 +234,14 @@ def _create_panel_table(
                 smd.company_name,
                 smd.market_code,
                 smd.scale_category,
-                CASE
-                    WHEN smd.scale_category IN ({_sql_string_list(TOPIX500_SCALE_CATEGORIES)})
-                        THEN 'topix500'
-                    WHEN smd.market_code IN ({_sql_string_list(PRIME_MARKET_CODES)})
-                        THEN 'prime_ex_topix500'
-                    WHEN smd.market_code IN ({_sql_string_list(STANDARD_MARKET_CODES)})
-                        THEN 'standard'
-                    WHEN smd.market_code IN ({_sql_string_list(GROWTH_MARKET_CODES)})
-                        THEN 'growth'
-                END AS universe_key,
+                {build_market_universe_case_sql(market_code_column="smd.market_code", scale_category_column="smd.scale_category")}
+                    AS universe_key,
                 row_number() OVER (
                     PARTITION BY {master_code}, smd.date
                     ORDER BY CASE WHEN length(smd.code) = 4 THEN 0 ELSE 1 END, smd.code
                 ) AS row_rank
             FROM stock_master_daily smd
-            WHERE smd.market_code IN ({_sql_string_list(all_market_codes)})
+            WHERE smd.market_code IN ({sql_string_list(all_market_codes)})
         ),
         scoped AS (
             SELECT p.*, m.company_name, m.market_code, m.scale_category, m.universe_key
@@ -745,7 +684,7 @@ def run_classical_momentum_research(
     min_avg_trading_value_mil_jpy: float = DEFAULT_MIN_AVG_TRADING_VALUE_MIL_JPY,
 ) -> ClassicalMomentumResearchResult:
     normalized_specs = _normalize_lookback_specs(lookback_specs)
-    normalized_holds = _normalize_positive_int_sequence(
+    normalized_holds = normalize_positive_int_sequence(
         hold_sessions,
         fallback=DEFAULT_HOLD_SESSIONS,
         name="hold_sessions",

--- a/apps/bt/src/domains/analytics/new_high_momentum_research.py
+++ b/apps/bt/src/domains/analytics/new_high_momentum_research.py
@@ -21,13 +21,21 @@ from src.domains.analytics.readonly_duckdb_support import (
     normalize_code_sql,
     open_readonly_analysis_connection,
 )
+from src.domains.analytics.research_core import (
+    UNIVERSE_LABELS,
+    build_market_universe_case_sql,
+    normalize_positive_int_sequence,
+    research_universe_market_codes,
+    sort_research_table,
+    sql_string_list,
+    warmup_start_date,
+)
 from src.domains.analytics.research_bundle import (
     ResearchBundleInfo,
     load_dataclass_research_bundle,
     write_dataclass_research_bundle,
 )
 from src.domains.analytics.topix_rank_future_close_core import _default_start_date
-from src.shared.utils.market_code_alias import expand_market_codes
 
 NEW_HIGH_MOMENTUM_EXPERIMENT_ID = "market-behavior/new-high-momentum-research"
 
@@ -38,27 +46,6 @@ DEFAULT_SAMPLE_EVENT_SIZE = 40
 TECHNICAL_BASELINE_WINDOW = 20
 RANGE_WINDOW = 252
 MEMBERSHIP_MODE = "stock_master_daily_as_of_price_date"
-
-PRIME_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["prime"]))
-STANDARD_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["standard"]))
-GROWTH_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["growth"]))
-TOPIX500_SCALE_CATEGORIES: tuple[str, ...] = (
-    "TOPIX Core30",
-    "TOPIX Large70",
-    "TOPIX Mid400",
-)
-UNIVERSE_ORDER: tuple[str, ...] = (
-    "topix500",
-    "prime_ex_topix500",
-    "standard",
-    "growth",
-)
-UNIVERSE_LABELS: dict[str, str] = {
-    "topix500": "TOPIX500",
-    "prime_ex_topix500": "Prime ex TOPIX500",
-    "standard": "Standard",
-    "growth": "Growth",
-}
 
 TABLE_FIELD_NAMES: tuple[str, ...] = (
     "universe_summary_df",
@@ -252,39 +239,18 @@ class NewHighMomentumResearchResult:
     sampled_events_df: pd.DataFrame
 
 
-def _normalize_positive_int_sequence(
-    values: tuple[int, ...] | list[int] | None,
-    *,
-    fallback: tuple[int, ...],
-    name: str,
-) -> tuple[int, ...]:
-    if values is None:
-        return fallback
-    normalized = tuple(sorted(dict.fromkeys(int(value) for value in values if int(value) > 0)))
-    if not normalized:
-        raise ValueError(f"{name} must contain at least one positive integer")
-    return normalized
-
-
 def _warmup_start_date(
     analysis_start_date: str | None,
     available_start_date: str | None,
     *,
     high_windows: tuple[int, ...],
 ) -> str | None:
-    if analysis_start_date is None:
-        return available_start_date
-    warmup_days = int(max(high_windows) * 2.1) + 30
-    candidate = (pd.Timestamp(analysis_start_date) - pd.Timedelta(days=warmup_days)).strftime(
-        "%Y-%m-%d"
+    return warmup_start_date(
+        analysis_start_date,
+        available_start_date,
+        warmup_sessions=max(high_windows),
+        session_to_calendar_multiplier=2.1,
     )
-    if available_start_date is None:
-        return candidate
-    return max(available_start_date, candidate)
-
-
-def _sql_string_list(values: tuple[str, ...]) -> str:
-    return ", ".join(f"'{value}'" for value in values)
 
 
 def _table_exists(conn: Any, table_name: str) -> bool:
@@ -300,43 +266,26 @@ def _table_exists(conn: Any, table_name: str) -> bool:
 
 
 def _sort_table(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    result = df.copy()
-    if "universe_key" in result.columns:
-        result["_universe_order"] = result["universe_key"].map(
-            {key: index for index, key in enumerate(UNIVERSE_ORDER)}
-        )
-    if "condition_family" in result.columns:
-        family_order = {
-            "baseline": 0,
-            "technical": 1,
-            "fundamental": 2,
-            "annual_value": 3,
-            "interaction": 4,
-        }
-        result["_condition_family_order"] = result["condition_family"].map(family_order)
-    if "condition_key" in result.columns:
-        result["_condition_order"] = result["condition_key"].map(
-            {item.key: index for index, item in enumerate(CONDITION_DEFINITIONS)}
-        )
-    sort_columns = [
-        column
-        for column in (
-            "_universe_order",
+    return sort_research_table(
+        df,
+        sort_columns=(
             "new_high_window",
-            "_condition_family_order",
-            "_condition_order",
             "horizon_days",
             "selection_rank",
             "date",
             "code",
-        )
-        if column in result.columns
-    ]
-    if sort_columns:
-        result = result.sort_values(sort_columns, kind="stable").reset_index(drop=True)
-    return result.drop(columns=[column for column in result.columns if column.startswith("_")])
+        ),
+        extra_order_columns={
+            "condition_family": {
+                "baseline": 0,
+                "technical": 1,
+                "fundamental": 2,
+                "annual_value": 3,
+                "interaction": 4,
+            },
+            "condition_key": {item.key: index for index, item in enumerate(CONDITION_DEFINITIONS)},
+        },
+    )
 
 
 def _create_panel_tables(
@@ -351,9 +300,7 @@ def _create_panel_tables(
     price_code = normalize_code_sql("sd.code")
     master_code = normalize_code_sql("smd.code")
     statement_code = normalize_code_sql("s.code")
-    all_market_codes = tuple(
-        dict.fromkeys([*PRIME_MARKET_CODES, *STANDARD_MARKET_CODES, *GROWTH_MARKET_CODES])
-    )
+    all_market_codes = research_universe_market_codes()
     raw_date_filter = ""
     raw_params: list[str] = []
     if raw_start_date is not None:
@@ -438,22 +385,14 @@ def _create_panel_tables(
                 smd.company_name,
                 smd.market_code,
                 smd.scale_category,
-                CASE
-                    WHEN smd.scale_category IN ({_sql_string_list(TOPIX500_SCALE_CATEGORIES)})
-                        THEN 'topix500'
-                    WHEN smd.market_code IN ({_sql_string_list(PRIME_MARKET_CODES)})
-                        THEN 'prime_ex_topix500'
-                    WHEN smd.market_code IN ({_sql_string_list(STANDARD_MARKET_CODES)})
-                        THEN 'standard'
-                    WHEN smd.market_code IN ({_sql_string_list(GROWTH_MARKET_CODES)})
-                        THEN 'growth'
-                END AS universe_key,
+                {build_market_universe_case_sql(market_code_column="smd.market_code", scale_category_column="smd.scale_category")}
+                    AS universe_key,
                 row_number() OVER (
                     PARTITION BY {master_code}, smd.date
                     ORDER BY CASE WHEN length(smd.code) = 4 THEN 0 ELSE 1 END, smd.code
                 ) AS row_rank
             FROM stock_master_daily smd
-            WHERE smd.market_code IN ({_sql_string_list(all_market_codes)})
+            WHERE smd.market_code IN ({sql_string_list(all_market_codes)})
         ),
         scoped AS (
             SELECT p.*, m.company_name, m.market_code, m.scale_category, m.universe_key
@@ -1285,15 +1224,17 @@ def run_new_high_momentum_research(
     horizons: tuple[int, ...] | list[int] | None = None,
     sample_event_size: int = DEFAULT_SAMPLE_EVENT_SIZE,
 ) -> NewHighMomentumResearchResult:
-    normalized_windows = _normalize_positive_int_sequence(
+    normalized_windows = normalize_positive_int_sequence(
         high_windows,
         fallback=DEFAULT_HIGH_WINDOWS,
         name="high_windows",
+        non_positive="filter",
     )
-    normalized_horizons = _normalize_positive_int_sequence(
+    normalized_horizons = normalize_positive_int_sequence(
         horizons,
         fallback=DEFAULT_HORIZONS,
         name="horizons",
+        non_positive="filter",
     )
     if sample_event_size < 1:
         raise ValueError("sample_event_size must be positive")

--- a/apps/bt/src/domains/analytics/research_core/__init__.py
+++ b/apps/bt/src/domains/analytics/research_core/__init__.py
@@ -1,0 +1,33 @@
+"""Thin internal primitives for runner-first analytics research."""
+
+from src.domains.analytics.research_core.parameters import (
+    normalize_positive_int_sequence,
+    warmup_start_date,
+)
+from src.domains.analytics.research_core.tables import sort_research_table
+from src.domains.analytics.research_core.universe import (
+    GROWTH_MARKET_CODES,
+    PRIME_MARKET_CODES,
+    STANDARD_MARKET_CODES,
+    TOPIX500_SCALE_CATEGORIES,
+    UNIVERSE_LABELS,
+    UNIVERSE_ORDER,
+    build_market_universe_case_sql,
+    research_universe_market_codes,
+    sql_string_list,
+)
+
+__all__ = [
+    "GROWTH_MARKET_CODES",
+    "PRIME_MARKET_CODES",
+    "STANDARD_MARKET_CODES",
+    "TOPIX500_SCALE_CATEGORIES",
+    "UNIVERSE_LABELS",
+    "UNIVERSE_ORDER",
+    "build_market_universe_case_sql",
+    "normalize_positive_int_sequence",
+    "research_universe_market_codes",
+    "sort_research_table",
+    "sql_string_list",
+    "warmup_start_date",
+]

--- a/apps/bt/src/domains/analytics/research_core/parameters.py
+++ b/apps/bt/src/domains/analytics/research_core/parameters.py
@@ -1,0 +1,50 @@
+"""Parameter and date helpers for internal analytics research."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def normalize_positive_int_sequence(
+    values: tuple[int, ...] | list[int] | None,
+    *,
+    fallback: tuple[int, ...],
+    name: str,
+    non_positive: str = "raise",
+) -> tuple[int, ...]:
+    """Return sorted unique positive integers for horizon/window parameters."""
+    raw_values = fallback if values is None else tuple(values)
+    normalized: list[int] = []
+    for raw_value in raw_values:
+        value = int(raw_value)
+        if value <= 0:
+            if non_positive == "filter":
+                continue
+            raise ValueError(f"{name} values must be positive")
+        if value not in normalized:
+            normalized.append(value)
+    if not normalized:
+        if non_positive == "filter":
+            raise ValueError(f"{name} must contain at least one positive integer")
+        raise ValueError(f"at least one {name} value is required")
+    return tuple(sorted(normalized))
+
+
+def warmup_start_date(
+    analysis_start_date: str | None,
+    available_start_date: str | None,
+    *,
+    warmup_sessions: int,
+    session_to_calendar_multiplier: float,
+    padding_days: int = 30,
+) -> str | None:
+    """Estimate a raw-data start date that preserves rolling-window warmup rows."""
+    if analysis_start_date is None:
+        return available_start_date
+    warmup_days = int(warmup_sessions * session_to_calendar_multiplier) + int(padding_days)
+    candidate = (pd.Timestamp(analysis_start_date) - pd.Timedelta(days=warmup_days)).strftime(
+        "%Y-%m-%d"
+    )
+    if available_start_date is None:
+        return candidate
+    return max(available_start_date, candidate)

--- a/apps/bt/src/domains/analytics/research_core/tables.py
+++ b/apps/bt/src/domains/analytics/research_core/tables.py
@@ -1,0 +1,43 @@
+"""Stable table ordering helpers for internal analytics research outputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import pandas as pd
+
+from src.domains.analytics.research_core.universe import UNIVERSE_ORDER
+
+
+def sort_research_table(
+    df: pd.DataFrame,
+    *,
+    sort_columns: Sequence[str],
+    universe_column: str = "universe_key",
+    universe_order: Sequence[str] = UNIVERSE_ORDER,
+    extra_order_columns: Mapping[str, Mapping[object, int]] | None = None,
+) -> pd.DataFrame:
+    """Sort research output tables without leaking temporary ordering columns."""
+    if df.empty:
+        return df
+    result = df.copy()
+    effective_sort_columns: list[str] = []
+    temporary_columns: list[str] = []
+    if universe_column in result.columns:
+        order_column = f"_{universe_column}_order"
+        result[order_column] = result[universe_column].map(
+            {key: index for index, key in enumerate(universe_order)}
+        )
+        temporary_columns.append(order_column)
+        effective_sort_columns.append(order_column)
+    for column, order_map in (extra_order_columns or {}).items():
+        if column not in result.columns:
+            continue
+        order_column = f"_{column}_order"
+        result[order_column] = result[column].map(order_map)
+        temporary_columns.append(order_column)
+        effective_sort_columns.append(order_column)
+    effective_sort_columns.extend(column for column in sort_columns if column in result.columns)
+    if effective_sort_columns:
+        result = result.sort_values(effective_sort_columns, kind="stable").reset_index(drop=True)
+    return result.drop(columns=temporary_columns)

--- a/apps/bt/src/domains/analytics/research_core/universe.py
+++ b/apps/bt/src/domains/analytics/research_core/universe.py
@@ -1,0 +1,60 @@
+"""Trading25 research universe primitives.
+
+These helpers are intentionally repo-local. They encode the market-behavior
+research universe used by runner-first studies, not a generic screening DSL.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.shared.utils.market_code_alias import expand_market_codes
+
+PRIME_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["prime"]))
+STANDARD_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["standard"]))
+GROWTH_MARKET_CODES: tuple[str, ...] = tuple(expand_market_codes(["growth"]))
+TOPIX500_SCALE_CATEGORIES: tuple[str, ...] = (
+    "TOPIX Core30",
+    "TOPIX Large70",
+    "TOPIX Mid400",
+)
+UNIVERSE_ORDER: tuple[str, ...] = (
+    "topix500",
+    "prime_ex_topix500",
+    "standard",
+    "growth",
+)
+UNIVERSE_LABELS: dict[str, str] = {
+    "topix500": "TOPIX500",
+    "prime_ex_topix500": "Prime ex TOPIX500",
+    "standard": "Standard",
+    "growth": "Growth",
+}
+
+
+def sql_string_list(values: Iterable[str]) -> str:
+    """Return a quoted SQL literal list for static repo-owned identifiers."""
+    return ", ".join("'" + str(value).replace("'", "''") + "'" for value in values)
+
+
+def research_universe_market_codes() -> tuple[str, ...]:
+    return tuple(dict.fromkeys([*PRIME_MARKET_CODES, *STANDARD_MARKET_CODES, *GROWTH_MARKET_CODES]))
+
+
+def build_market_universe_case_sql(
+    *,
+    market_code_column: str,
+    scale_category_column: str,
+) -> str:
+    return f"""
+                CASE
+                    WHEN {scale_category_column} IN ({sql_string_list(TOPIX500_SCALE_CATEGORIES)})
+                        THEN 'topix500'
+                    WHEN {market_code_column} IN ({sql_string_list(PRIME_MARKET_CODES)})
+                        THEN 'prime_ex_topix500'
+                    WHEN {market_code_column} IN ({sql_string_list(STANDARD_MARKET_CODES)})
+                        THEN 'standard'
+                    WHEN {market_code_column} IN ({sql_string_list(GROWTH_MARKET_CODES)})
+                        THEN 'growth'
+                END
+    """.strip()

--- a/apps/bt/src/domains/analytics/turtle_like_momentum_research.py
+++ b/apps/bt/src/domains/analytics/turtle_like_momentum_research.py
@@ -13,13 +13,13 @@ import numpy as np
 import pandas as pd
 
 from src.domains.analytics.annual_value_composite_selection import _daily_stats, _series_mean
-from src.domains.analytics.classical_momentum_research import (
-    GROWTH_MARKET_CODES,
-    PRIME_MARKET_CODES,
-    STANDARD_MARKET_CODES,
-    TOPIX500_SCALE_CATEGORIES,
+from src.domains.analytics.research_core import (
     UNIVERSE_LABELS,
-    UNIVERSE_ORDER,
+    build_market_universe_case_sql,
+    research_universe_market_codes,
+    sort_research_table,
+    sql_string_list,
+    warmup_start_date,
 )
 from src.domains.analytics.readonly_duckdb_support import (
     SourceMode,
@@ -86,22 +86,10 @@ class TurtleLikeMomentumResearchResult:
     portfolio_summary_df: pd.DataFrame
 
 
-def _sql_string_list(values: tuple[str, ...]) -> str:
-    return ", ".join(f"'{value}'" for value in values)
-
-
 def _sort_table(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    result = df.copy()
-    if "universe_key" in result.columns:
-        result["_universe_order"] = result["universe_key"].map(
-            {key: index for index, key in enumerate(UNIVERSE_ORDER)}
-        )
-    sort_columns = [
-        column
-        for column in (
-            "_universe_order",
+    return sort_research_table(
+        df,
+        sort_columns=(
             "entry_window_sessions",
             "exit_window_sessions",
             "entry_mode",
@@ -109,12 +97,8 @@ def _sort_table(df: pd.DataFrame) -> pd.DataFrame:
             "entry_signal_date",
             "date",
             "code",
-        )
-        if column in result.columns
-    ]
-    if sort_columns:
-        result = result.sort_values(sort_columns, kind="stable").reset_index(drop=True)
-    return result.drop(columns=[column for column in result.columns if column.startswith("_")])
+        ),
+    )
 
 
 def _normalize_channel_specs(
@@ -176,16 +160,13 @@ def _warmup_start_date(
     channel_specs: tuple[tuple[int, int], ...],
     atr_sessions: int,
 ) -> str | None:
-    if analysis_start_date is None:
-        return available_start_date
     max_window = max(max(entry, exit) for entry, exit in channel_specs)
-    warmup_days = int(max(max_window, atr_sessions, 60) * _WARMUP_MULTIPLIER) + 30
-    candidate = (pd.Timestamp(analysis_start_date) - pd.Timedelta(days=warmup_days)).strftime(
-        "%Y-%m-%d"
+    return warmup_start_date(
+        analysis_start_date,
+        available_start_date,
+        warmup_sessions=max(max_window, atr_sessions, 60),
+        session_to_calendar_multiplier=_WARMUP_MULTIPLIER,
     )
-    if available_start_date is None:
-        return candidate
-    return max(available_start_date, candidate)
 
 
 def _query_analysis_panel(
@@ -198,9 +179,7 @@ def _query_analysis_panel(
 ) -> pd.DataFrame:
     price_code = normalize_code_sql("sd.code")
     master_code = normalize_code_sql("smd.code")
-    all_market_codes = tuple(
-        dict.fromkeys([*PRIME_MARKET_CODES, *STANDARD_MARKET_CODES, *GROWTH_MARKET_CODES])
-    )
+    all_market_codes = research_universe_market_codes()
     raw_conditions: list[str] = []
     raw_params: list[str] = []
     if raw_start_date is not None:
@@ -251,22 +230,14 @@ def _query_analysis_panel(
                 smd.company_name,
                 smd.market_code,
                 smd.scale_category,
-                CASE
-                    WHEN smd.scale_category IN ({_sql_string_list(TOPIX500_SCALE_CATEGORIES)})
-                        THEN 'topix500'
-                    WHEN smd.market_code IN ({_sql_string_list(PRIME_MARKET_CODES)})
-                        THEN 'prime_ex_topix500'
-                    WHEN smd.market_code IN ({_sql_string_list(STANDARD_MARKET_CODES)})
-                        THEN 'standard'
-                    WHEN smd.market_code IN ({_sql_string_list(GROWTH_MARKET_CODES)})
-                        THEN 'growth'
-                END AS universe_key,
+                {build_market_universe_case_sql(market_code_column="smd.market_code", scale_category_column="smd.scale_category")}
+                    AS universe_key,
                 row_number() OVER (
                     PARTITION BY {master_code}, smd.date
                     ORDER BY CASE WHEN length(smd.code) = 4 THEN 0 ELSE 1 END, smd.code
                 ) AS row_rank
             FROM stock_master_daily smd
-            WHERE smd.market_code IN ({_sql_string_list(all_market_codes)})
+            WHERE smd.market_code IN ({sql_string_list(all_market_codes)})
         ),
         scoped AS (
             SELECT p.*, m.company_name, m.market_code, m.scale_category, m.universe_key

--- a/apps/bt/tests/unit/domains/analytics/test_research_core.py
+++ b/apps/bt/tests/unit/domains/analytics/test_research_core.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.domains.analytics.research_core import (
+    UNIVERSE_LABELS,
+    build_market_universe_case_sql,
+    normalize_positive_int_sequence,
+    research_universe_market_codes,
+    sort_research_table,
+    sql_string_list,
+    warmup_start_date,
+)
+
+
+def test_research_universe_sql_keeps_market_behavior_labels() -> None:
+    case_sql = build_market_universe_case_sql(
+        market_code_column="smd.market_code",
+        scale_category_column="smd.scale_category",
+    )
+
+    assert "TOPIX Core30" in case_sql
+    assert "prime_ex_topix500" in case_sql
+    assert "standard" in case_sql
+    assert "growth" in case_sql
+    assert UNIVERSE_LABELS["topix500"] == "TOPIX500"
+    assert "0111" in research_universe_market_codes()
+
+
+def test_sql_string_list_escapes_static_values() -> None:
+    assert sql_string_list(("0111", "O'Reilly")) == "'0111', 'O''Reilly'"
+
+
+def test_normalize_positive_int_sequence_preserves_existing_modes() -> None:
+    assert normalize_positive_int_sequence(
+        [10, "5", 10],
+        fallback=(20,),
+        name="horizons",
+    ) == (5, 10)
+    assert normalize_positive_int_sequence(
+        [0, 5, -1, 5],
+        fallback=(20,),
+        name="horizons",
+        non_positive="filter",
+    ) == (5,)
+
+    with pytest.raises(ValueError, match="horizons values must be positive"):
+        normalize_positive_int_sequence([0], fallback=(20,), name="horizons")
+
+
+def test_warmup_start_date_clamps_to_available_start() -> None:
+    assert (
+        warmup_start_date(
+            "2024-03-01",
+            "2024-01-15",
+            warmup_sessions=20,
+            session_to_calendar_multiplier=2.1,
+        )
+        == "2024-01-15"
+    )
+    assert (
+        warmup_start_date(
+            "2024-03-01",
+            "2024-02-01",
+            warmup_sessions=20,
+            session_to_calendar_multiplier=2.1,
+        )
+        == "2024-02-01"
+    )
+
+
+def test_sort_research_table_uses_universe_and_extra_order_without_temp_columns() -> None:
+    frame = pd.DataFrame(
+        [
+            {"universe_key": "growth", "condition_key": "high", "date": "2024-01-02"},
+            {"universe_key": "topix500", "condition_key": "low", "date": "2024-01-03"},
+            {"universe_key": "topix500", "condition_key": "high", "date": "2024-01-01"},
+        ]
+    )
+
+    sorted_frame = sort_research_table(
+        frame,
+        sort_columns=("date",),
+        extra_order_columns={"condition_key": {"high": 0, "low": 1}},
+    )
+
+    assert sorted_frame["universe_key"].tolist() == ["topix500", "topix500", "growth"]
+    assert sorted_frame["condition_key"].tolist() == ["high", "low", "high"]
+    assert not any(column.startswith("_") for column in sorted_frame.columns)


### PR DESCRIPTION
## Summary
- add a thin repo-local bt research_core package for universe SQL, parameter warmup helpers, and stable output table sorting
- migrate classical momentum, new-high momentum, and turtle-like momentum research modules to the shared primitives
- document research_core scope, boundaries, guardrails, and candidate backlog

Closes #402

## Validation
- uv run --project apps/bt ruff check apps/bt/src/domains/analytics/research_core apps/bt/src/domains/analytics/classical_momentum_research.py apps/bt/src/domains/analytics/new_high_momentum_research.py apps/bt/src/domains/analytics/turtle_like_momentum_research.py apps/bt/tests/unit/domains/analytics/test_research_core.py
- uv run --project apps/bt pytest apps/bt/tests/unit/domains/analytics/test_research_core.py apps/bt/tests/unit/domains/analytics/test_classical_momentum_research.py apps/bt/tests/unit/domains/analytics/test_new_high_momentum_research.py apps/bt/tests/unit/domains/analytics/test_turtle_like_momentum_research.py apps/bt/tests/unit/scripts/test_run_classical_momentum_research.py apps/bt/tests/unit/scripts/test_run_new_high_momentum_research.py apps/bt/tests/unit/scripts/test_run_turtle_like_momentum_research.py
- uv run --project apps/bt pyright apps/bt/src/domains/analytics/research_core apps/bt/src/domains/analytics/classical_momentum_research.py apps/bt/src/domains/analytics/new_high_momentum_research.py apps/bt/src/domains/analytics/turtle_like_momentum_research.py
- python3 scripts/check-research-guardrails.py
- python3 scripts/skills/audit_skills.py --strict-legacy
- uv run --project apps/bt python apps/bt/scripts/research/run_classical_momentum_research.py --help
- uv run --project apps/bt python apps/bt/scripts/research/run_new_high_momentum_research.py --help
- uv run --project apps/bt python apps/bt/scripts/research/run_turtle_like_momentum_research.py --help
- git diff --check