### PR TITLE
chore(bt): migrate pandas-stubs 3

### DIFF
--- a/apps/bt/pyproject.toml
+++ b/apps/bt/pyproject.toml
@@ -37,7 +37,7 @@ where = ["."]
 
 [dependency-groups]
 dev = [
-    "pandas-stubs>=2.3.2.250827",
+    "pandas-stubs>=3.0.3.260530",
     "pyright>=1.1.410",
     "ruff>=0.15.16",
     "pytest>=7.0.0",

--- a/apps/bt/requirements-dev.txt
+++ b/apps/bt/requirements-dev.txt
@@ -1,4 +1,4 @@
-pandas-stubs>=2.3.2.250827
+pandas-stubs>=3.0.3.260530
 pyright>=1.1.410
 ruff>=0.15.16
 pytest>=7.0.0

--- a/apps/bt/src/application/services/indicator_service.py
+++ b/apps/bt/src/application/services/indicator_service.py
@@ -122,7 +122,7 @@ class IndicatorService:
 
         if timeframe == "weekly":
             resampled = df.resample("W").agg(cast(Any, agg_rules)).dropna(subset=["Close"])
-            resampled.index = resampled.index - pd.Timedelta(days=6)
+            resampled.index = pd.DatetimeIndex(resampled.index) - pd.Timedelta(days=6)
             return resampled
 
         if timeframe == "monthly":

--- a/apps/bt/src/domains/analytics/accumulation_flow_followthrough.py
+++ b/apps/bt/src/domains/analytics/accumulation_flow_followthrough.py
@@ -34,6 +34,7 @@ from src.domains.strategy.indicators import (
     compute_on_balance_volume_score,
 )
 from src.shared.utils.market_code_alias import expand_market_codes
+from src.shared.utils.pandas_type_guards import int_or_none, required_int, required_str
 
 UniverseKey = Literal["topix500", "prime_ex_topix500", "standard", "growth"]
 FilterKey = Literal[
@@ -1097,11 +1098,11 @@ def _build_yearly_summary_df(
             )
             rows.append(
                 {
-                    "calendar_year": int(calendar_year),
-                    "universe_key": str(universe_key),
-                    "universe_label": str(universe_label),
-                    "filter_key": str(filter_key),
-                    "filter_label": str(filter_label),
+                    "calendar_year": required_int(calendar_year, field="calendar_year"),
+                    "universe_key": required_str(universe_key, field="universe_key"),
+                    "universe_label": required_str(universe_label, field="universe_label"),
+                    "filter_key": required_str(filter_key, field="filter_key"),
+                    "filter_label": required_str(filter_label, field="filter_label"),
                     "horizon_days": horizon_days,
                     **{
                         key: value
@@ -1154,12 +1155,12 @@ def _build_entry_cohort_df(
             )
             rows.append(
                 {
-                    "entry_date": str(entry_date),
-                    "calendar_year": int(calendar_year),
-                    "universe_key": str(universe_key),
-                    "universe_label": str(universe_label),
-                    "filter_key": str(filter_key),
-                    "filter_label": str(filter_label),
+                    "entry_date": required_str(entry_date, field="entry_date"),
+                    "calendar_year": required_int(calendar_year, field="calendar_year"),
+                    "universe_key": required_str(universe_key, field="universe_key"),
+                    "universe_label": required_str(universe_label, field="universe_label"),
+                    "filter_key": required_str(filter_key, field="filter_key"),
+                    "filter_label": required_str(filter_label, field="filter_label"),
                     "horizon_days": horizon_days,
                     "cohort_event_count": int(len(valid_df)),
                     "cohort_unique_code_count": int(valid_df["code"].nunique()),
@@ -1205,11 +1206,11 @@ def _build_cohort_portfolio_summary_df(
         total_signal_count = int(group_df["cohort_event_count"].sum())
         rows.append(
             {
-                "universe_key": str(universe_key),
-                "universe_label": str(universe_label),
-                "filter_key": str(filter_key),
-                "filter_label": str(filter_label),
-                "horizon_days": int(horizon_days),
+                "universe_key": required_str(universe_key, field="universe_key"),
+                "universe_label": required_str(universe_label, field="universe_label"),
+                "filter_key": required_str(filter_key, field="filter_key"),
+                "filter_label": required_str(filter_label, field="filter_label"),
+                "horizon_days": required_int(horizon_days, field="horizon_days"),
                 "date_count": int(len(group_df)),
                 "total_signal_count": total_signal_count,
                 "avg_names_per_date": float(group_df["cohort_event_count"].mean()),
@@ -1278,12 +1279,12 @@ def _build_yearly_cohort_summary_df(entry_cohort_df: pd.DataFrame) -> pd.DataFra
         ).dropna()
         rows.append(
             {
-                "calendar_year": int(calendar_year),
-                "universe_key": str(universe_key),
-                "universe_label": str(universe_label),
-                "filter_key": str(filter_key),
-                "filter_label": str(filter_label),
-                "horizon_days": int(horizon_days),
+                "calendar_year": required_int(calendar_year, field="calendar_year"),
+                "universe_key": required_str(universe_key, field="universe_key"),
+                "universe_label": required_str(universe_label, field="universe_label"),
+                "filter_key": required_str(filter_key, field="filter_key"),
+                "filter_label": required_str(filter_label, field="filter_label"),
+                "horizon_days": required_int(horizon_days, field="horizon_days"),
                 "date_count": int(len(group_df)),
                 "total_signal_count": int(group_df["cohort_event_count"].sum()),
                 "avg_names_per_date": float(group_df["cohort_event_count"].mean()),
@@ -1368,12 +1369,12 @@ def _build_capped_entry_cohort_df(
                 ).dropna()
                 rows.append(
                     {
-                        "entry_date": str(entry_date),
-                        "calendar_year": int(calendar_year),
-                        "universe_key": str(universe_key),
-                        "universe_label": str(universe_label),
-                        "filter_key": str(filter_key),
-                        "filter_label": str(filter_label),
+                        "entry_date": required_str(entry_date, field="entry_date"),
+                        "calendar_year": required_int(calendar_year, field="calendar_year"),
+                        "universe_key": required_str(universe_key, field="universe_key"),
+                        "universe_label": required_str(universe_label, field="universe_label"),
+                        "filter_key": required_str(filter_key, field="filter_key"),
+                        "filter_label": required_str(filter_label, field="filter_label"),
                         "horizon_days": horizon_days,
                         "max_names_per_date": max_names_per_date,
                         "cohort_event_count": int(len(valid_df)),
@@ -1407,7 +1408,7 @@ def _build_capped_cohort_portfolio_summary_df(
         summary_df = _build_cohort_portfolio_summary_df(scoped_df)
         if summary_df.empty:
             continue
-        cap_value = int(cast(Any, max_names_per_date))
+        cap_value = required_int(max_names_per_date, field="max_names_per_date")
         summary_df.insert(5, "max_names_per_date", cap_value)
         summary_frames.append(summary_df)
     if not summary_frames:
@@ -1423,6 +1424,18 @@ def _sample_period_for_year(year: int) -> tuple[str, str] | None:
             continue
         return sample_key, sample_label
     return None
+
+
+def _sample_period_key(value: object) -> str | None:
+    if not isinstance(value, tuple) or len(value) != 2:
+        return None
+    return required_str(value[0], field="sample_key")
+
+
+def _sample_period_label(value: object) -> str | None:
+    if not isinstance(value, tuple) or len(value) != 2:
+        return None
+    return required_str(value[1], field="sample_label")
 
 
 def _build_oos_portfolio_summary_df(
@@ -1446,14 +1459,14 @@ def _build_oos_portfolio_summary_df(
 
     combined_df = pd.concat(frames, ignore_index=True)
     sample_pairs = combined_df["calendar_year"].map(
-        lambda value: _sample_period_for_year(int(value)) if not pd.isna(value) else None
+        lambda value: (
+            _sample_period_for_year(normalized_year)
+            if (normalized_year := int_or_none(value)) is not None
+            else None
+        )
     )
-    combined_df["sample_key"] = sample_pairs.map(
-        lambda value: value[0] if value is not None else None
-    )
-    combined_df["sample_label"] = sample_pairs.map(
-        lambda value: value[1] if value is not None else None
-    )
+    combined_df["sample_key"] = sample_pairs.map(_sample_period_key)
+    combined_df["sample_label"] = sample_pairs.map(_sample_period_label)
     combined_df = combined_df.dropna(subset=["sample_key", "sample_label"])
     if combined_df.empty:
         return _empty_oos_portfolio_summary_df()
@@ -1496,17 +1509,18 @@ def _build_oos_portfolio_summary_df(
         ).dropna()
         rows.append(
             {
-                "sample_key": str(sample_key),
-                "sample_label": str(sample_label),
-                "portfolio_variant": str(portfolio_variant),
-                "max_names_per_date": None
-                if pd.isna(max_names_per_date)
-                else int(max_names_per_date),
-                "universe_key": str(universe_key),
-                "universe_label": str(universe_label),
-                "filter_key": str(filter_key),
-                "filter_label": str(filter_label),
-                "horizon_days": int(horizon_days),
+                "sample_key": required_str(sample_key, field="sample_key"),
+                "sample_label": required_str(sample_label, field="sample_label"),
+                "portfolio_variant": required_str(
+                    portfolio_variant,
+                    field="portfolio_variant",
+                ),
+                "max_names_per_date": int_or_none(max_names_per_date),
+                "universe_key": required_str(universe_key, field="universe_key"),
+                "universe_label": required_str(universe_label, field="universe_label"),
+                "filter_key": required_str(filter_key, field="filter_key"),
+                "filter_label": required_str(filter_label, field="filter_label"),
+                "horizon_days": required_int(horizon_days, field="horizon_days"),
                 "date_count": int(len(group_df)),
                 "total_signal_count": int(group_df["cohort_event_count"].sum()),
                 "avg_names_per_date": float(group_df["cohort_event_count"].mean()),

--- a/apps/bt/src/domains/analytics/annual_first_open_last_close_fundamental_panel.py
+++ b/apps/bt/src/domains/analytics/annual_first_open_last_close_fundamental_panel.py
@@ -52,6 +52,7 @@ from src.shared.utils.statement_document import (
     is_actual_fy_financial_statement,
     is_earn_forecast_revision_document,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 
 AnnualEventStatus = Literal[
@@ -1680,7 +1681,9 @@ def _assign_factor_buckets(
         )
         ordered["feature_name"] = factor_name
         ordered["feature_label"] = definition.label
-        ordered["bucket_label"] = ordered["bucket"].map(lambda value: f"Q{int(value)}")
+        ordered["bucket_label"] = ordered["bucket"].map(
+            lambda value: f"Q{required_int(value, field='bucket')}"
+        )
         frames.append(ordered)
     if not frames:
         return _empty_result_df(columns)
@@ -1732,11 +1735,11 @@ def _build_feature_bucket_summary_df(
         ):
             records.append(
                 {
-                    "market_scope": str(market_scope),
+                    "market_scope": required_str(market_scope, field="market_scope"),
                     "feature_name": definition.name,
                     "feature_label": definition.label,
-                    "bucket": int(bucket),
-                    "bucket_label": f"Q{int(bucket)}",
+                    "bucket": required_int(bucket, field="bucket"),
+                    "bucket_label": f"Q{required_int(bucket, field='bucket')}",
                     "year_count": int(group_df["year"].nunique()),
                     "realized_event_count": int(len(group_df)),
                     "mean_feature_value": _series_stat(

--- a/apps/bt/src/domains/analytics/annual_forward_per_regime_decomposition.py
+++ b/apps/bt/src/domains/analytics/annual_forward_per_regime_decomposition.py
@@ -39,6 +39,7 @@ from src.domains.analytics.research_bundle import (
     resolve_required_bundle_path,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import required_float, required_str
 
 ANNUAL_FORWARD_PER_REGIME_DECOMPOSITION_EXPERIMENT_ID = (
     "market-behavior/annual-forward-per-regime-decomposition"
@@ -1100,8 +1101,18 @@ def _build_portfolio_regime_contribution_df(
         observed=True,
         sort=False,
     ):
-        market_scope, score_method, liquidity_scenario, selection_fraction, regime_name = keys
-        labels = label_lookup[(market_scope, score_method, liquidity_scenario, selection_fraction)]
+        raw_market_scope, raw_score_method, raw_liquidity_scenario, raw_selection_fraction, regime_name = keys
+        market_scope = required_str(raw_market_scope, field="market_scope")
+        score_method = required_str(raw_score_method, field="score_method")
+        liquidity_scenario = required_str(
+            raw_liquidity_scenario, field="liquidity_scenario"
+        )
+        selection_fraction = required_float(
+            raw_selection_fraction, field="selection_fraction"
+        )
+        labels = label_lookup[
+            (market_scope, score_method, liquidity_scenario, selection_fraction)
+        ]
         contribution = pd.to_numeric(group["daily_return_contribution"], errors="coerce").dropna()
         records.append(
             {

--- a/apps/bt/src/domains/analytics/annual_prime_value_technical_risk_decomposition.py
+++ b/apps/bt/src/domains/analytics/annual_prime_value_technical_risk_decomposition.py
@@ -38,6 +38,7 @@ from src.domains.analytics.research_bundle import (
     resolve_required_bundle_path,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import required_float, required_int, required_str
 
 ANNUAL_PRIME_VALUE_TECHNICAL_RISK_DECOMPOSITION_EXPERIMENT_ID = (
     "market-behavior/annual-prime-value-technical-risk-decomposition"
@@ -383,7 +384,11 @@ def _build_risk_bucket_summary_df(enriched_event_df: pd.DataFrame, *, bucket_cou
         return _empty_df(columns)
     records: list[dict[str, Any]] = []
     for keys, group in enriched_event_df.groupby(["selection_fraction", "score_method"], sort=False):
-        selection_fraction, score_method = keys
+        raw_selection_fraction, raw_score_method = keys
+        selection_fraction = required_float(
+            raw_selection_fraction, field="selection_fraction"
+        )
+        score_method = required_str(raw_score_method, field="score_method")
         total_count = len(group)
         for feature_key in _RISK_FEATURES:
             if feature_key not in group.columns:
@@ -397,11 +402,11 @@ def _build_risk_bucket_summary_df(enriched_event_df: pd.DataFrame, *, bucket_cou
                 beta_adj = pd.to_numeric(bucket_df["beta_adjusted_event_return_pct"], errors="coerce").dropna()
                 records.append(
                     {
-                        "selection_fraction": float(selection_fraction),
-                        "score_method": str(score_method),
+                        "selection_fraction": selection_fraction,
+                        "score_method": score_method,
                         "feature_key": feature_key,
                         "feature_label": _RISK_FEATURE_LABELS[feature_key],
-                        "bucket_rank": int(cast(int, bucket_rank)),
+                        "bucket_rank": required_int(bucket_rank, field="bucket_rank"),
                         "bucket_count": int(bucket_count),
                         "event_count": int(len(bucket_df)),
                         "year_count": int(bucket_df["year"].nunique()),
@@ -449,7 +454,12 @@ def _build_risk_spread_df(risk_bucket_summary_df: pd.DataFrame) -> pd.DataFrame:
     records: list[dict[str, Any]] = []
     group_cols = ["selection_fraction", "score_method", "feature_key"]
     for keys, group in risk_bucket_summary_df.groupby(group_cols, sort=False):
-        selection_fraction, score_method, feature_key = keys
+        raw_selection_fraction, raw_score_method, raw_feature_key = keys
+        selection_fraction = required_float(
+            raw_selection_fraction, field="selection_fraction"
+        )
+        score_method = required_str(raw_score_method, field="score_method")
+        feature_key = required_str(raw_feature_key, field="feature_key")
         low = group[group["bucket_rank"].astype(int) == 1].head(1)
         high_rank = int(group["bucket_count"].astype(int).max())
         high = group[group["bucket_rank"].astype(int) == high_rank].head(1)
@@ -465,10 +475,10 @@ def _build_risk_spread_df(risk_bucket_summary_df: pd.DataFrame) -> pd.DataFrame:
         )
         records.append(
             {
-                "selection_fraction": float(selection_fraction),
-                "score_method": str(score_method),
-                "feature_key": str(feature_key),
-                "feature_label": _RISK_FEATURE_LABELS[str(feature_key)],
+                "selection_fraction": selection_fraction,
+                "score_method": score_method,
+                "feature_key": feature_key,
+                "feature_label": _RISK_FEATURE_LABELS[feature_key],
                 "low_bucket_rank": 1,
                 "high_bucket_rank": high_rank,
                 "low_event_count": int(_row_value(low, "event_count")),
@@ -590,11 +600,15 @@ def _build_portfolio_daily_df(portfolio_event_df: pd.DataFrame, stock_price_df: 
         daily_returns = close_values / previous_close - 1.0
         for date_value, daily_return in zip(path_df["date"].astype(str), daily_returns, strict=True):
             key = (
-                float(cast(float, event["selection_fraction"])),
-                str(event["score_method"]),
-                str(event["portfolio_feature_key"]),
-                str(event["portfolio_feature_label"]),
-                str(event["portfolio_variant"]),
+                required_float(event["selection_fraction"], field="selection_fraction"),
+                required_str(event["score_method"], field="score_method"),
+                required_str(
+                    event["portfolio_feature_key"], field="portfolio_feature_key"
+                ),
+                required_str(
+                    event["portfolio_feature_label"], field="portfolio_feature_label"
+                ),
+                required_str(event["portfolio_variant"], field="portfolio_variant"),
                 str(date_value),
             )
             values = aggregate.setdefault(key, [0.0, 0.0])
@@ -687,7 +701,13 @@ def _build_portfolio_summary_df(portfolio_daily_df: pd.DataFrame, portfolio_even
     records: list[dict[str, Any]] = []
     group_cols = ["selection_fraction", "score_method", "portfolio_feature_key", "portfolio_variant"]
     for keys, group in portfolio_daily_df.groupby(group_cols, observed=True, sort=False):
-        selection_fraction, score_method, feature_key, variant = keys
+        raw_selection_fraction, raw_score_method, raw_feature_key, raw_variant = keys
+        selection_fraction = required_float(
+            raw_selection_fraction, field="selection_fraction"
+        )
+        score_method = required_str(raw_score_method, field="score_method")
+        feature_key = required_str(raw_feature_key, field="portfolio_feature_key")
+        variant = required_str(raw_variant, field="portfolio_variant")
         start_date = str(group["date"].iloc[0])
         end_date = str(group["date"].iloc[-1])
         total_return = float(group["portfolio_value"].iloc[-1] - 1.0)
@@ -709,11 +729,11 @@ def _build_portfolio_summary_df(portfolio_daily_df: pd.DataFrame, portfolio_even
         stats_row = trade_stats.loc[count_key] if count_key in trade_stats.index else None
         records.append(
             {
-                "selection_fraction": float(selection_fraction),
-                "score_method": str(score_method),
-                "portfolio_feature_key": str(feature_key),
+                "selection_fraction": selection_fraction,
+                "score_method": score_method,
+                "portfolio_feature_key": feature_key,
                 "portfolio_feature_label": label,
-                "portfolio_variant": str(variant),
+                "portfolio_variant": variant,
                 "event_count": int(event_counts.get(count_key, 0)),
                 "start_date": start_date,
                 "end_date": end_date,
@@ -773,7 +793,7 @@ def _portfolio_year_returns(group: pd.DataFrame) -> pd.DataFrame:
         year_return = float(np.prod(1.0 + returns.to_numpy(dtype=float)) - 1.0) * 100.0
         records.append(
             {
-                "year": int(cast(Any, year)),
+                "year": required_int(year, field="year"),
                 "year_return_pct": year_return,
             }
         )

--- a/apps/bt/src/domains/analytics/annual_prime_value_volume_volatility_participation.py
+++ b/apps/bt/src/domains/analytics/annual_prime_value_volume_volatility_participation.py
@@ -45,6 +45,7 @@ from src.domains.analytics.research_bundle import (
     resolve_required_bundle_path,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import required_float, required_str
 
 ANNUAL_PRIME_VALUE_VOLUME_VOLATILITY_PARTICIPATION_EXPERIMENT_ID = (
     "market-behavior/annual-prime-value-volume-volatility-participation"
@@ -218,7 +219,11 @@ def _build_volatility_participation_summary_df(
         return _empty_df(columns)
     records: list[dict[str, Any]] = []
     for keys, group in enriched_event_df.groupby(["selection_fraction", "score_method"], sort=False):
-        selection_fraction, score_method = keys
+        raw_selection_fraction, raw_score_method = keys
+        selection_fraction = required_float(
+            raw_selection_fraction, field="selection_fraction"
+        )
+        score_method = required_str(raw_score_method, field="score_method")
         for vol_feature in _VOLATILITY_FEATURES:
             valid = group[pd.to_numeric(group[vol_feature], errors="coerce").notna()].copy()
             if valid.empty:
@@ -228,8 +233,8 @@ def _build_volatility_participation_summary_df(
             high = valid[valid["volatility_bucket_rank"].astype(int) == bucket_count]
             records.append(
                 {
-                    "selection_fraction": float(selection_fraction),
-                    "score_method": str(score_method),
+                    "selection_fraction": selection_fraction,
+                    "score_method": score_method,
                     "volatility_feature_key": vol_feature,
                     "volatility_feature_label": _VOLATILITY_FEATURE_LABELS[vol_feature],
                     "event_count": int(len(valid)),
@@ -282,7 +287,11 @@ def _build_participation_split_df(
         return _empty_df(columns)
     records: list[dict[str, Any]] = []
     for keys, group in enriched_event_df.groupby(["selection_fraction", "score_method"], sort=False):
-        selection_fraction, score_method = keys
+        raw_selection_fraction, raw_score_method = keys
+        selection_fraction = required_float(
+            raw_selection_fraction, field="selection_fraction"
+        )
+        score_method = required_str(raw_score_method, field="score_method")
         for vol_feature in _VOLATILITY_FEATURES:
             valid = group[pd.to_numeric(group[vol_feature], errors="coerce").notna()].copy()
             if valid.empty:
@@ -319,8 +328,8 @@ def _build_participation_split_df(
                 for variant, frame in frames:
                     records.append(
                         _split_record(
-                            selection_fraction=float(selection_fraction),
-                            score_method=str(score_method),
+                            selection_fraction=selection_fraction,
+                            score_method=score_method,
                             vol_feature=vol_feature,
                             participation_feature=participation_feature,
                             variant=variant,

--- a/apps/bt/src/domains/analytics/classical_momentum_research.py
+++ b/apps/bt/src/domains/analytics/classical_momentum_research.py
@@ -31,6 +31,12 @@ from src.domains.analytics.research_bundle import (
     write_dataclass_research_bundle,
 )
 from src.domains.analytics.topix_rank_future_close_core import _default_start_date
+from src.shared.utils.pandas_type_guards import (
+    finite_float_or_none,
+    int_or_none,
+    required_float,
+    required_int,
+)
 
 CLASSICAL_MOMENTUM_RESEARCH_EXPERIMENT_ID = "market-behavior/classical-momentum-research"
 
@@ -636,11 +642,13 @@ def _build_portfolio_summary_df(
             {
                 "universe_key": keys[0],
                 "universe_label": str(group["universe_label"].iloc[0]),
-                "lookback_sessions": int(keys[1]),
-                "skip_sessions": int(keys[2]),
+                "lookback_sessions": required_int(keys[1], field="lookback_sessions"),
+                "skip_sessions": required_int(keys[2], field="skip_sessions"),
                 "momentum_label": str(group["momentum_label"].iloc[0]),
-                "hold_sessions": int(keys[3]),
-                "selection_fraction": float(keys[4]),
+                "hold_sessions": required_int(keys[3], field="hold_sessions"),
+                "selection_fraction": required_float(
+                    keys[4], field="selection_fraction"
+                ),
                 "event_count": int(len(event_group)),
                 "unique_code_count": int(event_group["code"].nunique()) if not event_group.empty else 0,
                 "active_days": int((pd.to_numeric(group["active_positions"]) > 0).sum()),
@@ -765,27 +773,22 @@ def run_classical_momentum_research(
 
 
 def _format_int(value: object) -> str:
-    try:
-        number = int(float(value))  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+    number = int_or_none(value)
+    if number is None:
         return "-"
     return f"{number:,}"
 
 
 def _format_number(value: object, *, digits: int = 2, suffix: str = "") -> str:
-    try:
-        number = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return "-"
-    if pd.isna(number):
+    number = finite_float_or_none(value)
+    if number is None:
         return "-"
     return f"{number:.{digits}f}{suffix}"
 
 
 def _format_fraction_pct(value: object) -> str:
-    try:
-        number = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+    number = finite_float_or_none(value)
+    if number is None:
         return "-"
     return _format_number(number * 100.0, digits=1, suffix="%")
 

--- a/apps/bt/src/domains/analytics/daily_move_asymmetry.py
+++ b/apps/bt/src/domains/analytics/daily_move_asymmetry.py
@@ -22,6 +22,7 @@ from src.domains.analytics.research_bundle import (
     load_dataclass_research_bundle,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 DAILY_MOVE_ASYMMETRY_EXPERIMENT_ID = "market-behavior/daily-move-asymmetry"
 DEFAULT_ROLLING_VOL_WINDOW = 60
@@ -682,9 +683,11 @@ def _build_paired_asymmetry_df(event_summary_df: pd.DataFrame) -> pd.DataFrame:
                 continue
             rows.append(
                 {
-                    "scope": scope,
-                    "return_metric": return_metric,
-                    "horizon_sessions": int(horizon),
+                    "scope": required_str(scope, field="scope"),
+                    "return_metric": required_str(return_metric, field="return_metric"),
+                    "horizon_sessions": required_int(
+                        horizon, field="horizon_sessions"
+                    ),
                     "magnitude_bucket": magnitude,
                     "down_bucket": down_bucket,
                     "up_bucket": up_bucket,
@@ -765,7 +768,11 @@ def _build_streak_hazard_df(
     valid = with_streaks.dropna(subset=["next_1d_return_pct"]).copy()
     valid = valid[valid["streak_sign"].isin(["up", "down"])]
     valid["streak_bucket"] = valid["streak_length"].map(
-        lambda value: "5+" if int(value) >= 5 else str(int(value))
+        lambda value: (
+            "5+"
+            if required_int(value, field="streak_length") >= 5
+            else str(required_int(value, field="streak_length"))
+        )
     )
     rows: list[dict[str, object]] = []
     for keys, group in valid.groupby(["streak_sign", "streak_bucket"], sort=False):

--- a/apps/bt/src/domains/analytics/falling_knife_reversal_study.py
+++ b/apps/bt/src/domains/analytics/falling_knife_reversal_study.py
@@ -32,6 +32,7 @@ from src.domains.analytics.research_bundle import (
     write_dataclass_research_bundle,
 )
 from src.domains.strategy.indicators.calculations import compute_risk_adjusted_return
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 RatioType = Literal["sharpe", "sortino"]
 
@@ -618,7 +619,7 @@ def _build_trade_summary_df(
         "risk_adjusted_bucket",
     ]
     for keys, group in trade_df.groupby(group_columns, dropna=False, sort=False):
-        row = dict(zip(group_columns, keys, strict=True))
+        row = record_with_str_keys(dict(zip(group_columns, keys, strict=True)))
         row.update(
             _summarize_trade_returns(
                 group["trade_return"],
@@ -649,7 +650,7 @@ def _build_paired_delta_df(
             deltas = pd.to_numeric(group["return_delta"], errors="coerce").dropna()
             if deltas.empty:
                 continue
-            row = dict(zip(group_columns, keys, strict=True))
+            row = record_with_str_keys(dict(zip(group_columns, keys, strict=True)))
             row.update(
                 {
                     "horizon_days": horizon,

--- a/apps/bt/src/domains/analytics/forward_eps_driven_v3_factor_decomposition.py
+++ b/apps/bt/src/domains/analytics/forward_eps_driven_v3_factor_decomposition.py
@@ -27,7 +27,7 @@ from src.domains.analytics.research_bundle import (
     load_research_bundle_tables,
     write_research_bundle,
 )
-from src.shared.utils.pandas_type_guards import record_with_str_keys
+from src.shared.utils.pandas_type_guards import int_or_none, record_with_str_keys
 
 FORWARD_EPS_DRIVEN_V3_FACTOR_DECOMPOSITION_EXPERIMENT_ID = (
     "strategy-audit/forward-eps-driven-v3-factor-decomposition"
@@ -716,6 +716,7 @@ def _table_with_columns(
 
 
 def _build_summary_markdown(result: ForwardEpsDrivenV3FactorDecompositionResult) -> str:
+    published_summary = _build_published_summary(result)
     scenario = result.scenario_summary_df
     full = _first_row(scenario[scenario["window_label"] == "full"])
     holdout = _first_row(scenario[scenario["window_label"] == f"holdout_{result.holdout_months}m"])
@@ -747,7 +748,7 @@ def _build_summary_markdown(result: ForwardEpsDrivenV3FactorDecompositionResult)
         ]
     )
     lines = [
-        "# Forward EPS Driven V3 Factor Decomposition",
+        f"# {published_summary['title']}",
         "",
         "## Scope",
         "",
@@ -777,6 +778,36 @@ def _build_summary_markdown(result: ForwardEpsDrivenV3FactorDecompositionResult)
     ]
     return "\n".join(lines)
 
+
+
+def _build_published_summary(
+    result: ForwardEpsDrivenV3FactorDecompositionResult,
+) -> dict[str, Any]:
+    scenario = result.scenario_summary_df
+    full = _first_row(scenario[scenario["window_label"] == "full"])
+    holdout = _first_row(
+        scenario[scenario["window_label"] == f"holdout_{result.holdout_months}m"]
+    )
+    return {
+        "title": "Forward EPS Driven V3 Factor Decomposition",
+        "strategyName": result.strategy_name,
+        "datasetName": result.dataset_name,
+        "analysisStartDate": result.analysis_start_date,
+        "analysisEndDate": result.analysis_end_date,
+        "tradeCount": int_or_none(full.get("trade_count")),
+        "holdoutTradeCount": int_or_none(holdout.get("trade_count")),
+        "resultBullets": [
+            (
+                "Full-history average return "
+                f"{_fmt_pct(full.get('avg_trade_return_pct'))} across "
+                f"{_fmt_int(full.get('trade_count'))} trades."
+            ),
+            (
+                f"Holdout average return {_fmt_pct(holdout.get('avg_trade_return_pct'))} "
+                f"across {_fmt_int(holdout.get('trade_count'))} trades."
+            ),
+        ],
+    }
 
 
 def _first_row(frame: pd.DataFrame) -> dict[str, Any]:

--- a/apps/bt/src/domains/analytics/forward_eps_driven_v3_factor_decomposition.py
+++ b/apps/bt/src/domains/analytics/forward_eps_driven_v3_factor_decomposition.py
@@ -27,6 +27,7 @@ from src.domains.analytics.research_bundle import (
     load_research_bundle_tables,
     write_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 FORWARD_EPS_DRIVEN_V3_FACTOR_DECOMPOSITION_EXPERIMENT_ID = (
     "strategy-audit/forward-eps-driven-v3-factor-decomposition"
@@ -781,7 +782,7 @@ def _build_summary_markdown(result: ForwardEpsDrivenV3FactorDecompositionResult)
 def _first_row(frame: pd.DataFrame) -> dict[str, Any]:
     if frame.empty:
         return {}
-    return dict(frame.iloc[0].to_dict())
+    return record_with_str_keys(frame.iloc[0].to_dict())
 
 
 def _fmt_int(value: Any) -> str:

--- a/apps/bt/src/domains/analytics/forward_eps_technical_horizon_decomposition.py
+++ b/apps/bt/src/domains/analytics/forward_eps_technical_horizon_decomposition.py
@@ -27,6 +27,7 @@ from src.domains.analytics.research_bundle import (
     load_research_bundle_tables,
     write_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 from src.domains.strategy.indicators import compute_risk_adjusted_return, compute_rsi
 from src.infrastructure.data_access.loaders import load_stock_data
 from src.infrastructure.data_access.mode import data_access_mode_context
@@ -1044,7 +1045,7 @@ def _build_summary_markdown(result: ForwardEpsTechnicalHorizonDecompositionResul
 def _first_row(frame: pd.DataFrame) -> dict[str, Any]:
     if frame.empty:
         return {}
-    return dict(frame.iloc[0].to_dict())
+    return record_with_str_keys(frame.iloc[0].to_dict())
 
 
 def _fmt_int(value: Any) -> str:

--- a/apps/bt/src/domains/analytics/forward_eps_threshold_window_study.py
+++ b/apps/bt/src/domains/analytics/forward_eps_threshold_window_study.py
@@ -983,6 +983,7 @@ def _build_key_read_lines(
 
 
 def _fmt_pct(value: Any) -> str:
+    value = _to_native(value)
     try:
         if value is None or pd.isna(value):
             return "n/a"
@@ -992,6 +993,7 @@ def _fmt_pct(value: Any) -> str:
 
 
 def _fmt_num(value: Any) -> str:
+    value = _to_native(value)
     try:
         if value is None or pd.isna(value):
             return "n/a"
@@ -1001,6 +1003,7 @@ def _fmt_num(value: Any) -> str:
 
 
 def _fmt_threshold(value: Any) -> str:
+    value = _to_native(value)
     try:
         if value is None or pd.isna(value):
             return "n/a"
@@ -1011,6 +1014,7 @@ def _fmt_threshold(value: Any) -> str:
 
 
 def _fmt_int(value: Any) -> str:
+    value = _to_native(value)
     try:
         if value is None or pd.isna(value):
             return "n/a"
@@ -1028,3 +1032,13 @@ def _format_variant(row: Any) -> str:
         f"{_fmt_int(row.get('volume_ratio_above_long_period'))}@"
         f"{_fmt_threshold(row.get('volume_ratio_above_threshold'))}"
     )
+
+
+def _to_native(value: Any) -> Any:
+    item = getattr(value, "item", None)
+    if item is None:
+        return value
+    try:
+        return item()
+    except (TypeError, ValueError):
+        return value

--- a/apps/bt/src/domains/analytics/forward_eps_trade_archetype_decomposition.py
+++ b/apps/bt/src/domains/analytics/forward_eps_trade_archetype_decomposition.py
@@ -1170,7 +1170,7 @@ def _resolve_previous_index_value(
     position = index.searchsorted(target, side="left") - 1
     if position < 0:
         return None
-    return cast(pd.Timestamp, index[position])
+    return cast(pd.Timestamp, index[int(position)])
 
 
 def _resolve_last_index_value(
@@ -1180,7 +1180,7 @@ def _resolve_last_index_value(
     position = index.searchsorted(target, side="right") - 1
     if position < 0:
         return None
-    return cast(pd.Timestamp, index[position])
+    return cast(pd.Timestamp, index[int(position)])
 
 
 def _extract_row(frame: pd.DataFrame, ts: pd.Timestamp | None) -> dict[str, Any] | None:

--- a/apps/bt/src/domains/analytics/free_float_liquidity_gap.py
+++ b/apps/bt/src/domains/analytics/free_float_liquidity_gap.py
@@ -31,6 +31,12 @@ from src.domains.analytics.research_bundle import (
     write_dataclass_research_bundle,
 )
 from src.shared.utils.market_code_alias import normalize_market_scope
+from src.shared.utils.pandas_type_guards import (
+    int_or_none,
+    numeric_series_or_empty,
+    required_int,
+    required_str,
+)
 
 FREE_FLOAT_LIQUIDITY_GAP_EXPERIMENT_ID = "market-behavior/free-float-liquidity-gap"
 DEFAULT_ADV_WINDOWS: tuple[int, ...] = (20, 60)
@@ -768,8 +774,8 @@ def _build_market_regression_df(
         r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else np.nan
         records.append(
             {
-                "market_scope": str(market_scope),
-                "adv_window": int(adv_window),
+                "market_scope": required_str(market_scope, field="market_scope"),
+                "adv_window": required_int(adv_window, field="adv_window"),
                 "observation_count": int(len(valid)),
                 "code_count": int(valid["code"].nunique()),
                 "intercept": float(intercept),
@@ -927,8 +933,8 @@ def _build_bucket_forward_return_df(
                 excess = pd.to_numeric(bucket_frame[excess_col], errors="coerce")
                 records.append(
                     {
-                        "market_scope": str(market_scope),
-                        "adv_window": int(adv_window),
+                        "market_scope": required_str(market_scope, field="market_scope"),
+                        "adv_window": required_int(adv_window, field="adv_window"),
                         "horizon": int(horizon),
                         rank_column: resolved_bucket_rank,
                         label_column: _bucket_label(resolved_bucket_rank, bucket_count),
@@ -984,8 +990,8 @@ def _build_market_sample_diagnostics_df(observation_df: pd.DataFrame) -> pd.Data
         market_scope, adv_window = keys
         records.append(
             {
-                "market_scope": str(market_scope),
-                "adv_window": int(adv_window),
+                "market_scope": required_str(market_scope, field="market_scope"),
+                "adv_window": required_int(adv_window, field="adv_window"),
                 "observation_count": int(len(group)),
                 "code_count": int(group["code"].nunique()),
                 "start_date": _str_or_none(group["date"].min()),
@@ -1355,27 +1361,25 @@ def _to_float(value: Any) -> float | None:
         return None
 
 
-def _to_int(value: Any) -> int | None:
+def _to_int(value: object) -> int | None:
     try:
-        if value is None or pd.isna(value):
-            return None
-        return int(value)
+        return int_or_none(value)
     except (TypeError, ValueError):
         return None
 
 
 def _mean(values: Iterable[Any]) -> float:
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return _round_float(float(series.mean())) if not series.empty else np.nan
 
 
 def _median(values: Iterable[Any]) -> float:
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return _round_float(float(series.median())) if not series.empty else np.nan
 
 
 def _win_rate(values: Iterable[Any]) -> float:
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return (
         _round_float(float((series > 0).mean() * 100.0)) if not series.empty else np.nan
     )

--- a/apps/bt/src/domains/analytics/free_float_liquidity_prime_momentum_interaction.py
+++ b/apps/bt/src/domains/analytics/free_float_liquidity_prime_momentum_interaction.py
@@ -23,6 +23,11 @@ from src.domains.analytics.research_bundle import (
     resolve_required_bundle_path,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import (
+    numeric_series_or_empty,
+    required_int,
+    required_str,
+)
 
 FREE_FLOAT_LIQUIDITY_PRIME_MOMENTUM_INTERACTION_EXPERIMENT_ID = (
     "market-behavior/free-float-liquidity-prime-momentum-interaction"
@@ -460,10 +465,13 @@ def _build_interaction_bucket_df(
             returns = pd.to_numeric(group[y_column], errors="coerce")
             records.append(
                 {
-                    "adv_window": int(adv_window),
+                    "adv_window": required_int(adv_window, field="adv_window"),
                     "horizon": int(horizon),
-                    "momentum_state": str(momentum_state),
-                    "liquidity_state": str(liquidity_state),
+                    "momentum_state": required_str(momentum_state, field="momentum_state"),
+                    "liquidity_state": required_str(
+                        liquidity_state,
+                        field="liquidity_state",
+                    ),
                     "observation_count": int(returns.notna().sum()),
                     "code_count": int(group["code"].nunique()),
                     "mean_forward_excess_return_pct": _mean(returns),
@@ -532,8 +540,8 @@ def _build_momentum_residual_summary_df(bucket_df: pd.DataFrame) -> pd.DataFrame
                 continue
             records.append(
                 {
-                    "adv_window": int(adv_window),
-                    "horizon": int(horizon),
+                    "adv_window": required_int(adv_window, field="adv_window"),
+                    "horizon": required_int(horizon, field="horizon"),
                     "comparison_name": comparison_name,
                     "lhs_group": "__".join(lhs_key),
                     "rhs_group": "__".join(rhs_key),
@@ -620,21 +628,21 @@ def _format_markdown_cell(value: Any) -> str:
 def _mean(values: Iterable[Any] | None) -> float:
     if values is None:
         return np.nan
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return _round_float(float(series.mean())) if not series.empty else np.nan
 
 
 def _median(values: Iterable[Any] | None) -> float:
     if values is None:
         return np.nan
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return _round_float(float(series.median())) if not series.empty else np.nan
 
 
 def _win_rate(values: Iterable[Any] | None) -> float:
     if values is None:
         return np.nan
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return (
         _round_float(float((series > 0).mean() * 100.0)) if not series.empty else np.nan
     )

--- a/apps/bt/src/domains/analytics/free_float_liquidity_regime_decomposition.py
+++ b/apps/bt/src/domains/analytics/free_float_liquidity_regime_decomposition.py
@@ -28,6 +28,13 @@ from src.domains.analytics.research_bundle import (
     resolve_required_bundle_path,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import (
+    finite_float_or_none,
+    numeric_series_or_empty,
+    required_int,
+    required_str,
+    str_or_none,
+)
 
 FREE_FLOAT_LIQUIDITY_REGIME_DECOMPOSITION_EXPERIMENT_ID = (
     "market-behavior/free-float-liquidity-regime-decomposition"
@@ -487,10 +494,12 @@ def _build_regime_forward_return_df(enriched_df: pd.DataFrame) -> pd.DataFrame:
             )
             records.append(
                 {
-                    "market_scope": str(market_scope),
-                    "adv_window": int(adv_window),
+                    "market_scope": required_str(market_scope, field="market_scope"),
+                    "adv_window": required_int(adv_window, field="adv_window"),
                     "horizon": int(horizon),
-                    "liquidity_regime": str(regime),
+                    "liquidity_regime": required_str(
+                        regime, field="liquidity_regime"
+                    ),
                     "observation_count": int(returns.notna().sum()),
                     "code_count": int(group["code"].nunique()),
                     "mean_forward_return_pct": _mean(returns),
@@ -548,9 +557,9 @@ def _build_market_regime_diagnostics_df(enriched_df: pd.DataFrame) -> pd.DataFra
         market_scope, adv_window, regime = keys
         records.append(
             {
-                "market_scope": str(market_scope),
-                "adv_window": int(adv_window),
-                "liquidity_regime": str(regime),
+                "market_scope": required_str(market_scope, field="market_scope"),
+                "adv_window": required_int(adv_window, field="adv_window"),
+                "liquidity_regime": required_str(regime, field="liquidity_regime"),
                 "observation_count": int(len(group)),
                 "code_count": int(group["code"].nunique()),
                 "start_date": _str_or_none(group["date"].min()),
@@ -734,32 +743,21 @@ def _offset_calendar_date(date: str | None, *, days: int) -> str:
 
 
 def _to_float(value: Any) -> float | None:
-    try:
-        if value is None or pd.isna(value):
-            return None
-        return float(value)
-    except (TypeError, ValueError):
-        return None
+    return finite_float_or_none(value)
 
 
 def _mean(values: Iterable[Any] | None) -> float:
-    if values is None:
-        return np.nan
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return _round_float(float(series.mean())) if not series.empty else np.nan
 
 
 def _median(values: Iterable[Any] | None) -> float:
-    if values is None:
-        return np.nan
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return _round_float(float(series.median())) if not series.empty else np.nan
 
 
 def _win_rate(values: Iterable[Any] | None) -> float:
-    if values is None:
-        return np.nan
-    series = pd.to_numeric(pd.Series(values), errors="coerce").dropna()
+    series = numeric_series_or_empty(values)
     return (
         _round_float(float((series > 0).mean() * 100.0)) if not series.empty else np.nan
     )
@@ -776,6 +774,4 @@ def _round_float(value: Any, digits: int = 4) -> float:
 
 
 def _str_or_none(value: Any) -> str | None:
-    if value is None or pd.isna(value):
-        return None
-    return str(value)
+    return str_or_none(value)

--- a/apps/bt/src/domains/analytics/hedge_1357_nt_ratio_topix_market_frame.py
+++ b/apps/bt/src/domains/analytics/hedge_1357_nt_ratio_topix_market_frame.py
@@ -23,6 +23,7 @@ from src.domains.analytics.hedge_1357_nt_ratio_topix_support import (
     format_nt_ratio_bucket_label,
 )
 from src.domains.strategy.indicators import compute_moving_average
+from src.shared.utils.pandas_type_guards import finite_float_or_none, is_missing_scalar
 
 
 def _compute_ema_macd_histogram(
@@ -441,10 +442,14 @@ def _calculate_market_features(
     enriched["topix_ma60"] = enriched["topix_close"].rolling(60, min_periods=60).mean()
     enriched["topix_ma20_slope_5d"] = enriched["topix_ma20"] - enriched["topix_ma20"].shift(5)
     enriched["topix_close_bucket_key"] = enriched["topix_close_return"].map(
-        lambda value: _bucket_topix_close_return(value, stats=topix_close_stats)
+        lambda value: _bucket_topix_close_return(
+            finite_float_or_none(value), stats=topix_close_stats
+        )
     )
     enriched["nt_ratio_bucket_key"] = enriched["nt_ratio_return"].map(
-        lambda value: _bucket_nt_ratio_return(value, stats=nt_ratio_stats)
+        lambda value: _bucket_nt_ratio_return(
+            finite_float_or_none(value), stats=nt_ratio_stats
+        )
     )
     enriched["topix_close_bucket_label"] = enriched["topix_close_bucket_key"].map(
         lambda value: (
@@ -464,7 +469,7 @@ def _calculate_market_features(
                 sigma_threshold_1=nt_ratio_stats.sigma_threshold_1,
                 sigma_threshold_2=nt_ratio_stats.sigma_threshold_2,
             )
-            if value is not None and nt_ratio_stats is not None
+            if not is_missing_scalar(value) and nt_ratio_stats is not None
             else None
         )
     )

--- a/apps/bt/src/domains/analytics/hedge_1357_nt_ratio_topix_strategy_metrics.py
+++ b/apps/bt/src/domains/analytics/hedge_1357_nt_ratio_topix_strategy_metrics.py
@@ -18,6 +18,7 @@ from src.domains.analytics.hedge_1357_nt_ratio_topix_support import (
     _BETA_MIN_PERIODS,
     _TARGET_COLUMN_MAP,
 )
+from src.shared.utils.pandas_type_guards import required_int
 
 
 def _expected_shortfall(series: pd.Series, tail_probability: float = 0.05) -> float | None:
@@ -279,7 +280,7 @@ def _build_annual_rule_summary(
                     metrics.update(
                         {
                             "stock_group": stock_group,
-                            "calendar_year": int(year),
+                            "calendar_year": required_int(year, field="calendar_year"),
                         }
                     )
                     rows.append(metrics)

--- a/apps/bt/src/domains/analytics/high_zone_bearish_price_action.py
+++ b/apps/bt/src/domains/analytics/high_zone_bearish_price_action.py
@@ -513,8 +513,11 @@ def _aggregate_pattern_summary(conn: Any, *, horizons: tuple[int, ...]) -> pd.Da
         on=["market_key", "high_zone_key", "volume_key", "horizon_days"],
         how="left",
     )
+    baseline_event_count = summary["baseline_event_count"].where(
+        summary["baseline_event_count"] != 0
+    )
     summary["event_share_of_high_zone_baseline"] = (
-        summary["event_count"] / summary["baseline_event_count"].replace({0: pd.NA})
+        summary["event_count"] / baseline_event_count
     )
     summary["mean_lift_vs_high_zone_baseline"] = (
         summary["mean_forward_return"] - summary["baseline_mean_forward_return"]

--- a/apps/bt/src/domains/analytics/index_market_strength_research.py
+++ b/apps/bt/src/domains/analytics/index_market_strength_research.py
@@ -20,6 +20,7 @@ from src.domains.analytics.research_bundle import (
     load_dataclass_research_bundle,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import is_missing_scalar
 
 INDEX_MARKET_STRENGTH_RESEARCH_EXPERIMENT_ID = (
     "market-behavior/index-market-strength-research"
@@ -442,7 +443,7 @@ def _build_index_price_feature_df(
     if result.empty:
         return result
     result["sample_period"] = result["date"].map(
-        lambda value: _sample_period(
+        lambda value: _sample_period_from_value(
             value,
             discovery_end_date=discovery_end_date,
             validation_end_date=validation_end_date,
@@ -516,6 +517,21 @@ def _sample_period(
     if value <= pd.Timestamp(validation_end_date):
         return "validation"
     return "holdout"
+
+
+def _sample_period_from_value(
+    value: object,
+    *,
+    discovery_end_date: str,
+    validation_end_date: str,
+) -> str:
+    if is_missing_scalar(value):
+        raise ValueError("date is required for sample_period")
+    return _sample_period(
+        pd.Timestamp(str(value)),
+        discovery_end_date=discovery_end_date,
+        validation_end_date=validation_end_date,
+    )
 
 
 def _build_index_state_summary_df(

--- a/apps/bt/src/domains/analytics/margin_metrics.py
+++ b/apps/bt/src/domains/analytics/margin_metrics.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 import pandas as pd
+
+from src.shared.utils.pandas_type_guards import finite_float_or_none
 
 
 def _format_date(idx: Any) -> str:
@@ -27,11 +29,13 @@ def compute_margin_long_pressure(
         av = avg_vol.get(idx)
         if pd.isna(av) or av == 0:
             continue
-        nm = float(cast(Any, net_margin[idx]))
-        if pd.isna(nm):
+        nm = finite_float_or_none(net_margin[idx])
+        if nm is None:
             continue
-        lv = float(cast(Any, margin_df.at[idx, "longMarginVolume"]))
-        sv = float(cast(Any, margin_df.at[idx, "shortMarginVolume"]))
+        lv = finite_float_or_none(margin_df.at[idx, "longMarginVolume"])
+        sv = finite_float_or_none(margin_df.at[idx, "shortMarginVolume"])
+        if lv is None or sv is None:
+            continue
         records.append(
             {
                 "date": _format_date(idx),
@@ -63,13 +67,16 @@ def compute_margin_flow_pressure(
         d = delta.get(idx)
         if pd.isna(av) or av == 0 or pd.isna(d):
             continue
-        prev_val = float(cast(Any, prev_net_margin[idx]))
+        prev_val = finite_float_or_none(prev_net_margin[idx])
+        current_net_margin = finite_float_or_none(net_margin[idx])
+        if current_net_margin is None:
+            continue
         records.append(
             {
                 "date": _format_date(idx),
                 "flowPressure": round(float(d) / float(av), 4),
-                "currentNetMargin": int(float(cast(Any, net_margin[idx]))),
-                "previousNetMargin": int(prev_val) if not pd.isna(prev_val) else None,
+                "currentNetMargin": int(current_net_margin),
+                "previousNetMargin": int(prev_val) if prev_val is not None else None,
                 "avgVolume": round(float(av), 2),
             }
         )
@@ -120,7 +127,10 @@ def compute_margin_volume_ratio(
         return []
 
     week_keys = positive_vol.index.to_series().apply(_get_iso_week_key)
-    weekly_avg_map: dict[str, float] = positive_vol.groupby(week_keys).mean().to_dict()
+    weekly_avg_map = {
+        str(key): float(value)
+        for key, value in positive_vol.groupby(week_keys).mean().to_dict().items()
+    }
 
     records: list[dict[str, Any]] = []
     for idx in margin_df.index:
@@ -129,9 +139,9 @@ def compute_margin_volume_ratio(
         if avg_vol is None or avg_vol == 0:
             continue
 
-        lv = float(cast(Any, margin_df.at[idx, "longMarginVolume"]))
-        sv = float(cast(Any, margin_df.at[idx, "shortMarginVolume"]))
-        if pd.isna(lv) or pd.isna(sv):
+        lv = finite_float_or_none(margin_df.at[idx, "longMarginVolume"])
+        sv = finite_float_or_none(margin_df.at[idx, "shortMarginVolume"])
+        if lv is None or sv is None:
             continue
         avg_vol_f = float(avg_vol)
         records.append(

--- a/apps/bt/src/domains/analytics/new_high_momentum_research.py
+++ b/apps/bt/src/domains/analytics/new_high_momentum_research.py
@@ -36,6 +36,7 @@ from src.domains.analytics.research_bundle import (
     write_dataclass_research_bundle,
 )
 from src.domains.analytics.topix_rank_future_close_core import _default_start_date
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 NEW_HIGH_MOMENTUM_EXPERIMENT_ID = "market-behavior/new-high-momentum-research"
 
@@ -798,8 +799,11 @@ def _aggregate_condition_summary(
         on=["universe_key", "new_high_window", "horizon_days"],
         how="left",
     )
+    baseline_event_count = summary["new_high_baseline_event_count"].where(
+        summary["new_high_baseline_event_count"] != 0
+    )
     summary["event_share_of_new_high_baseline"] = (
-        summary["event_count"] / summary["new_high_baseline_event_count"].replace({0: pd.NA})
+        summary["event_count"] / baseline_event_count
     )
     summary["mean_lift_vs_new_high_baseline"] = (
         summary["mean_forward_return"] - summary["new_high_baseline_mean_forward_return"]
@@ -1186,10 +1190,10 @@ def _build_portfolio_summary_df(
             {
                 "universe_key": keys[0],
                 "universe_label": str(group["universe_label"].iloc[0]),
-                "new_high_window": int(keys[1]),
-                "condition_key": keys[2],
+                "new_high_window": required_int(keys[1], field="new_high_window"),
+                "condition_key": required_str(keys[2], field="condition_key"),
                 "condition_label": str(group["condition_label"].iloc[0]),
-                "horizon_days": int(keys[3]),
+                "horizon_days": required_int(keys[3], field="horizon_days"),
                 "event_count": int(len(event_group)),
                 "unique_code_count": int(event_group["code"].nunique()) if not event_group.empty else 0,
                 "active_days": int((pd.to_numeric(group["active_positions"]) > 0).sum()),

--- a/apps/bt/src/domains/analytics/pre_disclosure_flow_volatility.py
+++ b/apps/bt/src/domains/analytics/pre_disclosure_flow_volatility.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Sequence, cast
+from typing import Any, Iterable, Sequence
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,7 @@ from src.domains.analytics.readonly_duckdb_support import (
 from src.domains.analytics.research_bundle import ResearchBundleInfo, write_research_bundle
 from src.domains.strategy.indicators.calculations import compute_atr
 from src.shared.utils.market_code_alias import normalize_market_scope
+from src.shared.utils.pandas_type_guards import finite_float_or_none, int_or_none
 
 PRE_DISCLOSURE_FLOW_VOLATILITY_EXPERIMENT_ID = (
     "market-behavior/pre-disclosure-flow-volatility"
@@ -776,9 +777,7 @@ def _build_score_bucket_summary_df(
                     {
                         "market_scope": market_scope,
                         "horizon": horizon,
-                        "score_bucket_rank": int(bucket_rank)
-                        if pd.notna(bucket_rank)
-                        else None,
+                        "score_bucket_rank": int_or_none(bucket_rank),
                         "score_bucket": score_bucket,
                         "event_count": int(len(frame)),
                         "code_count": int(frame["code"].nunique()),
@@ -1323,12 +1322,8 @@ def _median_or_nan(values: pd.Series) -> float:
 
 
 def _float_or_nan(value: object) -> float:
-    try:
-        if _is_missing_scalar(value):
-            return np.nan
-        return float(cast(Any, value))
-    except (TypeError, ValueError):
-        return np.nan
+    numeric = finite_float_or_none(value)
+    return numeric if numeric is not None else np.nan
 
 
 def _str_or_none(value: object) -> str | None:

--- a/apps/bt/src/domains/analytics/production_strategy_robustness_audit.py
+++ b/apps/bt/src/domains/analytics/production_strategy_robustness_audit.py
@@ -20,6 +20,7 @@ from src.domains.analytics.research_bundle import (
     load_research_bundle_tables,
     write_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 from src.domains.analytics.window_warmup import (
     estimate_strategy_indicator_warmup_calendar_days,
     resolve_window_load_start_date,
@@ -1157,7 +1158,7 @@ def _select_metric_row(
     ]
     if filtered.empty:
         return None
-    return filtered.iloc[0].to_dict()
+    return record_with_str_keys(filtered.iloc[0].to_dict())
 
 
 def _fmt_pct(value: Any) -> str:

--- a/apps/bt/src/domains/analytics/production_strategy_single_name_trade_quality.py
+++ b/apps/bt/src/domains/analytics/production_strategy_single_name_trade_quality.py
@@ -23,6 +23,7 @@ from src.domains.analytics.research_bundle import (
     load_research_bundle_tables,
     write_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 from src.domains.backtest.core.market_universe import resolve_backtest_universe_codes
 from src.domains.analytics.window_warmup import (
     estimate_strategy_indicator_warmup_calendar_days,
@@ -1017,7 +1018,7 @@ def _select_scenario_row(
     ]
     if filtered.empty:
         return None
-    return filtered.iloc[0].to_dict()
+    return record_with_str_keys(filtered.iloc[0].to_dict())
 
 
 def _fmt_pct(value: Any) -> str:

--- a/apps/bt/src/domains/analytics/ranking_core_sector_neutral_value_regime_breakdown.py
+++ b/apps/bt/src/domains/analytics/ranking_core_sector_neutral_value_regime_breakdown.py
@@ -36,6 +36,7 @@ from src.domains.analytics.readonly_duckdb_support import (
     open_readonly_analysis_connection,
 )
 from src.domains.analytics.research_bundle import ResearchBundleInfo, write_research_bundle
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 RANKING_CORE_SECTOR_NEUTRAL_VALUE_REGIME_BREAKDOWN_EXPERIMENT_ID = (
     "market-behavior/ranking-core-sector-neutral-value-regime-breakdown"
@@ -830,10 +831,10 @@ def _build_bank_displacement_df(annual_df: pd.DataFrame) -> pd.DataFrame:
         )
         records.append(
             {
-                "horizon": int(horizon),
-                "market_scope": str(market_scope),
-                "year": str(year),
-                "factor_signal": str(factor_signal),
+                "horizon": required_int(horizon, field="horizon"),
+                "market_scope": required_str(market_scope, field="market_scope"),
+                "year": required_str(year, field="year"),
+                "factor_signal": required_str(factor_signal, field="factor_signal"),
                 "factor_display_name": str(all_row["factor_display_name"]),
                 "all_observation_count": int(all_row["observation_count"]),
                 "bank_observation_share_pct": _to_float(

--- a/apps/bt/src/domains/analytics/ranking_long_sector_leadership_horizon_decomposition.py
+++ b/apps/bt/src/domains/analytics/ranking_long_sector_leadership_horizon_decomposition.py
@@ -30,6 +30,7 @@ from src.domains.analytics.readonly_duckdb_support import (
     open_readonly_analysis_connection,
 )
 from src.domains.analytics.research_bundle import ResearchBundleInfo, write_research_bundle
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 RANKING_LONG_SECTOR_LEADERSHIP_HORIZON_DECOMPOSITION_EXPERIMENT_ID = (
     "market-behavior/ranking-long-sector-leadership-horizon-decomposition"
@@ -916,10 +917,12 @@ def _build_bank_concentration_df(annual_df: pd.DataFrame) -> pd.DataFrame:
         horizon, market_scope, year, overlay_signal = keys
         records.append(
             {
-                "horizon": int(horizon),
-                "market_scope": str(market_scope),
-                "year": str(year),
-                "overlay_signal": str(overlay_signal),
+                "horizon": required_int(horizon, field="horizon"),
+                "market_scope": required_str(market_scope, field="market_scope"),
+                "year": required_str(year, field="year"),
+                "overlay_signal": required_str(
+                    overlay_signal, field="overlay_signal"
+                ),
                 "overlay_display_name": str(all_row["overlay_display_name"]),
                 "all_observation_count": int(all_row["observation_count"]),
                 "bank_observation_share_pct": _to_float(

--- a/apps/bt/src/domains/analytics/speculative_volume_surge_follow_on.py
+++ b/apps/bt/src/domains/analytics/speculative_volume_surge_follow_on.py
@@ -43,6 +43,7 @@ from src.domains.analytics.research_bundle import (
     load_dataclass_research_bundle,
     write_dataclass_research_bundle,
 )
+from src.shared.utils.pandas_type_guards import is_missing_scalar
 from src.domains.analytics.topix_rank_future_close_core import _default_start_date
 
 CohortKey = Literal[
@@ -1046,13 +1047,15 @@ def _build_size_liquidity_summary_df(
             sort=False,
         ):
             extension_bucket_name = (
-                "missing" if pd.isna(extension_bucket) else str(extension_bucket)
+                "missing" if is_missing_scalar(extension_bucket) else str(extension_bucket)
             )
             rows.append(
                 {
                     "dimension_name": dimension_name,
                     "dimension_label": dimension_label,
-                    "dimension_value": "missing" if pd.isna(dimension_value) else str(dimension_value),
+                    "dimension_value": "missing"
+                    if is_missing_scalar(dimension_value)
+                    else str(dimension_value),
                     "extension_bucket": extension_bucket_name,
                     "extension_bucket_order": EXTENSION_BUCKET_ORDER.index(extension_bucket_name)
                     if extension_bucket_name in EXTENSION_BUCKET_ORDER

--- a/apps/bt/src/domains/analytics/speculative_volume_surge_prime_pullback_profile.py
+++ b/apps/bt/src/domains/analytics/speculative_volume_surge_prime_pullback_profile.py
@@ -45,6 +45,7 @@ from src.domains.analytics.speculative_volume_surge_follow_on import (
     SpeculativeVolumeSurgeFollowOnResult,
     run_speculative_volume_surge_follow_on_research,
 )
+from src.shared.utils.pandas_type_guards import is_missing_scalar
 
 SPECULATIVE_VOLUME_SURGE_PRIME_PULLBACK_PROFILE_EXPERIMENT_ID = (
     "market-behavior/speculative-volume-surge-prime-pullback-profile"
@@ -650,10 +651,12 @@ def _build_adv_bucket_summary_df(
         sort=False,
         dropna=False,
     ):
-        bucket_name = "missing" if pd.isna(bucket_label) else str(bucket_label)
+        bucket_name = "missing" if is_missing_scalar(bucket_label) else str(bucket_label)
         rows.append(
             {
-                "adv20_bucket": "missing" if pd.isna(adv20_bucket) else str(adv20_bucket),
+                "adv20_bucket": "missing"
+                if is_missing_scalar(adv20_bucket)
+                else str(adv20_bucket),
                 "pullback_bucket": bucket_name,
                 "pullback_bucket_order": PULLBACK_BUCKET_ORDER.index(bucket_name)
                 if bucket_name in PULLBACK_BUCKET_ORDER

--- a/apps/bt/src/domains/analytics/speculative_volume_surge_prime_pullback_tradeable.py
+++ b/apps/bt/src/domains/analytics/speculative_volume_surge_prime_pullback_tradeable.py
@@ -54,6 +54,7 @@ from src.domains.analytics.speculative_volume_surge_prime_pullback_profile impor
     _profile_columns,
     _query_episode_price_paths,
 )
+from src.shared.utils.pandas_type_guards import is_missing_scalar
 
 SPECULATIVE_VOLUME_SURGE_PRIME_PULLBACK_TRADEABLE_EXPERIMENT_ID = (
     "market-behavior/speculative-volume-surge-prime-pullback-tradeable"
@@ -473,8 +474,8 @@ def _build_entry_speed_summary_df(trade_entry_df: pd.DataFrame) -> pd.DataFrame:
         sort=False,
         dropna=False,
     ):
-        entry_name = "missing" if pd.isna(entry_bucket) else str(entry_bucket)
-        speed_name = "missing" if pd.isna(speed_bucket) else str(speed_bucket)
+        entry_name = "missing" if is_missing_scalar(entry_bucket) else str(entry_bucket)
+        speed_name = "missing" if is_missing_scalar(speed_bucket) else str(speed_bucket)
         rows.append(
             {
                 "entry_bucket": entry_name,

--- a/apps/bt/src/domains/analytics/speculative_volume_surge_pullback_edge.py
+++ b/apps/bt/src/domains/analytics/speculative_volume_surge_pullback_edge.py
@@ -43,6 +43,7 @@ from src.domains.analytics.speculative_volume_surge_follow_on import (
     SpeculativeVolumeSurgeFollowOnResult,
     run_speculative_volume_surge_follow_on_research,
 )
+from src.shared.utils.pandas_type_guards import is_missing_scalar
 
 SPECULATIVE_VOLUME_SURGE_PULLBACK_EDGE_EXPERIMENT_ID = (
     "market-behavior/speculative-volume-surge-pullback-edge"
@@ -638,12 +639,14 @@ def _build_pullback_dimension_summary_df(
             sort=False,
             dropna=False,
         ):
-            bucket_name = "missing" if pd.isna(bucket_label) else str(bucket_label)
+            bucket_name = "missing" if is_missing_scalar(bucket_label) else str(bucket_label)
             rows.append(
                 {
                     "dimension_name": dimension_name,
                     "dimension_label": dimension_label,
-                    "dimension_value": "missing" if pd.isna(dimension_value) else str(dimension_value),
+                    "dimension_value": "missing"
+                    if is_missing_scalar(dimension_value)
+                    else str(dimension_value),
                     "pullback_bucket": bucket_name,
                     "pullback_bucket_order": PULLBACK_BUCKET_ORDER.index(bucket_name)
                     if bucket_name in PULLBACK_BUCKET_ORDER

--- a/apps/bt/src/domains/analytics/standard_negative_eps_speculative_winner_feature_combos.py
+++ b/apps/bt/src/domains/analytics/standard_negative_eps_speculative_winner_feature_combos.py
@@ -55,6 +55,7 @@ from src.domains.analytics.standard_negative_eps_right_tail_decomposition import
     _to_nullable_float,
     run_standard_negative_eps_right_tail_decomposition,
 )
+from src.shared.utils.pandas_type_guards import str_or_none
 
 STANDARD_NEGATIVE_EPS_SPECULATIVE_WINNER_FEATURE_COMBOS_EXPERIMENT_ID = (
     "market-behavior/standard-negative-eps-speculative-winner-feature-combos"
@@ -513,7 +514,7 @@ def _apply_sector_bucket_collapse(
     )
     collapsed["sector_bucket"] = collapsed["sector_33_name"].map(
         lambda value: _bucket_sector_name(
-            value,
+            str_or_none(value),
             keep_named=int(sector_counts.get(str(value or "").strip(), 0))
             >= sparse_sector_min_event_count,
         )

--- a/apps/bt/src/domains/analytics/stock_intraday_overnight_share.py
+++ b/apps/bt/src/domains/analytics/stock_intraday_overnight_share.py
@@ -123,7 +123,9 @@ def _open_analysis_connection(db_path: str):
     )
 
 
-def _group_order_key(series: pd.Series, selected_groups: Sequence[StockGroup]) -> pd.Categorical:
+def _group_order_key(
+    series: pd.Series, selected_groups: Sequence[StockGroup]
+) -> pd.Categorical[str]:
     return pd.Categorical(series, categories=list(selected_groups), ordered=True)
 
 

--- a/apps/bt/src/domains/analytics/stop_limit_buy_only_next_close_followthrough.py
+++ b/apps/bt/src/domains/analytics/stop_limit_buy_only_next_close_followthrough.py
@@ -32,6 +32,7 @@ from src.domains.analytics.stop_limit_daily_classification import (
     StopLimitDailyClassificationResult,
     run_stop_limit_daily_classification_research,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 MarketName = Literal["プライム", "スタンダード", "グロース"]
 NextCloseSign = Literal["minus", "flat", "plus"]
@@ -316,10 +317,14 @@ def _build_yearly_summary_df(signal_event_df: pd.DataFrame) -> pd.DataFrame:
     for (calendar_year, market_name, close_limit_state, next_close_sign), group_df in grouped:
         rows.append(
             {
-                "calendar_year": int(calendar_year),
-                "market_name": str(market_name),
-                "close_limit_state": str(close_limit_state),
-                "next_close_sign": str(next_close_sign),
+                "calendar_year": required_int(calendar_year, field="calendar_year"),
+                "market_name": required_str(market_name, field="market_name"),
+                "close_limit_state": required_str(
+                    close_limit_state, field="close_limit_state"
+                ),
+                "next_close_sign": required_str(
+                    next_close_sign, field="next_close_sign"
+                ),
                 **{
                     key: value
                     for key, value in _summarize_signal_group(group_df).items()
@@ -352,11 +357,15 @@ def _build_entry_cohort_df(signal_event_df: pd.DataFrame) -> pd.DataFrame:
         entry_date, calendar_year, market_name, close_limit_state, next_close_sign = group_key
         rows.append(
             {
-                "entry_date": str(entry_date),
-                "calendar_year": int(calendar_year),
-                "market_name": str(market_name),
-                "close_limit_state": str(close_limit_state),
-                "next_close_sign": str(next_close_sign),
+                "entry_date": required_str(entry_date, field="entry_date"),
+                "calendar_year": required_int(calendar_year, field="calendar_year"),
+                "market_name": required_str(market_name, field="market_name"),
+                "close_limit_state": required_str(
+                    close_limit_state, field="close_limit_state"
+                ),
+                "next_close_sign": required_str(
+                    next_close_sign, field="next_close_sign"
+                ),
                 "cohort_event_count": int(len(group_df)),
                 "cohort_unique_code_count": int(group_df["code"].nunique()),
                 "equal_weight_next_close_to_close_3d_return": _mean_or_none(

--- a/apps/bt/src/domains/analytics/topix100_1330_entry_next_1045_exit.py
+++ b/apps/bt/src/domains/analytics/topix100_1330_entry_next_1045_exit.py
@@ -40,6 +40,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
 from src.domains.analytics.topix100_second_bar_volume_drop_performance import (
     _safe_welch_t_test,
 )
+from src.shared.utils.pandas_type_guards import required_int
 
 TOPIX100_1330_ENTRY_NEXT_1045_EXIT_EXPERIMENT_ID = (
     "market-behavior/topix100-1330-entry-next-1045-exit"
@@ -413,8 +414,8 @@ def _assign_rank_groups(
         lambda value: max(
             1,
             min(
-                int(value) // 2,
-                int(math.floor(int(value) * tail_fraction)),
+                required_int(value, field=count_column) // 2,
+                int(math.floor(required_int(value, field=count_column) * tail_fraction)),
             ),
         )
     )

--- a/apps/bt/src/domains/analytics/topix100_1445_entry_daily_sma_filter_portfolio.py
+++ b/apps/bt/src/domains/analytics/topix100_1445_entry_daily_sma_filter_portfolio.py
@@ -40,6 +40,7 @@ from src.domains.analytics.topix_return_standard_deviation_exposure_timing impor
     _build_drawdown_series,
     _compute_return_series_stats,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 TOPIX100_1445_ENTRY_DAILY_SMA_FILTER_PORTFOLIO_EXPERIMENT_ID = (
     "market-behavior/topix100-1445-entry-daily-sma-filter-portfolio"
@@ -432,10 +433,10 @@ def _build_period_portfolio_stats_df(portfolio_daily_df: pd.DataFrame) -> pd.Dat
         ).dropna()
         rows.append(
             {
-                "series_name": str(series_name),
-                "series_label": str(series_label),
-                "period_index": int(period_index),
-                "period_label": str(period_label),
+                "series_name": required_str(series_name, field="series_name"),
+                "series_label": required_str(series_label, field="series_label"),
+                "period_index": required_int(period_index, field="period_index"),
+                "period_label": required_str(period_label, field="period_label"),
                 "period_start_date": _to_scalar_string(period_start_date, fallback=""),
                 "period_end_date": _to_scalar_string(period_end_date, fallback=""),
                 "trading_day_count": int(len(ordered_df)),

--- a/apps/bt/src/domains/analytics/topix100_1445_entry_signal_regime_comparison.py
+++ b/apps/bt/src/domains/analytics/topix100_1445_entry_signal_regime_comparison.py
@@ -50,6 +50,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
     _open_analysis_connection,
     _topix100_stocks_cte,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 TOPIX100_1445_ENTRY_SIGNAL_REGIME_COMPARISON_EXPERIMENT_ID = (
     "market-behavior/topix100-1445-entry-signal-regime-comparison"
@@ -756,8 +757,13 @@ def _assign_rank_groups(
         lambda value: max(
             1,
             min(
-                int(value) // 2,
-                int(math.floor(int(value) * tail_fraction)),
+                required_int(value, field="entry_split_session_count") // 2,
+                int(
+                    math.floor(
+                        required_int(value, field="entry_split_session_count")
+                        * tail_fraction
+                    )
+                ),
             ),
         )
     )
@@ -897,10 +903,12 @@ def _assign_periods_to_signal_sessions(
     date_ts = pd.to_datetime(working_df["date"])
     period_frames: list[pd.DataFrame] = []
     for period in periods_df.itertuples(index=False):
-        period_index = int(cast(Any, period.period_index))
-        period_label = str(cast(Any, period.period_label))
-        period_start_date = str(cast(Any, period.period_start_date))
-        period_end_date = str(cast(Any, period.period_end_date))
+        period_index = required_int(period.period_index, field="period_index")
+        period_label = required_str(period.period_label, field="period_label")
+        period_start_date = required_str(
+            period.period_start_date, field="period_start_date"
+        )
+        period_end_date = required_str(period.period_end_date, field="period_end_date")
         period_mask = (
             date_ts >= pd.Timestamp(period_start_date)
         ) & (date_ts <= pd.Timestamp(period_end_date))
@@ -1021,9 +1029,12 @@ def _assign_signal_buckets(
                 bucket_count=effective_bucket_count,
             )
             scoped_df["signal_bucket_label"] = scoped_df["signal_bucket_index"].map(
-                lambda value: f"Q{int(value)}"
+                lambda value: f"Q{required_int(value, field='signal_bucket_index')}"
             )
-        max_bucket_index = int(pd.Series(scoped_df["signal_bucket_index"]).max())
+        max_bucket_index = required_int(
+            pd.Series(scoped_df["signal_bucket_index"]).max(),
+            field="signal_bucket_index",
+        )
         scoped_df["signal_selected"] = False
         low_mask = scoped_df["target_bucket_side"].astype(str) == "low"
         high_mask = scoped_df["target_bucket_side"].astype(str) == "high"

--- a/apps/bt/src/domains/analytics/topix100_open_close_volume_ratio_conditioning.py
+++ b/apps/bt/src/domains/analytics/topix100_open_close_volume_ratio_conditioning.py
@@ -43,6 +43,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
     _open_analysis_connection,
     _query_resampled_topix100_intraday_bars_from_connection,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 TOPIX100_OPEN_CLOSE_VOLUME_RATIO_CONDITIONING_EXPERIMENT_ID = (
     "market-behavior/topix100-open-close-volume-ratio-conditioning"
@@ -389,10 +390,12 @@ def _assign_periods_to_sessions(
     date_ts = pd.to_datetime(working_df["date"])
     period_frames: list[pd.DataFrame] = []
     for period in periods_df.itertuples(index=False):
-        period_index = int(cast(Any, period.period_index))
-        period_label = str(cast(Any, period.period_label))
-        period_start_date = str(cast(Any, period.period_start_date))
-        period_end_date = str(cast(Any, period.period_end_date))
+        period_index = required_int(period.period_index, field="period_index")
+        period_label = required_str(period.period_label, field="period_label")
+        period_start_date = required_str(
+            period.period_start_date, field="period_start_date"
+        )
+        period_end_date = required_str(period.period_end_date, field="period_end_date")
         period_mask = (
             date_ts >= pd.Timestamp(period_start_date)
         ) & (date_ts <= pd.Timestamp(period_end_date))
@@ -575,7 +578,7 @@ def _assign_ratio_buckets(
             bucket_count=effective_bucket_count,
         )
         scoped_df["ratio_bucket_label"] = scoped_df["ratio_bucket_index"].map(
-            lambda value: f"Q{int(value)}"
+            lambda value: f"Q{required_int(value, field='ratio_bucket_index')}"
         )
         bucketed_frames.append(scoped_df)
 
@@ -653,9 +656,15 @@ def _build_bucket_summary_rows(
 
         ratio_series = bucket_df["comparison_to_reference_volume_ratio"].astype(float)
         row = {
-            "interval_minutes": int(key_map["interval_minutes"]),
-            "ratio_bucket_index": int(key_map["ratio_bucket_index"]),
-            "ratio_bucket_label": str(key_map["ratio_bucket_label"]),
+            "interval_minutes": required_int(
+                key_map["interval_minutes"], field="interval_minutes"
+            ),
+            "ratio_bucket_index": required_int(
+                key_map["ratio_bucket_index"], field="ratio_bucket_index"
+            ),
+            "ratio_bucket_label": required_str(
+                key_map["ratio_bucket_label"], field="ratio_bucket_label"
+            ),
             "sample_count": int(len(bucket_df)),
             "sample_share": float(len(bucket_df) / total_sample_count),
             "stock_count": int(bucket_df["code"].nunique()),
@@ -685,10 +694,18 @@ def _build_bucket_summary_rows(
         if include_period_columns:
             row.update(
                 {
-                    "period_index": int(key_map["period_index"]),
-                    "period_label": str(key_map["period_label"]),
-                    "period_start_date": str(key_map["period_start_date"]),
-                    "period_end_date": str(key_map["period_end_date"]),
+                    "period_index": required_int(
+                        key_map["period_index"], field="period_index"
+                    ),
+                    "period_label": required_str(
+                        key_map["period_label"], field="period_label"
+                    ),
+                    "period_start_date": required_str(
+                        key_map["period_start_date"], field="period_start_date"
+                    ),
+                    "period_end_date": required_str(
+                        key_map["period_end_date"], field="period_end_date"
+                    ),
                 }
             )
         else:

--- a/apps/bt/src/domains/analytics/topix100_peak_winner_loser_intraday_path.py
+++ b/apps/bt/src/domains/analytics/topix100_peak_winner_loser_intraday_path.py
@@ -44,6 +44,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
 from src.domains.analytics.topix100_second_bar_volume_drop_performance import (
     _safe_welch_t_test,
 )
+from src.shared.utils.pandas_type_guards import required_int
 
 TOPIX100_PEAK_WINNER_LOSER_INTRADAY_PATH_EXPERIMENT_ID = (
     "market-behavior/topix100-peak-winner-loser-intraday-path"
@@ -442,7 +443,13 @@ def _assign_rank_groups(
     ranked_df[rank_column] = ranked_df.groupby("date").cumcount() + 1
     ranked_df[count_column] = ranked_df.groupby("date")["code"].transform("size")
     ranked_df["tail_count"] = ranked_df[count_column].map(
-        lambda value: max(1, min(int(value) // 2, int(math.floor(int(value) * tail_fraction))))
+        lambda value: max(
+            1,
+            min(
+                required_int(value, field=count_column) // 2,
+                int(math.floor(required_int(value, field=count_column) * tail_fraction)),
+            ),
+        )
     )
     ranked_df[group_column] = pd.Series(pd.NA, index=ranked_df.index, dtype="string")
     ranked_df.loc[

--- a/apps/bt/src/domains/analytics/topix100_prev_open_vs_open_entry_exit_profit.py
+++ b/apps/bt/src/domains/analytics/topix100_prev_open_vs_open_entry_exit_profit.py
@@ -45,6 +45,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
     _open_analysis_connection,
     _topix100_stocks_cte,
 )
+from src.shared.utils.pandas_type_guards import int_or_none, required_int, required_str
 
 TOPIX100_PREV_OPEN_VS_OPEN_ENTRY_EXIT_PROFIT_EXPERIMENT_ID = (
     "market-behavior/topix100-prev-open-vs-open-entry-exit-profit"
@@ -632,7 +633,11 @@ def _assign_ratio_buckets(
             bucket_count=effective_bucket_count,
         )
         scoped_df["ratio_bucket_label"] = scoped_df["ratio_bucket_index"].map(
-            lambda value: f"Q{int(value)}"
+            lambda value: (
+                f"Q{bucket_index}"
+                if (bucket_index := int_or_none(value)) is not None
+                else None
+            )
         )
         bucketed_frames.append(scoped_df)
 
@@ -796,12 +801,24 @@ def _build_bucket_summary_rows(
             _,
         ) = _summarize_return_series(bucket_df["net_short_return"])
         row = {
-            "interval_minutes": int(key_map["interval_minutes"]),
-            "entry_time": str(key_map["entry_time"]),
-            "exit_label": str(key_map["exit_label"]),
-            "exit_time_target": str(key_map["exit_time_target"]),
-            "ratio_bucket_index": int(key_map["ratio_bucket_index"]),
-            "ratio_bucket_label": str(key_map["ratio_bucket_label"]),
+            "interval_minutes": required_int(
+                key_map["interval_minutes"],
+                field="interval_minutes",
+            ),
+            "entry_time": required_str(key_map["entry_time"], field="entry_time"),
+            "exit_label": required_str(key_map["exit_label"], field="exit_label"),
+            "exit_time_target": required_str(
+                key_map["exit_time_target"],
+                field="exit_time_target",
+            ),
+            "ratio_bucket_index": required_int(
+                key_map["ratio_bucket_index"],
+                field="ratio_bucket_index",
+            ),
+            "ratio_bucket_label": required_str(
+                key_map["ratio_bucket_label"],
+                field="ratio_bucket_label",
+            ),
             "sample_count": int(len(bucket_df)),
             "sample_share": float(len(bucket_df) / total_sample_count),
             "stock_count": int(bucket_df["code"].nunique()),
@@ -824,10 +841,22 @@ def _build_bucket_summary_rows(
         if include_period_columns:
             row.update(
                 {
-                    "period_index": int(key_map["period_index"]),
-                    "period_label": str(key_map["period_label"]),
-                    "period_start_date": str(key_map["period_start_date"]),
-                    "period_end_date": str(key_map["period_end_date"]),
+                    "period_index": required_int(
+                        key_map["period_index"],
+                        field="period_index",
+                    ),
+                    "period_label": required_str(
+                        key_map["period_label"],
+                        field="period_label",
+                    ),
+                    "period_start_date": required_str(
+                        key_map["period_start_date"],
+                        field="period_start_date",
+                    ),
+                    "period_end_date": required_str(
+                        key_map["period_end_date"],
+                        field="period_end_date",
+                    ),
                 }
             )
         else:

--- a/apps/bt/src/domains/analytics/topix100_second_bar_volume_drop_performance.py
+++ b/apps/bt/src/domains/analytics/topix100_second_bar_volume_drop_performance.py
@@ -44,6 +44,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
     _open_analysis_connection,
     _query_resampled_topix100_intraday_bars_from_connection,
 )
+from src.shared.utils.pandas_type_guards import required_int
 
 SECOND_BAR_VOLUME_DROP_PERFORMANCE_EXPERIMENT_ID = (
     "market-behavior/topix100-second-bar-volume-drop-window-performance"
@@ -593,7 +594,7 @@ def _build_ratio_bucket_summary_df(
         .reset_index(drop=True)
     )
     summary_df["ratio_bucket_label"] = summary_df["ratio_bucket_index"].map(
-        lambda value: f"D{int(value)}"
+        lambda value: f"D{required_int(value, field='ratio_bucket_index')}"
     )
     summary_df["sample_share"] = summary_df["sample_count"] / float(total_count)
     summary_df.insert(0, "interval_minutes", interval_minutes)

--- a/apps/bt/src/domains/analytics/topix100_sma_ratio_rank_future_close_lightgbm.py
+++ b/apps/bt/src/domains/analytics/topix100_sma_ratio_rank_future_close_lightgbm.py
@@ -53,6 +53,7 @@ from src.domains.backtest.core.walkforward import (
     WalkForwardSplit,
     generate_walkforward_splits,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 LIGHTGBM_RESEARCH_INSTALL_HINT = (
     "uv sync --project apps/bt --group research"
@@ -937,9 +938,11 @@ def _build_train_only_composite_candidates(
             kind="stable",
         )
         selected_records.append(
-            horizon_candidates_df.iloc[0]
-            .drop(labels=["_train_spread", "_pairwise_p", "_global_p"])
-            .to_dict()
+            record_with_str_keys(
+                horizon_candidates_df.iloc[0]
+                .drop(labels=["_train_spread", "_pairwise_p", "_global_p"])
+                .to_dict()
+            )
         )
 
     composite_candidate_df = pd.DataFrame.from_records(candidate_records)

--- a/apps/bt/src/domains/analytics/topix100_streak_353_next_session_intraday_lightgbm_walkforward.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_next_session_intraday_lightgbm_walkforward.py
@@ -62,6 +62,7 @@ from src.domains.analytics.topix_close_return_streaks import (
 )
 from src.domains.analytics.topix_close_stock_overnight_distribution import SourceMode
 from src.domains.backtest.core.walkforward import generate_walkforward_splits
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 DEFAULT_WALKFORWARD_TRAIN_WINDOW = 756
 DEFAULT_WALKFORWARD_TEST_WINDOW = 126
@@ -577,8 +578,8 @@ def _build_portfolio_stats_df(walkforward_topk_daily_df: pd.DataFrame) -> pd.Dat
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_portfolio_performance_stats(series),
@@ -603,8 +604,8 @@ def _build_daily_return_distribution_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_daily_return_distribution_stats(series),

--- a/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_close_10d_lightgbm_walkforward.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_close_10d_lightgbm_walkforward.py
@@ -76,6 +76,7 @@ from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
 from src.domains.backtest.core.walkforward import generate_walkforward_splits
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 DEFAULT_WALKFORWARD_TRAIN_WINDOW = 756
 DEFAULT_WALKFORWARD_TEST_WINDOW = 126
@@ -999,8 +1000,8 @@ def _build_portfolio_stats_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_portfolio_performance_stats(series),
@@ -1025,8 +1026,8 @@ def _build_daily_return_distribution_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_daily_return_distribution_stats(series),

--- a/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_close_5d_excess_vs_topix_lightgbm_walkforward.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_close_5d_excess_vs_topix_lightgbm_walkforward.py
@@ -76,6 +76,7 @@ from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
 from src.domains.backtest.core.walkforward import generate_walkforward_splits
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 DEFAULT_WALKFORWARD_TRAIN_WINDOW = 756
 DEFAULT_WALKFORWARD_TEST_WINDOW = 126
@@ -1031,8 +1032,8 @@ def _build_portfolio_stats_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_portfolio_performance_stats(series),
@@ -1057,8 +1058,8 @@ def _build_daily_return_distribution_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_daily_return_distribution_stats(series),

--- a/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_close_5d_lightgbm_walkforward.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_close_5d_lightgbm_walkforward.py
@@ -76,6 +76,7 @@ from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
 from src.domains.backtest.core.walkforward import generate_walkforward_splits
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 DEFAULT_WALKFORWARD_TRAIN_WINDOW = 756
 DEFAULT_WALKFORWARD_TEST_WINDOW = 126
@@ -999,8 +1000,8 @@ def _build_portfolio_stats_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_portfolio_performance_stats(series),
@@ -1025,8 +1026,8 @@ def _build_daily_return_distribution_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_daily_return_distribution_stats(series),

--- a/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_open_5d_lightgbm_walkforward.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_next_session_open_to_open_5d_lightgbm_walkforward.py
@@ -76,6 +76,7 @@ from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
 from src.domains.backtest.core.walkforward import generate_walkforward_splits
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 DEFAULT_WALKFORWARD_TRAIN_WINDOW = 756
 DEFAULT_WALKFORWARD_TEST_WINDOW = 126
@@ -999,8 +1000,8 @@ def _build_portfolio_stats_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_portfolio_performance_stats(series),
@@ -1025,8 +1026,8 @@ def _build_daily_return_distribution_df(
         for series_name, series_label, series in _iter_daily_return_series(ordered_df):
             records.append(
                 {
-                    "model_name": str(model_name),
-                    "top_k": int(top_k),
+                    "model_name": required_str(model_name, field="model_name"),
+                    "top_k": required_int(top_k, field="top_k"),
                     "series_name": series_name,
                     "series_label": series_label,
                     **_compute_daily_return_distribution_stats(series),

--- a/apps/bt/src/domains/analytics/topix100_streak_353_signal_score_lightgbm.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_signal_score_lightgbm.py
@@ -78,6 +78,7 @@ from src.domains.analytics.topix_streak_extreme_mode import (
     _format_int_sequence,
     _format_return,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 LIGHTGBM_RESEARCH_INSTALL_HINT = "uv sync --project apps/bt --group research"
 LIGHTGBM_LIBOMP_INSTALL_HINT = "brew install libomp"
@@ -1676,8 +1677,8 @@ def _build_validation_model_comparison_df(
         lightgbm = lightgbm_row.iloc[0]
         records.append(
             {
-                "side": side,
-                "top_k": int(top_k),
+                "side": required_str(side, field="side"),
+                "top_k": required_int(top_k, field="top_k"),
                 "baseline_avg_selected_edge": float(baseline["avg_selected_edge"]),
                 "lightgbm_avg_selected_edge": float(lightgbm["avg_selected_edge"]),
                 "edge_lift_vs_baseline": float(lightgbm["avg_selected_edge"])

--- a/apps/bt/src/domains/analytics/topix100_streak_353_transfer.py
+++ b/apps/bt/src/domains/analytics/topix100_streak_353_transfer.py
@@ -927,9 +927,37 @@ def _iter_split_frames(
     return split_frames
 
 
+def _build_published_summary_payload(
+    result: Topix100Streak353TransferResearchResult,
+) -> dict[str, Any]:
+    validation_date_summary = result.state_date_summary_df[
+        result.state_date_summary_df["sample_split"] == "validation"
+    ].copy()
+    result_bullets: list[str] = []
+    if not validation_date_summary.empty:
+        result_bullets.append(
+            "Fixed transfer test applies the TOPIX 3/53 state model to TOPIX100 constituents."
+        )
+    return {
+        "title": "TOPIX100 Streak 3/53 Transfer Study",
+        "analysisStartDate": result.analysis_start_date,
+        "analysisEndDate": result.analysis_end_date,
+        "resultBullets": result_bullets,
+        "selectedParameters": [
+            {"label": "Short window", "value": f"{result.short_window_streaks} streaks"},
+            {"label": "Long window", "value": f"{result.long_window_streaks} streaks"},
+            {
+                "label": "Future horizons",
+                "value": f"{_format_int_sequence(result.future_horizons)} trading days",
+            },
+        ],
+    }
+
+
 def _build_research_bundle_summary_markdown(
     result: Topix100Streak353TransferResearchResult,
 ) -> str:
+    published_summary = _build_published_summary_payload(result)
     validation_date_summary = result.state_date_summary_df[
         result.state_date_summary_df["sample_split"] == "validation"
     ].copy()
@@ -938,7 +966,7 @@ def _build_research_bundle_summary_markdown(
     ].copy()
 
     lines = [
-        "# TOPIX100 Streak 3/53 Transfer Study",
+        f"# {published_summary['title']}",
         "",
         "This study applies the fixed streak pair discovered on TOPIX itself (3 / 53) to each TOPIX100 constituent's own price series, then asks whether the same four-state hierarchy survives at the stock level.",
         "",

--- a/apps/bt/src/domains/analytics/topix100_symbol_intraday_habit.py
+++ b/apps/bt/src/domains/analytics/topix100_symbol_intraday_habit.py
@@ -45,6 +45,7 @@ from src.domains.analytics.topix100_open_relative_intraday_path import (
     _query_resampled_topix100_intraday_bars_from_connection,
     _topix100_stocks_cte,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 TOPIX100_SYMBOL_INTRADAY_HABIT_EXPERIMENT_ID = (
     "market-behavior/topix100-symbol-intraday-habit"
@@ -351,10 +352,12 @@ def _assign_periods_to_bars(
     date_ts = pd.to_datetime(working_df["date"])
     period_frames: list[pd.DataFrame] = []
     for period in periods_df.itertuples(index=False):
-        period_index = int(cast(Any, period.period_index))
-        period_label = str(cast(Any, period.period_label))
-        period_start_date = str(cast(Any, period.period_start_date))
-        period_end_date = str(cast(Any, period.period_end_date))
+        period_index = required_int(period.period_index, field="period_index")
+        period_label = required_str(period.period_label, field="period_label")
+        period_start_date = required_str(
+            period.period_start_date, field="period_start_date"
+        )
+        period_end_date = required_str(period.period_end_date, field="period_end_date")
         period_start_ts = pd.Timestamp(period_start_date)
         period_end_ts = pd.Timestamp(period_end_date)
         period_mask = (date_ts >= period_start_ts) & (date_ts <= period_end_ts)
@@ -483,12 +486,14 @@ def _build_period_symbol_summary_df(
         rows.append(
             {
                 "interval_minutes": interval_minutes,
-                "period_index": int(group_key[0]),
-                "period_label": str(group_key[1]),
-                "period_start_date": str(group_key[2]),
-                "period_end_date": str(group_key[3]),
-                "code": str(group_key[4]),
-                "company_name": str(group_key[5]),
+                "period_index": required_int(group_key[0], field="period_index"),
+                "period_label": required_str(group_key[1], field="period_label"),
+                "period_start_date": required_str(
+                    group_key[2], field="period_start_date"
+                ),
+                "period_end_date": required_str(group_key[3], field="period_end_date"),
+                "code": required_str(group_key[4], field="code"),
+                "company_name": required_str(group_key[5], field="company_name"),
                 "session_count": int(group_df["session_count"].max()),
                 "bar_count": int(group_df["sample_count"].sum()),
                 "lowest_mean_bucket_time": str(lowest_row["bucket_time"]),
@@ -543,10 +548,10 @@ def _build_habit_summary_df(
         rows.append(
             {
                 "interval_minutes": interval_minutes,
-                "code": str(group_key[0]),
-                "company_name": str(group_key[1]),
-                "bucket_minute": int(group_key[2]),
-                "bucket_time": str(group_key[3]),
+                "code": required_str(group_key[0], field="code"),
+                "company_name": required_str(group_key[1], field="company_name"),
+                "bucket_minute": required_int(group_key[2], field="bucket_minute"),
+                "bucket_time": required_str(group_key[3], field="bucket_time"),
                 "period_count": period_count,
                 "positive_periods": positive_periods,
                 "negative_periods": negative_periods,
@@ -903,10 +908,10 @@ def _build_axes_grid(axes: Any, row_count: int, column_count: int) -> list[list[
 
 def _coerce_period_tuple(period: Any) -> tuple[int, str, str, str]:
     return (
-        int(cast(Any, period.period_index)),
-        str(cast(Any, period.period_label)),
-        str(cast(Any, period.period_start_date)),
-        str(cast(Any, period.period_end_date)),
+        required_int(period.period_index, field="period_index"),
+        required_str(period.period_label, field="period_label"),
+        required_str(period.period_start_date, field="period_start_date"),
+        required_str(period.period_end_date, field="period_end_date"),
     )
 
 

--- a/apps/bt/src/domains/analytics/topix100_top1_open_to_open_5d_duplicate_policy_analysis.py
+++ b/apps/bt/src/domains/analytics/topix100_top1_open_to_open_5d_duplicate_policy_analysis.py
@@ -74,6 +74,7 @@ from src.domains.analytics.topix_downside_return_standard_deviation_shock_confir
 from src.domains.analytics.topix_downside_return_standard_deviation_exposure_timing import (
     _normalize_non_negative_float_sequence,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 DuplicatePolicy = Literal["allow_stack", "skip_if_held", "next_unique_within_top5"]
 DEFAULT_DUPLICATE_POLICIES: tuple[DuplicatePolicy, ...] = (
@@ -606,7 +607,7 @@ def _build_selected_trade_df_for_policy(
             "selected_realized_return": None,
         }
         if chosen_row is not None:
-            chosen_payload = chosen_row.to_dict()
+            chosen_payload = record_with_str_keys(chosen_row.to_dict())
             selected_rows.append(chosen_payload)
             active_trades.append(
                 {

--- a/apps/bt/src/domains/analytics/topix100_vi_change_regime_conditioning.py
+++ b/apps/bt/src/domains/analytics/topix100_vi_change_regime_conditioning.py
@@ -58,6 +58,7 @@ from src.domains.analytics.topix_regime_conditioning_core import (
     _summarize_regime_daily_means as _core_summarize_regime_daily_means,
     _summarize_regime_group_daily_means as _core_summarize_regime_group_daily_means,
 )
+from src.shared.utils.pandas_type_guards import finite_float_or_none, is_missing_scalar
 
 HorizonKey = Literal["t_plus_1", "t_plus_5", "t_plus_10"]
 MetricKey = Literal["future_close", "future_return"]
@@ -286,16 +287,16 @@ def _build_regime_market_df(
         sigma_threshold_2=sigma_threshold_2,
     )
     ordered["regime_bucket_key"] = ordered["vi_change"].map(
-        lambda value: _bucket_vi_change(value, stats=vi_change_stats)
+        lambda value: _bucket_vi_change(finite_float_or_none(value), stats=vi_change_stats)
     )
     ordered["regime_bucket_label"] = ordered["regime_bucket_key"].map(
         lambda value: (
             format_nt_ratio_bucket_label(
-                value,
+                _required_vi_bucket_key(value),
                 sigma_threshold_1=vi_change_stats.sigma_threshold_1,
                 sigma_threshold_2=vi_change_stats.sigma_threshold_2,
             )
-            if value is not None and vi_change_stats is not None
+            if not is_missing_scalar(value) and vi_change_stats is not None
             else None
         )
     )
@@ -305,6 +306,20 @@ def _build_regime_market_df(
     if end_date:
         ordered = ordered.loc[ordered["date"] <= end_date].copy()
     return _sort_frame(ordered), vi_change_stats
+
+
+def _required_vi_bucket_key(value: object) -> NtRatioBucketKey:
+    if value == "return_le_mean_minus_2sd":
+        return "return_le_mean_minus_2sd"
+    if value == "return_mean_minus_2sd_to_minus_1sd":
+        return "return_mean_minus_2sd_to_minus_1sd"
+    if value == "return_mean_minus_1sd_to_plus_1sd":
+        return "return_mean_minus_1sd_to_plus_1sd"
+    if value == "return_mean_plus_1sd_to_plus_2sd":
+        return "return_mean_plus_1sd_to_plus_2sd"
+    if value == "return_ge_mean_plus_2sd":
+        return "return_ge_mean_plus_2sd"
+    raise ValueError(f"unknown VI bucket key: {value!r}")
 
 
 def _build_regime_assignments_df(regime_market_df: pd.DataFrame) -> pd.DataFrame:

--- a/apps/bt/src/domains/analytics/topix_close_return_streaks.py
+++ b/apps/bt/src/domains/analytics/topix_close_return_streaks.py
@@ -35,6 +35,7 @@ from src.domains.analytics.topix_close_stock_overnight_distribution import (
     _fetch_date_range,
     _open_analysis_connection,
 )
+from src.shared.utils.pandas_type_guards import required_int, required_str
 
 ModeKey = Literal["bullish", "bearish", "flat"]
 
@@ -428,14 +429,26 @@ def _build_streak_tables(
     anchor_rows = start_rows - 1
     grouped["synthetic_open"] = close[anchor_rows]
     grouped["synthetic_close"] = close[end_rows]
-    grouped["synthetic_high"] = [
-        max(close[anchor_row], float(high[start_row : end_row + 1].max()))
-        for anchor_row, start_row, end_row in zip(anchor_rows, start_rows, end_rows, strict=True)
-    ]
-    grouped["synthetic_low"] = [
-        min(close[anchor_row], float(low[start_row : end_row + 1].min()))
-        for anchor_row, start_row, end_row in zip(anchor_rows, start_rows, end_rows, strict=True)
-    ]
+    grouped["synthetic_high"] = pd.Series(
+        [
+            max(float(close[anchor_row]), float(high[start_row : end_row + 1].max()))
+            for anchor_row, start_row, end_row in zip(
+                anchor_rows, start_rows, end_rows, strict=True
+            )
+        ],
+        index=grouped.index,
+        dtype="float64",
+    )
+    grouped["synthetic_low"] = pd.Series(
+        [
+            min(float(close[anchor_row]), float(low[start_row : end_row + 1].min()))
+            for anchor_row, start_row, end_row in zip(
+                anchor_rows, start_rows, end_rows, strict=True
+            )
+        ],
+        index=grouped.index,
+        dtype="float64",
+    )
     grouped["segment_return"] = grouped["synthetic_close"] / grouped["synthetic_open"] - 1.0
     grouped["is_complete"] = end_rows < (len(full_df) - 1)
     grouped["segment_sample_split"] = end_splits[end_rows]
@@ -542,9 +555,13 @@ def _build_streak_state_summary_df(
                 summary_rows.append(
                     {
                         "sample_split": split_name,
-                        "mode": str(mode),
-                        "streak_day_bucket": int(streak_day_bucket),
-                        "streak_day_label": str(streak_day_label),
+                        "mode": required_str(mode, field="mode"),
+                        "streak_day_bucket": required_int(
+                            streak_day_bucket, field="streak_day_bucket"
+                        ),
+                        "streak_day_label": required_str(
+                            streak_day_label, field="streak_day_label"
+                        ),
                         "sample_count": int(len(group_df)),
                         "horizon_days": int(horizon),
                         "mean_close_return": float(group_df["close_return"].mean()),
@@ -683,9 +700,13 @@ def _build_segment_end_summary_df(
                 summary_rows.append(
                     {
                         "sample_split": split_name,
-                        "mode": str(mode),
-                        "segment_length_bucket": int(length_bucket),
-                        "segment_length_label": str(length_label),
+                        "mode": required_str(mode, field="mode"),
+                        "segment_length_bucket": required_int(
+                            length_bucket, field="segment_length_bucket"
+                        ),
+                        "segment_length_label": required_str(
+                            length_label, field="segment_length_label"
+                        ),
                         "horizon_days": int(horizon),
                         "sample_count": int(len(group_df)),
                         "mean_segment_return": float(group_df["segment_return"].mean()),

--- a/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_exposure_timing.py
+++ b/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_exposure_timing.py
@@ -42,6 +42,7 @@ from src.domains.analytics.topix_close_stock_overnight_distribution import (
     _fetch_date_range,
     _open_analysis_connection,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 ANNUALIZATION_FACTOR = 252.0
 DEFAULT_DOWNSIDE_RETURN_STANDARD_DEVIATION_WINDOW_DAYS: tuple[int, ...] = (5, 10, 20, 40)
@@ -753,7 +754,7 @@ def _build_selection_summary_df(
         )
         if selected_row is None:
             continue
-        payload = selected_row.to_dict()
+        payload = record_with_str_keys(selected_row.to_dict())
         payload["selection_label"] = selection_label
         rows.append(payload)
     return pd.DataFrame(rows)

--- a/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_shock_confirmation_committee_overlay.py
+++ b/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_shock_confirmation_committee_overlay.py
@@ -78,6 +78,7 @@ from src.domains.analytics.topix_downside_return_standard_deviation_shock_confir
 from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
+from src.shared.utils.pandas_type_guards import required_int
 
 DEFAULT_DOWNSIDE_RETURN_STANDARD_DEVIATION_WINDOW_DAYS = 5
 DEFAULT_COMMITTEE_MEAN_WINDOW_DAYS: tuple[int, ...] = (1, 2)
@@ -1093,7 +1094,11 @@ def _build_committee_daily_df(
     committee_daily_df["rebalanced"] = committee_daily_df["exposure_change"].abs().gt(1e-12)
     committee_daily_df["strategy_return"] = strategy_return_panel.mean(axis=1)
     committee_daily_df["signal_state"] = committee_daily_df["member_reduced_count"].map(
-        lambda value: "all_full" if int(value) == 0 else "committee_reduced"
+        lambda value: (
+            "all_full"
+            if required_int(value, field="member_reduced_count") == 0
+            else "committee_reduced"
+        )
     )
     committee_daily_df["strategy_equity_curve"] = (
         1.0 + committee_daily_df["strategy_return"].astype(float)

--- a/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_shock_confirmation_vote_overlay.py
+++ b/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_shock_confirmation_vote_overlay.py
@@ -73,6 +73,7 @@ from src.domains.analytics.topix_downside_return_standard_deviation_trend_breadt
     _lookup_split_row,
     _normalize_rule_sequence,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
@@ -1290,7 +1291,7 @@ def _build_selection_summary_df(
         )
         if selected_row is None:
             continue
-        payload = selected_row.to_dict()
+        payload = record_with_str_keys(selected_row.to_dict())
         payload["selection_label"] = selection_label
         rows.append(payload)
     return pd.DataFrame(rows)

--- a/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_trend_breadth_overlay.py
+++ b/apps/bt/src/domains/analytics/topix_downside_return_standard_deviation_trend_breadth_overlay.py
@@ -66,6 +66,7 @@ from src.domains.analytics.topix_downside_return_standard_deviation_exposure_tim
 from src.domains.analytics.topix_rank_future_close_core import (
     _query_topix100_stock_history,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 DEFAULT_DOWNSIDE_RETURN_STANDARD_DEVIATION_WINDOW_DAYS: tuple[int, ...] = (5,)
 DEFAULT_DOWNSIDE_RETURN_STANDARD_DEVIATION_MEAN_WINDOW_DAYS: tuple[int, ...] = (1, 2)
@@ -1328,7 +1329,7 @@ def _build_selection_summary_df(
         )
         if selected_row is None:
             continue
-        payload = selected_row.to_dict()
+        payload = record_with_str_keys(selected_row.to_dict())
         payload["selection_label"] = selection_label
         rows.append(payload)
     return pd.DataFrame(rows)

--- a/apps/bt/src/domains/analytics/topix_rank_future_close_core.py
+++ b/apps/bt/src/domains/analytics/topix_rank_future_close_core.py
@@ -20,6 +20,7 @@ from src.domains.analytics.topix_close_stock_overnight_distribution import (
     _normalize_code_sql,
 )
 from src.shared.utils.market_code_alias import expand_market_codes
+from src.shared.utils.pandas_type_guards import ensure_str_key, str_or_none
 
 DecileKey = Literal[
     "Q1",
@@ -406,9 +407,13 @@ def _ranking_feature_label_lookup(df: pd.DataFrame) -> dict[str, str]:
             feature: feature
             for feature in scoped_df["ranking_feature"].astype(str).unique().tolist()
         }
-    return (
+    labels: dict[str, str] = {}
+    for feature_key, label_value in (
         scoped_df.groupby("ranking_feature")["ranking_feature_label"].first().to_dict()
-    )
+    ).items():
+        feature = ensure_str_key(feature_key, field="ranking_feature")
+        labels[feature] = str_or_none(label_value) or feature
+    return labels
 
 
 def _assign_feature_deciles(

--- a/apps/bt/src/domains/analytics/topix_regime_conditioning_core.py
+++ b/apps/bt/src/domains/analytics/topix_regime_conditioning_core.py
@@ -33,6 +33,7 @@ from src.domains.analytics.topix_rank_future_close_core import (
     _safe_paired_t_test,
     _safe_wilcoxon,
 )
+from src.shared.utils.pandas_type_guards import finite_float_or_none
 
 HorizonKey = Literal["t_plus_1", "t_plus_5", "t_plus_10"]
 MetricKey = Literal["future_close", "future_return"]
@@ -346,6 +347,34 @@ def _bucket_nt_ratio_return(
     return "return_ge_mean_plus_2sd"
 
 
+def _normalize_close_bucket_key(value: object) -> CloseBucketKey | None:
+    if value == "close_le_negative_threshold_2":
+        return "close_le_negative_threshold_2"
+    if value == "close_negative_threshold_2_to_1":
+        return "close_negative_threshold_2_to_1"
+    if value == "close_negative_threshold_1_to_threshold_1":
+        return "close_negative_threshold_1_to_threshold_1"
+    if value == "close_threshold_1_to_2":
+        return "close_threshold_1_to_2"
+    if value == "close_ge_threshold_2":
+        return "close_ge_threshold_2"
+    return None
+
+
+def _normalize_nt_ratio_bucket_key(value: object) -> NtRatioBucketKey | None:
+    if value == "return_le_mean_minus_2sd":
+        return "return_le_mean_minus_2sd"
+    if value == "return_mean_minus_2sd_to_minus_1sd":
+        return "return_mean_minus_2sd_to_minus_1sd"
+    if value == "return_mean_minus_1sd_to_plus_1sd":
+        return "return_mean_minus_1sd_to_plus_1sd"
+    if value == "return_mean_plus_1sd_to_plus_2sd":
+        return "return_mean_plus_1sd_to_plus_2sd"
+    if value == "return_ge_mean_plus_2sd":
+        return "return_ge_mean_plus_2sd"
+    return None
+
+
 def _build_regime_market_df(
     market_df: pd.DataFrame,
     *,
@@ -375,30 +404,38 @@ def _build_regime_market_df(
     )
 
     ordered["topix_close_bucket_key"] = ordered["topix_close_return"].map(
-        lambda value: _bucket_topix_close_return(value, stats=topix_stats)
+        lambda value: _bucket_topix_close_return(
+            finite_float_or_none(value),
+            stats=topix_stats,
+        )
     )
     ordered["topix_close_bucket_label"] = ordered["topix_close_bucket_key"].map(
         lambda value: (
             format_close_bucket_label(
-                value,
+                close_bucket_key,
                 close_threshold_1=topix_stats.threshold_1,
                 close_threshold_2=topix_stats.threshold_2,
             )
-            if value is not None and topix_stats is not None
+            if (close_bucket_key := _normalize_close_bucket_key(value)) is not None
+            and topix_stats is not None
             else None
         )
     )
     ordered["nt_ratio_bucket_key"] = ordered["nt_ratio_return"].map(
-        lambda value: _bucket_nt_ratio_return(value, stats=nt_ratio_stats)
+        lambda value: _bucket_nt_ratio_return(
+            finite_float_or_none(value),
+            stats=nt_ratio_stats,
+        )
     )
     ordered["nt_ratio_bucket_label"] = ordered["nt_ratio_bucket_key"].map(
         lambda value: (
             format_nt_ratio_bucket_label(
-                value,
+                nt_ratio_bucket_key,
                 sigma_threshold_1=nt_ratio_stats.sigma_threshold_1,
                 sigma_threshold_2=nt_ratio_stats.sigma_threshold_2,
             )
-            if value is not None and nt_ratio_stats is not None
+            if (nt_ratio_bucket_key := _normalize_nt_ratio_bucket_key(value)) is not None
+            and nt_ratio_stats is not None
             else None
         )
     )

--- a/apps/bt/src/domains/analytics/topix_return_standard_deviation_exposure_timing.py
+++ b/apps/bt/src/domains/analytics/topix_return_standard_deviation_exposure_timing.py
@@ -42,6 +42,7 @@ from src.domains.analytics.topix_close_stock_overnight_distribution import (
     _fetch_date_range,
     _open_analysis_connection,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 ANNUALIZATION_FACTOR = 252.0
 DEFAULT_RETURN_STANDARD_DEVIATION_WINDOW_DAYS: tuple[int, ...] = (5, 10, 20, 40)
@@ -753,7 +754,7 @@ def _build_selection_summary_df(
         )
         if selected_row is None:
             continue
-        payload = selected_row.to_dict()
+        payload = record_with_str_keys(selected_row.to_dict())
         payload["selection_label"] = selection_label
         rows.append(payload)
     return pd.DataFrame(rows)

--- a/apps/bt/src/domains/analytics/topix_sma_ratio_rank_future_close_selection.py
+++ b/apps/bt/src/domains/analytics/topix_sma_ratio_rank_future_close_selection.py
@@ -40,6 +40,7 @@ from src.domains.analytics.topix_sma_ratio_rank_future_close_support import (
     DecileKey,
     _sort_frame,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 
 def _oriented_rank_score(
@@ -532,9 +533,11 @@ def _build_composite_candidates(
             ascending=[False, True, True],
         )
         selected_records.append(
-            horizon_candidates_df.iloc[0]
-            .drop(labels=["_robustness_score", "_validation_p", "_validation_global_p"])
-            .to_dict()
+            record_with_str_keys(
+                horizon_candidates_df.iloc[0]
+                .drop(labels=["_robustness_score", "_validation_p", "_validation_global_p"])
+                .to_dict()
+            )
         )
 
     selected_composite_df = _sort_frame(pd.DataFrame.from_records(selected_records))

--- a/apps/bt/src/domains/analytics/topix_streak_multi_timeframe_mode.py
+++ b/apps/bt/src/domains/analytics/topix_streak_multi_timeframe_mode.py
@@ -39,6 +39,7 @@ from src.domains.analytics.topix_streak_extreme_mode import (
     _format_return,
     run_topix_streak_extreme_mode_research,
 )
+from src.shared.utils.pandas_type_guards import record_with_str_keys
 
 DEFAULT_SHORT_WINDOW_MAX = 10
 DEFAULT_LONG_WINDOW_MIN = 20
@@ -916,6 +917,28 @@ def _build_pair_horizon_rank_df(
     return pd.concat(rank_frames, ignore_index=True)
 
 
+def _select_state_row(
+    state_summary_df: pd.DataFrame,
+    *,
+    largest: bool,
+    horizons: tuple[int, ...],
+) -> dict[str, Any] | None:
+    if state_summary_df.empty:
+        return None
+    filtered_df = state_summary_df[
+        (state_summary_df["sample_split"] == "validation")
+        & (state_summary_df["horizon_days"].isin(horizons))
+    ].copy()
+    if filtered_df.empty:
+        return None
+    sorted_df = filtered_df.sort_values(
+        ["mean_future_return", "state_key"],
+        ascending=[not largest, True],
+        kind="stable",
+    )
+    return record_with_str_keys(sorted_df.iloc[0].to_dict())
+
+
 def _build_multi_timeframe_state_key(*, long_mode: str, short_mode: str) -> str:
     return f"long_{long_mode}__short_{short_mode}"
 
@@ -926,9 +949,53 @@ def _format_multi_timeframe_state_label(state_key: str) -> str:
     ).title()
 
 
+def _build_published_summary_payload(
+    result: TopixStreakMultiTimeframeModeResearchResult,
+) -> dict[str, Any]:
+    validation_forward = result.selected_pair_state_summary_df[
+        result.selected_pair_state_summary_df["sample_split"] == "validation"
+    ].copy()
+    result_bullets: list[str] = []
+    best_state = _select_state_row(
+        result.selected_pair_state_summary_df,
+        largest=True,
+        horizons=tuple(result.stability_horizons),
+    )
+    if best_state is not None:
+        result_bullets.append(
+            "Validation best forward-return state is "
+            f"{best_state.get('state_label', best_state.get('state_key', 'n/a'))}."
+        )
+    elif not validation_forward.empty:
+        result_bullets.append(
+            "Validation forward-return ordering is available for the selected streak pair."
+        )
+    return {
+        "title": "TOPIX Streak Multi-Timeframe Mode",
+        "analysisStartDate": result.analysis_start_date,
+        "analysisEndDate": result.analysis_end_date,
+        "resultBullets": result_bullets,
+        "selectedParameters": [
+            {
+                "label": "Short window",
+                "value": f"{result.selected_short_window_streaks} streaks",
+            },
+            {
+                "label": "Long window",
+                "value": f"{result.selected_long_window_streaks} streaks",
+            },
+            {
+                "label": "Stability horizons",
+                "value": f"{_format_int_sequence(result.stability_horizons)} trading days",
+            },
+        ],
+    }
+
+
 def _build_research_bundle_summary_markdown(
     result: TopixStreakMultiTimeframeModeResearchResult,
 ) -> str:
+    published_summary = _build_published_summary_payload(result)
     top_pairs = result.pair_score_df.head(5).copy()
     validation_segments = result.selected_pair_state_segment_summary_df[
         result.selected_pair_state_segment_summary_df["sample_split"] == "validation"
@@ -938,7 +1005,7 @@ def _build_research_bundle_summary_markdown(
     ].copy()
 
     lines = [
-        "# TOPIX Streak Multi-Timeframe Mode",
+        f"# {published_summary['title']}",
         "",
         "This study scans short and long streak-candle windows simultaneously, then evaluates which 4-state combination remains most stable across validation horizons.",
         "",

--- a/apps/bt/src/domains/analytics/value_breakout_overheat_filter.py
+++ b/apps/bt/src/domains/analytics/value_breakout_overheat_filter.py
@@ -27,6 +27,7 @@ from src.domains.analytics.research_bundle import (
     write_dataclass_research_bundle,
 )
 from src.domains.strategy.indicators import compute_risk_adjusted_return, compute_rsi
+from src.shared.utils.pandas_type_guards import required_str
 
 VALUE_BREAKOUT_OVERHEAT_FILTER_EXPERIMENT_ID = "market-behavior/value-breakout-overheat-filter"
 DEFAULT_MARKET_SCOPE = "standard"
@@ -539,7 +540,10 @@ def _overlap_count(
     for feature_name in rule.feature_names:
         feature_values = pd.to_numeric(frame[feature_name], errors="coerce")
         feature_thresholds = frame["market_scope"].astype(str).map(
-            lambda scope: thresholds.get((scope, feature_name), np.nan)
+            lambda scope: thresholds.get(
+                (required_str(scope, field="market_scope"), feature_name),
+                np.nan,
+            )
         )
         count += (feature_values >= feature_thresholds).fillna(False).astype(int)
     return count

--- a/apps/bt/src/shared/utils/pandas_type_guards.py
+++ b/apps/bt/src/shared/utils/pandas_type_guards.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Hashable, Iterable, Mapping
+from typing import Any, SupportsFloat, SupportsIndex, SupportsInt
+
+import numpy as np
+import pandas as pd
+
+
+def is_missing_scalar(value: object) -> bool:
+    """Return True when a scalar-like pandas value is missing.
+
+    `pd.isna` can also return arrays for array-like inputs. These helpers are
+    for row/group scalar extraction, so array-like results are treated as
+    present and should be handled by the caller.
+    """
+
+    if value is None or value is pd.NA or value is pd.NaT:
+        return True
+    if isinstance(value, float):
+        return math.isnan(value)
+    if isinstance(value, np.floating):
+        return bool(np.isnan(value))
+    return False
+
+
+def str_or_none(value: object) -> str | None:
+    if is_missing_scalar(value):
+        return None
+    return str(value)
+
+
+def required_str(value: object, *, field: str) -> str:
+    normalized = str_or_none(value)
+    if normalized is None:
+        raise ValueError(f"missing pandas scalar: {field}")
+    return normalized
+
+
+def int_or_none(value: object) -> int | None:
+    if is_missing_scalar(value):
+        return None
+    if isinstance(value, str | bytes | bytearray | SupportsInt | SupportsIndex):
+        return int(value)
+    if isinstance(value, SupportsFloat):
+        return int(float(value))
+    raise TypeError(f"cannot normalize pandas scalar to int: {type(value).__name__}")
+
+
+def required_int(value: object, *, field: str) -> int:
+    normalized = int_or_none(value)
+    if normalized is None:
+        raise ValueError(f"missing pandas scalar: {field}")
+    return normalized
+
+
+def float_or_none(value: object) -> float | None:
+    if is_missing_scalar(value):
+        return None
+    if isinstance(value, str | bytes | bytearray | SupportsFloat | SupportsIndex):
+        return float(value)
+    if isinstance(value, SupportsInt):
+        return float(int(value))
+    raise TypeError(f"cannot normalize pandas scalar to float: {type(value).__name__}")
+
+
+def finite_float_or_none(value: object) -> float | None:
+    normalized = float_or_none(value)
+    if normalized is None or not math.isfinite(normalized):
+        return None
+    return normalized
+
+
+def required_float(value: object, *, field: str) -> float:
+    normalized = float_or_none(value)
+    if normalized is None:
+        raise ValueError(f"missing pandas scalar: {field}")
+    return normalized
+
+
+def ensure_str_key(key: Hashable, *, field: str = "pandas key") -> str:
+    if is_missing_scalar(key):
+        raise ValueError(f"missing pandas key: {field}")
+    return str(key)
+
+
+def record_with_str_keys(record: Mapping[Hashable, Any]) -> dict[str, Any]:
+    return {ensure_str_key(key): value for key, value in record.items()}
+
+
+def records_with_str_keys(records: Iterable[Mapping[Hashable, Any]]) -> list[dict[str, Any]]:
+    return [record_with_str_keys(record) for record in records]
+
+
+def numeric_series_or_empty(values: Iterable[Any] | None) -> pd.Series:
+    if values is None:
+        return pd.Series(dtype="float64")
+    return pd.to_numeric(pd.Series(list(values)), errors="coerce").dropna()

--- a/apps/bt/tests/unit/shared/test_pandas_type_guards.py
+++ b/apps/bt/tests/unit/shared/test_pandas_type_guards.py
@@ -1,0 +1,62 @@
+from collections.abc import Hashable
+
+import pandas as pd
+import pytest
+
+from src.shared.utils.pandas_type_guards import (
+    ensure_str_key,
+    finite_float_or_none,
+    int_or_none,
+    is_missing_scalar,
+    records_with_str_keys,
+    numeric_series_or_empty,
+    str_or_none,
+)
+
+
+def test_is_missing_scalar_treats_pandas_na_and_nan_as_missing() -> None:
+    assert is_missing_scalar(pd.NA)
+    assert is_missing_scalar(float("nan"))
+    assert is_missing_scalar(None)
+    assert not is_missing_scalar("7203")
+    assert not is_missing_scalar(0)
+
+
+def test_scalar_extractors_return_none_for_missing_values() -> None:
+    assert str_or_none(pd.NA) is None
+    assert int_or_none(pd.NA) is None
+    assert finite_float_or_none(pd.NA) is None
+    assert finite_float_or_none(float("inf")) is None
+
+
+def test_scalar_extractors_normalize_present_values() -> None:
+    assert str_or_none(7203) == "7203"
+    assert int_or_none("42") == 42
+    assert finite_float_or_none("12.5") == 12.5
+
+
+def test_ensure_str_key_rejects_missing_pandas_keys() -> None:
+    assert ensure_str_key("sector") == "sector"
+    assert ensure_str_key(2025) == "2025"
+
+    with pytest.raises(ValueError, match="missing pandas key"):
+        ensure_str_key(pd.NA)
+
+
+def test_records_with_str_keys_normalizes_dataframe_record_keys() -> None:
+    raw_records: list[dict[Hashable, object]] = [
+        {"code": 7203, "event_count": 2},
+        {2025: "calendar_year", "mean_return": 0.12},
+    ]
+
+    assert records_with_str_keys(raw_records) == [
+        {"code": 7203, "event_count": 2},
+        {"2025": "calendar_year", "mean_return": 0.12},
+    ]
+
+
+def test_numeric_series_or_empty_coerces_iterables_and_drops_missing_values() -> None:
+    series = numeric_series_or_empty(["1.0", pd.NA, "bad", 2])
+
+    assert series.tolist() == [1.0, 2.0]
+    assert numeric_series_or_empty(None).empty

--- a/apps/bt/uv.lock
+++ b/apps/bt/uv.lock
@@ -854,15 +854,14 @@ wheels = [
 
 [[package]]
 name = "pandas-stubs"
-version = "2.3.2.250827"
+version = "3.0.3.260530"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "types-pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/7b/8d2076a76ddf35806319798037056e4bbdcacdc832fb7c95b517f4c03fb2/pandas_stubs-2.3.2.250827.tar.gz", hash = "sha256:bcc2d49a2766325e4a1a492c3eeda879e9521bb5e26e69e2bbf13e80e7ef569a", size = 100032, upload-time = "2025-08-27T23:18:12.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/b8/dc820157be5aa9527f1f7ffe81737ee4d1cf0924081e1bfbd680530dde41/pandas_stubs-2.3.2.250827-py3-none-any.whl", hash = "sha256:3d613013b4189147a9a6bb18d8bec1e5b137de091496e9b9ff9f137ec3e223a9", size = 157775, upload-time = "2025-08-27T23:18:11.083Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
 ]
 
 [[package]]
@@ -1572,7 +1571,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=2.1.0" },
-    { name = "pandas-stubs", specifier = ">=2.3.2.250827" },
+    { name = "pandas-stubs", specifier = ">=3.0.3.260530" },
     { name = "pyright", specifier = ">=1.1.410" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -1607,15 +1606,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
-]
-
-[[package]]
-name = "types-pytz"
-version = "2025.2.0.20250809"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/e2/c774f754de26848f53f05defff5bb21dd9375a059d1ba5b5ea943cf8206e/types_pytz-2025.2.0.20250809.tar.gz", hash = "sha256:222e32e6a29bb28871f8834e8785e3801f2dc4441c715cd2082b271eecbe21e5", size = 10876, upload-time = "2025-08-09T03:14:17.453Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d0/91c24fe54e565f2344d7a6821e6c6bb099841ef09007ea6321a0bac0f808/types_pytz-2025.2.0.20250809-py3-none-any.whl", hash = "sha256:4f55ed1b43e925cf851a756fe1707e0f5deeb1976e15bf844bcaa025e8fbd0db", size = 10095, upload-time = "2025-08-09T03:14:16.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- migrate apps/bt pandas-stubs to 3.0.3.260530
- add shared pandas scalar/key guard helpers for missing checks, scalar extraction, and Hashable-key record normalization
- update analytics call sites to satisfy pandas-stubs 3.x without adding type ignores or cast(Any)

## Validation
- uv run pyright src
- uv run ruff check src tests/unit/shared/test_pandas_type_guards.py
- uv run pytest tests/unit/shared/test_pandas_type_guards.py
- uv run pytest tests/unit/domains/analytics/test_free_float_liquidity_gap.py tests/unit/domains/analytics/test_free_float_liquidity_prime_momentum_interaction.py tests/unit/domains/analytics/test_free_float_liquidity_regime_decomposition.py tests/unit/domains/analytics/test_topix100_open_close_volume_ratio_conditioning.py tests/unit/domains/analytics/test_topix100_prev_open_vs_open_entry_exit_profit.py tests/unit/domains/analytics/test_topix100_1445_entry_signal_regime_comparison.py tests/unit/domains/analytics/test_topix_close_return_streaks.py tests/unit/domains/analytics/test_new_high_momentum_research.py tests/unit/domains/analytics/test_classical_momentum_research.py tests/unit/domains/analytics/test_daily_move_asymmetry.py tests/unit/domains/analytics/test_speculative_volume_surge_follow_on.py tests/unit/domains/analytics/test_speculative_volume_surge_prime_pullback_profile.py tests/unit/domains/analytics/test_speculative_volume_surge_prime_pullback_tradeable.py tests/unit/domains/analytics/test_speculative_volume_surge_pullback_edge.py tests/unit/domains/analytics/test_annual_prime_value_technical_risk_decomposition.py tests/unit/domains/analytics/test_annual_prime_value_volume_volatility_participation.py tests/unit/domains/analytics/test_pre_disclosure_flow_volatility.py tests/unit/domains/analytics/test_index_market_strength_research.py tests/unit/domains/analytics/test_margin_balance_supply_demand.py

Closes #428

Note: dependency-only PR #422 was closed because pandas-stubs 3.x requires this explicit migration.