### PR TITLE
[codex] Resolve TS contract cleanup issues 411-414

### DIFF
--- a/apps/ts/README.md
+++ b/apps/ts/README.md
@@ -69,7 +69,7 @@ bun run workspace:build
 
 - `runtime keep`: `react`, `react-dom`, `@tanstack/react-query`, `@tanstack/react-router`, `zustand`, `lucide-react`, `lightweight-charts`, `@monaco-editor/react`, `monaco-editor`
 - `tooling keep`: `vite`, `vitest`, `@playwright/test`, `@biomejs/biome`, `typescript`, `bun-types`
-- `transitive pin`: root `overrides` の `@redocly/openapi-core`, `rollup`, `minimatch`, `flatted`, `monaco-editor`
+- `transitive pin`: root `overrides` の `@redocly/openapi-core`, `brace-expansion`, `dompurify`, `fast-uri`, `flatted`, `minimatch`, `monaco-editor`, `picomatch`, `rollup`, `ws`, `yaml`
 - `remove`: `@radix-ui/react-label`, `tsx`
 
 `zustand` は完全撤去ではなく縮小方針です。URL と相性の良い page selection state は TanStack Router search params を SoT にし、`zustand` は chart preset / panel visibility / active job tracking のような session-local state に限定します。

--- a/apps/ts/packages/contracts/src/types/api-response-types.test.ts
+++ b/apps/ts/packages/contracts/src/types/api-response-types.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from 'bun:test';
 import type {
   DeleteResponse,
+  IndicatorComputeRequest,
+  IndicatorComputeResponse,
+  IndicatorSpec,
   ListPortfoliosResponse,
   ListWatchlistsResponse,
+  MarginIndicatorRequest,
+  MarginIndicatorResponse,
   PortfolioItemResponse,
   PortfolioResponse,
   PortfolioSummaryResponse,
   PortfolioWithItemsResponse,
+  PublishedResearchSummaryContract,
+  ResearchCatalogItemContract,
+  ResearchCatalogResponseContract,
+  ResearchDecisionStatus,
+  ResearchDetailResponseContract,
+  ResearchHighlightContract,
+  ResearchRunReferenceContract,
+  SignalComputeRequest,
+  SignalComputeResponse,
+  SignalResult,
   WatchlistDeleteResponse,
   WatchlistItemResponse,
   WatchlistPricesResponse,
@@ -15,6 +30,128 @@ import type {
   WatchlistSummaryResponse,
   WatchlistWithItemsResponse,
 } from './api-response-types';
+
+describe('api-response-types bt signal and indicator contracts', () => {
+  it('keeps indicator compute request and response contracts aligned with bt OpenAPI', () => {
+    const indicator: IndicatorSpec = {
+      type: 'sma',
+      params: { period: 25 },
+    };
+    const request: IndicatorComputeRequest = {
+      stock_code: '7203',
+      source: 'market',
+      timeframe: 'daily',
+      indicators: [indicator],
+      nan_handling: 'include',
+      output: 'indicators',
+    };
+    const response: IndicatorComputeResponse = {
+      stock_code: '7203',
+      timeframe: 'daily',
+      indicators: {
+        sma_25: [{ date: '2026-05-25', value: 3000 }],
+      },
+      provenance: { source_kind: 'market' },
+    };
+
+    expect(request.indicators?.[0]?.type).toBe('sma');
+    expect(response.indicators?.sma_25?.[0]?.value).toBe(3000);
+  });
+
+  it('keeps margin indicator request and response contracts aligned with bt OpenAPI', () => {
+    const request: MarginIndicatorRequest = {
+      stock_code: '7203',
+      source: 'market',
+      indicators: ['margin_long_pressure', 'margin_flow_pressure', 'margin_turnover_days'],
+      average_period: 15,
+    };
+    const response: MarginIndicatorResponse = {
+      stock_code: '7203',
+      indicators: {
+        margin_long_pressure: [{ date: '2026-05-25', pressure: 0.4 }],
+      },
+      provenance: { source_kind: 'market' },
+    };
+
+    expect(request.indicators).toContain('margin_flow_pressure');
+    expect(response.indicators.margin_long_pressure?.[0]?.pressure).toBe(0.4);
+  });
+
+  it('keeps signal compute request and response contracts aligned with bt OpenAPI', () => {
+    const result: SignalResult = {
+      mode: 'entry',
+      label: 'breakout',
+      trigger_dates: ['2026-05-25'],
+      count: 1,
+    };
+    const request: SignalComputeRequest = {
+      stock_code: '7203',
+      source: 'market',
+      timeframe: 'daily',
+      signals: [{ type: 'breakout', mode: 'entry', params: {} }],
+    };
+    const response: SignalComputeResponse = {
+      stock_code: '7203',
+      timeframe: 'daily',
+      signals: { breakout: result },
+      provenance: { source_kind: 'market' },
+    };
+
+    expect(request.signals?.[0]?.mode).toBe('entry');
+    expect(response.signals.breakout?.trigger_dates).toEqual(['2026-05-25']);
+  });
+});
+
+describe('api-response-types research contracts', () => {
+  it('keeps research API contracts separate from web normalized models', () => {
+    const status: ResearchDecisionStatus = 'observed';
+    const highlight: ResearchHighlightContract = {
+      label: 'CAGR',
+      value: '12%',
+      tone: 'success',
+    };
+    const summary: PublishedResearchSummaryContract = {
+      title: 'Research readout',
+      status,
+      tags: ['research'],
+      selectedParameters: [{ label: 'lookback', value: '120' }],
+      highlights: [highlight],
+      tableHighlights: [],
+      riskFlags: [],
+      relatedExperiments: [],
+      readoutSections: [{ title: 'Decision', items: ['Keep'] }],
+    };
+    const item: ResearchCatalogItemContract = {
+      createdAt: '2026-05-25T00:00:00Z',
+      experimentId: 'annual/value',
+      family: 'annual',
+      hasStructuredSummary: true,
+      runId: 'run-1',
+      status,
+      title: 'Value research',
+    };
+    const run: ResearchRunReferenceContract = {
+      createdAt: '2026-05-25T00:00:00Z',
+      runId: 'run-1',
+      isLatest: true,
+    };
+    const catalog: ResearchCatalogResponseContract = {
+      lastUpdated: '2026-05-25T00:00:00Z',
+      items: [item],
+    };
+    const detail: ResearchDetailResponseContract = {
+      item,
+      summary,
+      summaryMarkdown: '# Research readout',
+      outputTables: [],
+      availableRuns: [run],
+      resultMetadata: {},
+    };
+
+    expect(catalog.items?.[0]?.status).toBe('observed');
+    expect(detail.summary?.highlights?.[0]?.tone).toBe('success');
+  });
+});
 
 describe('api-response-types portfolio/watchlist contracts', () => {
   it('keeps portfolio response contracts aligned with web usage', () => {

--- a/apps/ts/packages/contracts/src/types/api-response-types.ts
+++ b/apps/ts/packages/contracts/src/types/api-response-types.ts
@@ -4,7 +4,36 @@
  * Single source of truth for API response types shared between packages/web and packages/api-clients.
  */
 
+import type { components as BtApiComponents } from '../clients/backtest/generated/bt-api-types';
 import type { DataProvenance, ResponseDiagnostics } from './api-types';
+
+type BtApiSchemas = BtApiComponents['schemas'];
+
+// ===== BT SIGNAL / INDICATOR CONTRACT TYPES =====
+
+export type IndicatorSpec = BtApiSchemas['IndicatorSpec'];
+export type IndicatorComputeRequest = BtApiSchemas['IndicatorComputeRequest'];
+export type IndicatorComputeResponse = BtApiSchemas['IndicatorComputeResponse'];
+export type MarginIndicatorRequest = BtApiSchemas['MarginIndicatorRequest'];
+export type MarginIndicatorResponse = BtApiSchemas['MarginIndicatorResponse'];
+export type SignalSpec = BtApiSchemas['SignalSpec'];
+export type SignalResult = BtApiSchemas['SignalResult'];
+export type SignalComputeRequest = BtApiSchemas['SignalComputeRequest'];
+export type SignalComputeResponse = BtApiSchemas['SignalComputeResponse'];
+
+// ===== RESEARCH API CONTRACT TYPES =====
+
+export type ResearchHighlightTone = BtApiSchemas['ResearchHighlight']['tone'];
+export type ResearchDecisionStatus = BtApiSchemas['ResearchCatalogItem']['status'];
+export type ResearchLabelValueContract = BtApiSchemas['ResearchLabelValue'];
+export type ResearchHighlightContract = BtApiSchemas['ResearchHighlight'];
+export type ResearchTableHighlightContract = BtApiSchemas['ResearchTableHighlight'];
+export type PublishedReadoutSectionContract = BtApiSchemas['PublishedReadoutSection'];
+export type PublishedResearchSummaryContract = BtApiSchemas['PublishedResearchSummary'];
+export type ResearchCatalogItemContract = BtApiSchemas['ResearchCatalogItem'];
+export type ResearchRunReferenceContract = BtApiSchemas['ResearchRunReference'];
+export type ResearchCatalogResponseContract = BtApiSchemas['ResearchCatalogResponse'];
+export type ResearchDetailResponseContract = BtApiSchemas['ResearchDetailResponse'];
 
 // ===== RANKING TYPES =====
 
@@ -38,7 +67,13 @@ export interface RankingItem {
   pbrPercentile?: number | null;
   marketCap?: number | null;
   liquidityResidualZ?: number | null;
-  liquidityRegime?: 'neutral_rerating' | 'crowded_rerating' | 'distribution_stress' | 'stale_liquidity' | 'neutral' | null;
+  liquidityRegime?:
+    | 'neutral_rerating'
+    | 'crowded_rerating'
+    | 'distribution_stress'
+    | 'stale_liquidity'
+    | 'neutral'
+    | null;
   adv60ToFreeFloatPct?: number | null;
   riskFlags?: RankingRiskFlag[];
 }

--- a/apps/ts/packages/web/src/hooks/useBtIndicators.test.ts
+++ b/apps/ts/packages/web/src/hooks/useBtIndicators.test.ts
@@ -180,7 +180,11 @@ describe('buildIndicatorSpecs', () => {
   });
 
   it('should include recent_return for short and long periods when enabled', () => {
-    const settings = { ...baseSettings, showRecentReturnChart: true, recentReturn: { shortPeriod: 20, longPeriod: 60 } };
+    const settings = {
+      ...baseSettings,
+      showRecentReturnChart: true,
+      recentReturn: { shortPeriod: 20, longPeriod: 60 },
+    };
     const specs = buildIndicatorSpecs(settings);
     expect(specs).toContainEqual({ type: 'recent_return', params: { lookback_period: 20 } });
     expect(specs).toContainEqual({ type: 'recent_return', params: { lookback_period: 60 } });
@@ -490,7 +494,7 @@ describe('useBtIndicators', () => {
         '/api/indicators/compute',
         expect.objectContaining({
           benchmark_code: 'topix',
-          relative_options: { align_dates: true, handle_zero_division: 'skip' },
+          relative_options: { handle_zero_division: 'skip' },
         })
       );
     });
@@ -515,6 +519,8 @@ describe('useBtIndicators', () => {
         source: 'market',
         timeframe: 'daily',
         indicators: [{ type: 'sma', params: { period: 20 } }],
+        nan_handling: 'include',
+        output: 'indicators',
       });
     });
   });

--- a/apps/ts/packages/web/src/hooks/useBtIndicators.ts
+++ b/apps/ts/packages/web/src/hooks/useBtIndicators.ts
@@ -1,4 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
+import type {
+  IndicatorComputeRequest,
+  IndicatorComputeResponse,
+  IndicatorSpec,
+} from '@trading25/contracts/types/api-response-types';
 import { useMemo } from 'react';
 import { apiPost } from '@/lib/api-client';
 import type { ChartSettings } from '@/stores/chartStore';
@@ -17,33 +22,14 @@ import type {
 // ===== Types =====
 
 export interface BtIndicatorSpec {
-  type: string;
+  type: IndicatorSpec['type'];
   params: Record<string, number | string>;
 }
 
-interface BtIndicatorComputeRequest {
-  stock_code: string;
-  source: 'market';
-  timeframe: 'daily' | 'weekly' | 'monthly';
-  indicators: BtIndicatorSpec[];
-  benchmark_code?: string;
-  relative_options?: {
-    align_dates?: boolean;
-    handle_zero_division?: 'skip' | 'zero';
-  };
-}
-
-interface BtIndicatorComputeResponse {
-  stock_code: string;
-  timeframe: string;
-  meta: { bars: number };
-  indicators: Record<string, BtIndicatorRecord[]>;
-}
-
-interface BtIndicatorRecord {
-  date: string;
-  [key: string]: string | number | null;
-}
+type BtIndicatorComputeRequest = IndicatorComputeRequest;
+type BtIndicatorComputeResponse = IndicatorComputeResponse;
+type IndicatorTransformResponse = Pick<BtIndicatorComputeResponse, 'indicators'>;
+type BtIndicatorRecord = NonNullable<BtIndicatorComputeResponse['indicators']>[string][number];
 
 // ===== Query Key Factory =====
 
@@ -166,15 +152,19 @@ export function buildIndicatorSpecs(settings: ChartSettings): BtIndicatorSpec[] 
 // Note: Type assertions (as number) are used here because apps/bt/ API is an internal service
 // with OpenAPI-defined contracts. Null checks are performed via .filter() before mapping.
 
+function getRecordDate(record: BtIndicatorRecord): string {
+  return typeof record.date === 'string' ? record.date : String(record.date ?? '');
+}
+
 function transformSingleValueRecords(records: BtIndicatorRecord[]): IndicatorValue[] {
-  return records.filter((r) => r.value != null).map((r) => ({ time: r.date, value: r.value as number }));
+  return records.filter((r) => r.value != null).map((r) => ({ time: getRecordDate(r), value: r.value as number }));
 }
 
 function transformMACDRecords(records: BtIndicatorRecord[]): MACDIndicatorData[] {
   return records
     .filter((r) => r.macd != null && r.signal != null && r.histogram != null)
     .map((r) => ({
-      time: r.date,
+      time: getRecordDate(r),
       macd: r.macd as number,
       signal: r.signal as number,
       histogram: r.histogram as number,
@@ -185,7 +175,7 @@ function transformPPORecords(records: BtIndicatorRecord[]): PPOIndicatorData[] {
   return records
     .filter((r) => r.ppo != null && r.signal != null && r.histogram != null)
     .map((r) => ({
-      time: r.date,
+      time: getRecordDate(r),
       ppo: r.ppo as number,
       signal: r.signal as number,
       histogram: r.histogram as number,
@@ -196,7 +186,7 @@ function transformBollingerRecords(records: BtIndicatorRecord[]): BollingerBands
   return records
     .filter((r) => r.upper != null && r.middle != null && r.lower != null)
     .map((r) => ({
-      time: r.date,
+      time: getRecordDate(r),
       upper: r.upper as number,
       middle: r.middle as number,
       lower: r.lower as number,
@@ -207,7 +197,7 @@ function transformVolumeComparisonRecords(records: BtIndicatorRecord[]): VolumeC
   return records
     .filter((r) => r.shortMA != null && r.longThresholdLower != null && r.longThresholdHigher != null)
     .map((r) => ({
-      time: r.date,
+      time: getRecordDate(r),
       shortMA: r.shortMA as number,
       longThresholdLower: r.longThresholdLower as number,
       longThresholdHigher: r.longThresholdHigher as number,
@@ -303,13 +293,13 @@ function transformIndicatorKey(key: string, records: BtIndicatorRecord[]): Indic
   return entry ? entry.transform(records, key) : null;
 }
 
-export function mapBtResponseToChartData(response: BtIndicatorComputeResponse): Omit<ChartData, 'candlestickData'> {
+export function mapBtResponseToChartData(response: IndicatorTransformResponse): Omit<ChartData, 'candlestickData'> {
   const indicators: Record<string, IndicatorData[]> = {};
   let bollingerBands: BollingerBandsData[] | undefined;
   let volumeComparison: VolumeComparisonData[] | undefined;
   let tradingValueMA: TradingValueMAData[] | undefined;
 
-  for (const [key, records] of Object.entries(response.indicators)) {
+  for (const [key, records] of Object.entries(response.indicators ?? {})) {
     const result = transformIndicatorKey(key, records);
     if (!result) continue;
 
@@ -361,10 +351,11 @@ export function useBtIndicators(
         source: 'market',
         timeframe,
         indicators: specs,
+        nan_handling: 'include',
+        output: 'indicators',
         ...(settings.relativeMode && {
           benchmark_code: 'topix',
           relative_options: {
-            align_dates: true,
             handle_zero_division: 'skip',
           },
         }),

--- a/apps/ts/packages/web/src/hooks/useBtMarginIndicators.test.ts
+++ b/apps/ts/packages/web/src/hooks/useBtMarginIndicators.test.ts
@@ -52,6 +52,7 @@ describe('useBtMarginIndicators', () => {
     await waitFor(() => {
       expect(mockApiPost).toHaveBeenCalledWith('/api/indicators/margin', {
         stock_code: '7203',
+        source: 'market',
         indicators: ['margin_long_pressure', 'margin_flow_pressure', 'margin_turnover_days'],
         average_period: 15,
       });

--- a/apps/ts/packages/web/src/hooks/useBtMarginIndicators.ts
+++ b/apps/ts/packages/web/src/hooks/useBtMarginIndicators.ts
@@ -1,31 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
+import type { MarginIndicatorRequest, MarginIndicatorResponse } from '@trading25/contracts/types/api-response-types';
 import { useMemo } from 'react';
 import { apiPost } from '@/lib/api-client';
 import type { MarginPressureIndicatorsResponse } from '@/types/chart';
 
 // ===== Types =====
 
-interface BtMarginRequest {
-  stock_code: string;
-  indicators: ('margin_long_pressure' | 'margin_flow_pressure' | 'margin_turnover_days')[];
-  average_period: number;
-}
-
-interface BtMarginResponse {
-  stock_code: string;
-  indicators: {
-    margin_long_pressure?: BtMarginRecord[];
-    margin_flow_pressure?: BtMarginRecord[];
-    margin_turnover_days?: BtMarginRecord[];
-  };
-  provenance: MarginPressureIndicatorsResponse['provenance'];
-  diagnostics: MarginPressureIndicatorsResponse['diagnostics'];
-}
-
-interface BtMarginRecord {
-  date: string;
-  [key: string]: string | number | null;
-}
+type BtMarginRequest = MarginIndicatorRequest;
+type BtMarginResponse = MarginIndicatorResponse;
+type BtMarginRecord = BtMarginResponse['indicators'][string][number];
 
 // ===== Query Keys =====
 
@@ -36,9 +19,13 @@ export const btMarginKeys = {
 
 // ===== Response Transformer =====
 
+function getRecordDate(record: BtMarginRecord): string {
+  return typeof record.date === 'string' ? record.date : String(record.date ?? '');
+}
+
 function transformBtMarginResponse(response: BtMarginResponse, period: number): MarginPressureIndicatorsResponse {
   const longPressure = (response.indicators.margin_long_pressure ?? []).map((r) => ({
-    date: r.date,
+    date: getRecordDate(r),
     pressure: r.pressure as number,
     longVol: r.longVol as number,
     shortVol: r.shortVol as number,
@@ -46,7 +33,7 @@ function transformBtMarginResponse(response: BtMarginResponse, period: number): 
   }));
 
   const flowPressure = (response.indicators.margin_flow_pressure ?? []).map((r) => ({
-    date: r.date,
+    date: getRecordDate(r),
     flowPressure: r.flowPressure as number,
     currentNetMargin: r.currentNetMargin as number,
     previousNetMargin: (r.previousNetMargin as number) ?? 0,
@@ -54,7 +41,7 @@ function transformBtMarginResponse(response: BtMarginResponse, period: number): 
   }));
 
   const turnoverDays = (response.indicators.margin_turnover_days ?? []).map((r) => ({
-    date: r.date,
+    date: getRecordDate(r),
     turnoverDays: r.turnoverDays as number,
     longVol: r.longVol as number,
     avgVolume: r.avgVolume as number,
@@ -68,7 +55,7 @@ function transformBtMarginResponse(response: BtMarginResponse, period: number): 
     turnoverDays,
     lastUpdated: new Date().toISOString(),
     provenance: response.provenance,
-    diagnostics: response.diagnostics,
+    diagnostics: response.diagnostics ?? {},
   };
 }
 
@@ -91,6 +78,7 @@ export function useBtMarginIndicators(symbol: string | null, options: number | U
       if (!symbol) throw new Error('symbol is required');
       const request: BtMarginRequest = {
         stock_code: symbol,
+        source: 'market',
         indicators: ['margin_long_pressure', 'margin_flow_pressure', 'margin_turnover_days'],
         average_period: period,
       };

--- a/apps/ts/packages/web/src/hooks/useBtSignals.ts
+++ b/apps/ts/packages/web/src/hooks/useBtSignals.ts
@@ -1,4 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
+import type {
+  SignalComputeRequest,
+  SignalComputeResponse,
+  SignalResult,
+} from '@trading25/contracts/types/api-response-types';
 import { useMemo } from 'react';
 import { useSignalReference } from '@/hooks/useBacktest';
 import { apiPost } from '@/lib/api-client';
@@ -11,53 +16,9 @@ export interface BtSignalSpec {
   mode: 'entry' | 'exit';
 }
 
-interface BtSignalComputeRequest {
-  stock_code: string;
-  source: 'market';
-  timeframe: 'daily' | 'weekly' | 'monthly';
-  signals?: BtSignalSpec[];
-  strategy_name?: string;
-  start_date?: string;
-  end_date?: string;
-}
-
-interface SignalDiagnostics {
-  missing_required_data?: string[];
-  used_fields?: string[];
-  effective_period_type?: string | null;
-  warnings?: string[];
-}
-
-interface BtSignalResult {
-  label?: string | null;
-  mode?: 'entry' | 'exit' | null;
-  trigger_dates: string[];
-  count: number;
-  error?: string;
-  diagnostics?: SignalDiagnostics;
-}
-
-interface DataProvenance {
-  source_kind: 'market' | 'dataset';
-  market_snapshot_id?: string | null;
-  dataset_snapshot_id?: string | null;
-  reference_date?: string | null;
-  loaded_domains?: string[];
-  strategy_name?: string | null;
-  strategy_fingerprint?: string | null;
-  warnings?: string[];
-}
-
-interface BtSignalComputeResponse {
-  stock_code: string;
-  timeframe: string;
-  strategy_name?: string | null;
-  signals: Record<string, BtSignalResult>;
-  combined_entry?: BtSignalResult | null;
-  combined_exit?: BtSignalResult | null;
-  provenance: DataProvenance;
-  diagnostics?: SignalDiagnostics;
-}
+type BtSignalComputeRequest = SignalComputeRequest;
+type BtSignalComputeResponse = SignalComputeResponse;
+type BtSignalResult = SignalResult;
 
 export const btSignalKeys = {
   all: ['bt-signals'] as const,

--- a/apps/ts/packages/web/src/types/research.ts
+++ b/apps/ts/packages/web/src/types/research.ts
@@ -1,16 +1,27 @@
-import type { components } from '@trading25/contracts/clients/backtest/generated/bt-api-types';
+import type {
+  PublishedResearchSummaryContract,
+  ResearchCatalogItemContract,
+  ResearchCatalogResponseContract,
+  ResearchDecisionStatus,
+  ResearchDetailResponseContract,
+  ResearchHighlightContract,
+  ResearchHighlightTone,
+  ResearchLabelValueContract,
+  ResearchRunReferenceContract,
+  ResearchTableHighlightContract,
+} from '@trading25/contracts/types/api-response-types';
 
-export type ResearchHighlightTone = components['schemas']['ResearchHighlight']['tone'];
-export type ResearchDecisionStatus = components['schemas']['ResearchCatalogItem']['status'];
+export type { ResearchDecisionStatus, ResearchHighlightTone };
 
-export type ApiResearchLabelValue = components['schemas']['ResearchLabelValue'];
-export type ApiResearchHighlight = components['schemas']['ResearchHighlight'];
-export type ApiResearchTableHighlight = components['schemas']['ResearchTableHighlight'];
-export type ApiPublishedResearchSummary = components['schemas']['PublishedResearchSummary'];
-export type ApiResearchCatalogItem = components['schemas']['ResearchCatalogItem'];
-export type ApiResearchRunReference = components['schemas']['ResearchRunReference'];
-export type ApiResearchCatalogResponse = components['schemas']['ResearchCatalogResponse'];
-export type ApiResearchDetailResponse = components['schemas']['ResearchDetailResponse'];
+// API contract aliases stay tied to the stable contracts package; normalized UI models below stay web-local.
+export type ApiResearchLabelValue = ResearchLabelValueContract;
+export type ApiResearchHighlight = ResearchHighlightContract;
+export type ApiResearchTableHighlight = ResearchTableHighlightContract;
+export type ApiPublishedResearchSummary = PublishedResearchSummaryContract;
+export type ApiResearchCatalogItem = ResearchCatalogItemContract;
+export type ApiResearchRunReference = ResearchRunReferenceContract;
+export type ApiResearchCatalogResponse = ResearchCatalogResponseContract;
+export type ApiResearchDetailResponse = ResearchDetailResponseContract;
 
 export type ResearchLabelValue = ApiResearchLabelValue;
 

--- a/docs/superpowers/plans/2026-05-26-issues-411-414-contract-cleanup.md
+++ b/docs/superpowers/plans/2026-05-26-issues-411-414-contract-cleanup.md
@@ -1,0 +1,107 @@
+# Issues 411-414 Contract Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve GitHub issues #411, #412, #413, and #414 by moving direct TS OpenAPI schema references behind stable contract exports, separating research API contracts from UI models, and verifying Hono/dependency cleanup.
+
+**Architecture:** `@trading25/contracts/types/api-response-types` owns stable names for bt signal/indicator/research API contracts. `apps/ts/packages/web` imports those stable names and keeps UI normalized models in web-local type files. Hono archive references remain historical; runtime manifests and dependency audit remain the current SoT.
+
+**Tech Stack:** TypeScript, Bun, React hooks, OpenAPI generated types, Biome, TypeScript compiler.
+
+---
+
+### Task 1: Add Stable bt Signal/Indicator Contract Exports
+
+**Files:**
+- Modify: `apps/ts/packages/contracts/src/types/api-response-types.ts`
+- Test: `apps/ts/packages/contracts/src/types/api-response-types.test.ts`
+
+- [ ] **Step 1: Write the failing type-contract test**
+  Add sample `IndicatorComputeRequest`, `MarginIndicatorRequest`, and `SignalComputeRequest` values imported from `api-response-types.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+  Run: `bun run --filter @trading25/contracts test src/types/api-response-types.test.ts`
+  Expected: FAIL because these stable exports do not exist yet.
+
+- [ ] **Step 3: Add stable aliases**
+  Export aliases for indicator, margin indicator, and signal request/response schemas from `api-response-types.ts`.
+
+- [ ] **Step 4: Run test to verify it passes**
+  Run: `bun run --filter @trading25/contracts test src/types/api-response-types.test.ts`
+  Expected: PASS.
+
+### Task 2: Move Web Hooks to Stable Contract Types
+
+**Files:**
+- Modify: `apps/ts/packages/web/src/hooks/useBtMarginIndicators.ts`
+- Modify: `apps/ts/packages/web/src/hooks/useBtSignals.ts`
+- Modify: `apps/ts/packages/web/src/hooks/useBtIndicators.ts`
+
+- [ ] **Step 1: Replace generated schema imports**
+  Import stable request/response/spec/result types from `@trading25/contracts/types/api-response-types`.
+
+- [ ] **Step 2: Run focused typecheck**
+  Run: `bun run --filter @trading25/web typecheck`
+  Expected: PASS.
+
+### Task 3: Split Research API Contracts from UI Models
+
+**Files:**
+- Modify: `apps/ts/packages/contracts/src/types/api-response-types.ts`
+- Modify: `apps/ts/packages/contracts/src/types/api-response-types.test.ts`
+- Modify: `apps/ts/packages/web/src/types/research.ts`
+- Modify: `apps/ts/packages/web/src/hooks/useResearch.ts`
+- Check: `apps/ts/packages/web/src/components/Research/*`
+
+- [ ] **Step 1: Write the failing stable research type test**
+  Add sample research catalog/detail contract values imported from `api-response-types.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+  Run: `bun run --filter @trading25/contracts test src/types/api-response-types.test.ts`
+  Expected: FAIL because research API contract exports do not exist yet.
+
+- [ ] **Step 3: Add stable research aliases**
+  Export API contract aliases from `api-response-types.ts`.
+
+- [ ] **Step 4: Keep web-local normalized models explicit**
+  Update `web/src/types/research.ts` so `Api*` names come from contracts while UI normalized interfaces stay local.
+
+- [ ] **Step 5: Run focused typecheck**
+  Run: `bun run --filter @trading25/web typecheck`
+  Expected: PASS.
+
+### Task 4: Verify Hono and Dependency Cleanup
+
+**Files:**
+- Inspect: `apps/ts/package.json`
+- Inspect: `apps/ts/packages/*/package.json`
+- Inspect: `apps/ts/scripts/dependency-audit.ts`
+- Inspect: `scripts/skills/audit_skills.py`
+- Preserve: `docs/archive/**`
+
+- [ ] **Step 1: Confirm no runtime Hono dependency**
+  Run: `rg -n '"hono"|@hono|hono' apps/ts/package.json apps/ts/packages/*/package.json apps/ts/bun.lock`
+  Expected: no matches.
+
+- [ ] **Step 2: Run dependency audit**
+  Run: `bun run quality:deps:audit`
+  Expected: PASS.
+
+- [ ] **Step 3: Keep archive references**
+  Do not delete `docs/archive/**` Hono migration history unless runtime/docs current SoT contradicts it.
+
+### Task 5: Final Verification and Issue Closeout
+
+**Files:**
+- Check: all touched files
+
+- [ ] **Step 1: Verify no direct generated schema imports remain in scoped hooks/research facade**
+  Run: `rg -n "components\\['schemas'\\]|components\\[\\\"schemas\\\"\\]|clients/backtest/generated/bt-api-types" apps/ts/packages/web/src/hooks/useBtMarginIndicators.ts apps/ts/packages/web/src/hooks/useBtSignals.ts apps/ts/packages/web/src/hooks/useBtIndicators.ts apps/ts/packages/web/src/types/research.ts`
+  Expected: no matches.
+
+- [ ] **Step 2: Run full relevant TS checks**
+  Run: `bun run --filter @trading25/contracts test src/types/api-response-types.test.ts && bun run --filter @trading25/web typecheck && bun run quality:deps:audit`
+  Expected: PASS.
+
+- [ ] **Step 3: Commit in small slices**
+  Commit #411/#412 type-boundary changes separately from #413/#414 audit/doc cleanup if there are code changes for both slices.

--- a/scripts/dep-direction-allowlist.txt
+++ b/scripts/dep-direction-allowlist.txt
@@ -17,6 +17,8 @@ apps/ts/packages/contracts/scripts/fetch-bt-openapi.ts
 apps/ts/packages/contracts/scripts/fetch-bt-openapi.test.ts
 apps/ts/packages/contracts/scripts/check-bt-types.ts
 apps/ts/packages/contracts/src/clients/backtest/generated/type-compatibility-check.ts
+# PR #415: stable contracts facade aliases selected bt OpenAPI schemas for web/API clients
+apps/ts/packages/contracts/src/types/api-response-types.ts
 
 # ─────────────────────────────────────────────────────────
 # [runtime] apps that intentionally call FastAPI (:3002)
@@ -27,9 +29,6 @@ apps/ts/packages/contracts/src/clients/backtest/generated/type-compatibility-che
 apps/ts/packages/web/src/components/Lab/LabResultSection.tsx
 apps/ts/packages/web/src/hooks/useBtOHLCV.ts
 apps/ts/packages/web/src/types/backtest.ts
-# PR #research-ui: research web types wrap bt OpenAPI schemas for published analytics views
-apps/ts/packages/web/src/types/research.ts
-
 # Vite proxy config env resolver (BT_API_URL is the backend URL SoT)
 apps/ts/packages/web/src/lib/btApiUrl.ts
 apps/ts/packages/web/src/lib/btApiUrl.test.ts


### PR DESCRIPTION
## Summary
- Add stable bt signal, indicator, margin indicator, and research API contract exports in `@trading25/contracts/types/api-response-types`.
- Move scoped web hooks and the research facade off direct generated OpenAPI schema imports while keeping UI-normalized research models web-local.
- Verify Hono is absent from TS runtime manifests/lockfile and update the dependency policy override list to match `apps/ts/package.json`.

Closes #411
Closes #412
Closes #413
Closes #414

## Verification
- `bun run quality:typecheck`
- `bun run --filter @trading25/contracts test src/types/api-response-types.test.ts`
- `bunx biome check packages/contracts/src/types/api-response-types.ts packages/contracts/src/types/api-response-types.test.ts packages/web/src/hooks/useBtMarginIndicators.ts packages/web/src/hooks/useBtSignals.ts packages/web/src/hooks/useBtIndicators.ts packages/web/src/types/research.ts README.md`
- `rg -n "components\['schemas'\]|components\[\"schemas\"\]|clients/backtest/generated/bt-api-types" apps/ts/packages/web/src/hooks/useBtMarginIndicators.ts apps/ts/packages/web/src/hooks/useBtSignals.ts apps/ts/packages/web/src/hooks/useBtIndicators.ts apps/ts/packages/web/src/types/research.ts` (no matches)
- `rg -n ""hono"|@hono|hono" apps/ts/package.json apps/ts/packages/*/package.json apps/ts/bun.lock` (no matches)